### PR TITLE
Handle the error when user selects non-existing columns in the table

### DIFF
--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -159,6 +159,11 @@ impl QueryResultMapper {
                 Some("42P01".to_owned()),
                 Some(format!("table \"{}\" does not exist", table_name)),
             )],
+            Err(QueryError::ColumnDoesNotExist(non_existing_columns)) => vec![Message::ErrorResponse(
+                Some("ERROR".to_owned()),
+                Some("42703".to_owned()),
+                Some(format!("column \"{}\" does not exist", non_existing_columns)),
+            )],
             Err(QueryError::NotSupportedOperation(raw_sql_query)) => vec![Message::ErrorResponse(
                 Some("ERROR".to_owned()),
                 Some("42601".to_owned()),
@@ -303,6 +308,19 @@ mod mapper {
                 Some("ERROR".to_owned()),
                 Some("42P01".to_owned()),
                 Some(format!("table \"{}\" does not exist", table_name)),
+            )]
+        )
+    }
+
+    #[test]
+    fn column_does_not_exists() {
+        let non_existing_columns = "column_not_in_table1, column_not_in_table2".to_owned();
+        assert_eq!(
+            QueryResultMapper::map(Err(QueryError::ColumnDoesNotExist(non_existing_columns.clone()))),
+            vec![Message::ErrorResponse(
+                Some("ERROR".to_owned()),
+                Some("42703".to_owned()),
+                Some(format!("column \"{}\" does not exist", non_existing_columns)),
             )]
         )
     }

--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -162,7 +162,7 @@ impl QueryResultMapper {
             Err(QueryError::ColumnDoesNotExist(non_existing_columns)) => vec![Message::ErrorResponse(
                 Some("ERROR".to_owned()),
                 Some("42703".to_owned()),
-                Some(format!("column \"{}\" does not exist", non_existing_columns)),
+                Some(format!("column \"{:?}\" does not exist", non_existing_columns)),
             )],
             Err(QueryError::NotSupportedOperation(raw_sql_query)) => vec![Message::ErrorResponse(
                 Some("ERROR".to_owned()),
@@ -314,13 +314,13 @@ mod mapper {
 
     #[test]
     fn column_does_not_exists() {
-        let non_existing_columns = "column_not_in_table1, column_not_in_table2".to_owned();
+        let non_existing_columns = vec!["column_not_in_table1".to_owned(), "column_not_in_table2".to_owned()];
         assert_eq!(
             QueryResultMapper::map(Err(QueryError::ColumnDoesNotExist(non_existing_columns.clone()))),
             vec![Message::ErrorResponse(
                 Some("ERROR".to_owned()),
                 Some("42703".to_owned()),
-                Some(format!("column \"{}\" does not exist", non_existing_columns)),
+                Some(format!("column \"{:?}\" does not exist", non_existing_columns)),
             )]
         )
     }

--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -344,7 +344,7 @@ mod mapper {
             vec![Message::ErrorResponse(
                 Some("ERROR".to_owned()),
                 Some("42703".to_owned()),
-                Some("columns column_not_in_table1, column_not_in_table2 does not exist".to_owned()),
+                Some("columns column_not_in_table1, column_not_in_table2 do not exist".to_owned()),
             )]
         )
     }

--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -161,7 +161,7 @@ impl QueryResultMapper {
             )],
             Err(QueryError::ColumnDoesNotExist(non_existing_columns)) => {
                 let error_message = if non_existing_columns.len() > 1 {
-                    format!("columns {} does not exist", non_existing_columns.join(", "))
+                    format!("columns {} do not exist", non_existing_columns.join(", "))
                 } else {
                     format!("column {} does not exist", non_existing_columns[0])
                 };

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -41,4 +41,6 @@ pub enum DropTableError {
 pub enum OperationOnTableError {
     SchemaDoesNotExist,
     TableDoesNotExist,
+    // Returns non existing columns.
+    ColumnDoesNotExist(Vec<String>),
 }


### PR DESCRIPTION
Fixes #70 

Tests with unit-tests and `psql` as below.

```
psql (12.1, server 0.0.0)
Type "help" for help.

asongala=> create schema schema_name;
CREATE SCHEMA
asongala=> create table schema_name.table_name (column_in_table smallint);
CREATE TABLE
asongala=> select column_not_in_table from schema_name.table_name;
ERROR:  column "column_not_in_table" does not exist
```