### PR TITLE
Handle updating specified columns of all records and return an error if the updated column is not existing

### DIFF
--- a/src/storage/src/frontend/tests/queries/update.rs
+++ b/src/storage/src/frontend/tests/queries/update.rs
@@ -32,7 +32,11 @@ fn update_all_records() {
 
     assert_eq!(
         storage
-            .update_all("schema_name", "table_name", "567".to_owned())
+            .update_all(
+                "schema_name",
+                "table_name",
+                vec![("column_test".to_owned(), "567".to_owned())]
+            )
             .expect("no system errors"),
         Ok(3)
     );
@@ -64,7 +68,7 @@ fn update_not_existed_table() {
 
     assert_eq!(
         storage
-            .update_all("schema_name", "not_existed", "123".to_owned())
+            .update_all("schema_name", "not_existed", vec![])
             .expect("no system errors"),
         Err(OperationOnTableError::TableDoesNotExist)
     );


### PR DESCRIPTION
Fixes #72 

1. Handles updating specified columns of all records.

```
psql (12.1, server 0.0.0)
Type "help" for help.

xxx=> create schema schema_name;
CREATE SCHEMA
xxx=> create table schema_name.table_name (col1 smallint, col2 smallint, col3 smallint);
CREATE TABLE
xxx=> insert into schema_name.table_name values (111, 222, 333);
INSERT 0 1
xxx=> insert into schema_name.table_name values (444, 555, 666);
INSERT 0 1
xxx=> select * from schema_name.table_name;
 col1 | col2 | col3 
------+------+------
  111 |  222 |  333
  444 |  555 |  666
(2 rows)

xxx=> update schema_name.table_name set col3=777, col1=999;
UPDATE 2
xxx=> select * from schema_name.table_name;
 col1 | col2 | col3 
------+------+------
  999 |  222 |  777
  999 |  555 |  777
(2 rows)
```

2. Returns an error if the updated column is not existing.

```
psql (12.1, server 0.0.0)
Type "help" for help.

xxx=> create schema schema_name;
CREATE SCHEMA
xxx=> create table schema_name.table_name (column_test smallint);
CREATE TABLE
xxx=> insert into schema_name.table_name values (123);
INSERT 0 1
xxx=> select * from schema_name.table_name;
 column_test 
-------------
         123
(1 row)

xxx=> update schema_name.table_name set col1=456, col2=789;
ERROR:  columns col1, col2 do not exist
```