### PR TITLE
 Handling named columns insertion

### DIFF
--- a/src/storage/src/frontend/tests/mod.rs
+++ b/src/storage/src/frontend/tests/mod.rs
@@ -69,12 +69,19 @@ fn insert_into<P: backend::BackendStorage>(
     schema_name: &str,
     table_name: &str,
     values: Vec<&str>,
+    columns: Option<Vec<&str>>,
 ) {
+    let columns = match columns {
+        Some(cols) => Some(cols.into_iter().map(ToOwned::to_owned).collect()),
+        None => None,
+    };
+
     storage
         .insert_into(
             schema_name,
             table_name,
             vec![values.into_iter().map(ToOwned::to_owned).collect()],
+            columns,
         )
         .expect("no system errors")
         .expect("values are inserted");

--- a/src/storage/src/frontend/tests/mod.rs
+++ b/src/storage/src/frontend/tests/mod.rs
@@ -68,20 +68,15 @@ fn insert_into<P: backend::BackendStorage>(
     storage: &mut FrontendStorage<P>,
     schema_name: &str,
     table_name: &str,
+    columns: Vec<&str>,
     values: Vec<&str>,
-    columns: Option<Vec<&str>>,
 ) {
-    let columns = match columns {
-        Some(cols) => Some(cols.into_iter().map(ToOwned::to_owned).collect()),
-        None => None,
-    };
-
     storage
         .insert_into(
             schema_name,
             table_name,
+            columns.into_iter().map(ToOwned::to_owned).collect(),
             vec![values.into_iter().map(ToOwned::to_owned).collect()],
-            columns,
         )
         .expect("no system errors")
         .expect("values are inserted");

--- a/src/storage/src/frontend/tests/queries/delete.rs
+++ b/src/storage/src/frontend/tests/queries/delete.rs
@@ -45,9 +45,9 @@ fn delete_all_from_table(mut storage: PersistentStorage) {
         "table_name",
         vec![("column_test", SqlType::SmallInt)],
     );
-    insert_into(&mut storage, "schema_name", "table_name", vec!["123"], None);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["456"], None);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["789"], None);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["123"]);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["456"]);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["789"]);
 
     assert_eq!(
         storage

--- a/src/storage/src/frontend/tests/queries/delete.rs
+++ b/src/storage/src/frontend/tests/queries/delete.rs
@@ -45,9 +45,9 @@ fn delete_all_from_table(mut storage: PersistentStorage) {
         "table_name",
         vec![("column_test", SqlType::SmallInt)],
     );
-    insert_into(&mut storage, "schema_name", "table_name", vec!["123"]);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["456"]);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["789"]);
+    insert_into(&mut storage, "schema_name", "table_name", vec!["123"], None);
+    insert_into(&mut storage, "schema_name", "table_name", vec!["456"], None);
+    insert_into(&mut storage, "schema_name", "table_name", vec!["789"], None);
 
     assert_eq!(
         storage

--- a/src/storage/src/frontend/tests/queries/insert.rs
+++ b/src/storage/src/frontend/tests/queries/insert.rs
@@ -19,7 +19,7 @@ use sql_types::SqlType;
 fn insert_into_non_existent_schema(mut storage: PersistentStorage) {
     assert_eq!(
         storage
-            .insert_into("non_existent", "not_existed", vec![vec!["123".to_owned()]], None)
+            .insert_into("non_existent", "not_existed", vec![], vec![vec!["123".to_owned()]])
             .expect("no system errors"),
         Err(OperationOnTableError::SchemaDoesNotExist)
     );
@@ -31,7 +31,7 @@ fn insert_into_non_existent_table(mut storage: PersistentStorage) {
 
     assert_eq!(
         storage
-            .insert_into("schema_name", "not_existed", vec![vec!["123".to_owned()]], None)
+            .insert_into("schema_name", "not_existed", vec![], vec![vec!["123".to_owned()]])
             .expect("no system errors"),
         Err(OperationOnTableError::TableDoesNotExist)
     );
@@ -46,8 +46,8 @@ fn insert_many_rows_into_table(mut storage: PersistentStorage) {
         vec![("column_test", SqlType::SmallInt)],
     );
 
-    insert_into(&mut storage, "schema_name", "table_name", vec!["123"], None);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["456"], None);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["123"]);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["456"]);
 
     let table_columns = storage
         .table_columns("schema_name", "table_name")
@@ -81,9 +81,9 @@ fn insert_multiple_values_rows(mut storage: PersistentStorage) {
         ],
     );
 
-    insert_into(&mut storage, "schema_name", "table_name", vec!["1", "2", "3"], None);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["4", "5", "6"], None);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["7", "8", "9"], None);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["1", "2", "3"]);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["4", "5", "6"]);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["7", "8", "9"]);
 
     let table_columns = storage
         .table_columns("schema_name", "table_name")
@@ -125,22 +125,29 @@ fn insert_named_columns(mut storage: PersistentStorage) {
         ],
     );
 
-    let columns = Some(vec!["column_3", "column_2", "column_1"]);
+    let columns = vec!["column_3", "column_2", "column_1"];
+
     insert_into(
         &mut storage,
         "schema_name",
         "table_name",
+        columns.clone(),
         vec!["1", "2", "3"],
-        columns.clone(),
     );
     insert_into(
         &mut storage,
         "schema_name",
         "table_name",
-        vec!["4", "5", "6"],
         columns.clone(),
+        vec!["4", "5", "6"],
     );
-    insert_into(&mut storage, "schema_name", "table_name", vec!["7", "8", "9"], columns);
+    insert_into(
+        &mut storage,
+        "schema_name",
+        "table_name",
+        columns.clone(),
+        vec!["7", "8", "9"],
+    );
 
     let table_columns = storage
         .table_columns("schema_name", "table_name")
@@ -178,7 +185,7 @@ fn insert_row_into_table(mut storage: PersistentStorage) {
     );
     assert_eq!(
         storage
-            .insert_into("schema_name", "table_name", vec![vec!["123".to_owned()]], None)
+            .insert_into("schema_name", "table_name", vec![], vec![vec!["123".to_owned()]])
             .expect("no system errors"),
         Ok(())
     );
@@ -239,8 +246,8 @@ mod constraints {
                 .insert_into(
                     "schema_name",
                     "table_name",
+                    vec![],
                     vec![vec!["-32769".to_owned(), "100".to_owned(), "100".to_owned()]],
-                    None,
                 )
                 .expect("no system errors"),
             Err(constraint_violations(
@@ -257,8 +264,8 @@ mod constraints {
                 .insert_into(
                     "schema_name",
                     "table_name",
+                    vec![],
                     vec![vec!["abc".to_owned(), "100".to_owned(), "100".to_owned()]],
-                    None,
                 )
                 .expect("no system errors"),
             Err(constraint_violations(
@@ -275,8 +282,8 @@ mod constraints {
                 .insert_into(
                     "schema_name",
                     "table_name",
+                    vec![],
                     vec![vec!["12345678901".to_owned(), "100".to_owned()]],
-                    None,
                 )
                 .expect("no system errors"),
             Err(constraint_violations(
@@ -293,8 +300,8 @@ mod constraints {
                 .insert_into(
                     "schema_name",
                     "table_name",
+                    vec![],
                     vec![vec!["-32769".to_owned(), "-2147483649".to_owned(), "100".to_owned()]],
-                    None,
                 )
                 .expect("no system errors"),
             Err(constraint_violations(
@@ -314,6 +321,7 @@ mod constraints {
                 .insert_into(
                     "schema_name",
                     "table_name",
+                    vec![],
                     vec![
                         vec!["-32769".to_owned(), "-2147483649".to_owned(), "100".to_owned()],
                         vec![
@@ -322,7 +330,6 @@ mod constraints {
                             "-9223372036854775809".to_owned()
                         ],
                     ],
-                    None,
                 )
                 .expect("no system errors"),
             Err(constraint_violations(

--- a/src/storage/src/frontend/tests/queries/select.rs
+++ b/src/storage/src/frontend/tests/queries/select.rs
@@ -66,6 +66,7 @@ fn select_all_from_table_with_many_columns(mut with_small_ints_table: Persistent
         "schema_name",
         "table_name",
         vec!["1", "2", "3"],
+        None,
     );
 
     let table_columns = with_small_ints_table
@@ -98,18 +99,21 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(mut with_small
         "schema_name",
         "table_name",
         vec!["1", "2", "3"],
+        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
         vec!["4", "5", "6"],
+        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
         vec!["7", "8", "9"],
+        None,
     );
 
     assert_eq!(
@@ -141,18 +145,21 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(mut with_small_
         "schema_name",
         "table_name",
         vec!["1", "2", "3"],
+        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
         vec!["4", "5", "6"],
+        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
         vec!["7", "8", "9"],
+        None,
     );
 
     assert_eq!(
@@ -185,18 +192,21 @@ fn select_with_column_name_duplication(mut with_small_ints_table: PersistentStor
         "schema_name",
         "table_name",
         vec!["1", "2", "3"],
+        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
         vec!["4", "5", "6"],
+        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
         vec!["7", "8", "9"],
+        None,
     );
 
     assert_eq!(
@@ -266,18 +276,21 @@ fn select_different_integer_types(mut storage: PersistentStorage) {
         "schema_name",
         "table_name",
         vec!["1000", "2000000", "3000000000"],
+        None,
     );
     insert_into(
         &mut storage,
         "schema_name",
         "table_name",
         vec!["4000", "5000000", "6000000000"],
+        None,
     );
     insert_into(
         &mut storage,
         "schema_name",
         "table_name",
         vec!["7000", "8000000", "9000000000"],
+        None,
     );
 
     assert_eq!(
@@ -317,13 +330,21 @@ fn select_different_character_strings_types(mut storage: PersistentStorage) {
         "schema_name",
         "table_name",
         vec!["1234567890", "12345678901234567890"],
+        None,
     );
-    insert_into(&mut storage, "schema_name", "table_name", vec!["12345", "1234567890"]);
+    insert_into(
+        &mut storage,
+        "schema_name",
+        "table_name",
+        vec!["12345", "1234567890"],
+        None,
+    );
     insert_into(
         &mut storage,
         "schema_name",
         "table_name",
         vec!["12345", "1234567890     "],
+        None,
     );
 
     assert_eq!(

--- a/src/storage/src/frontend/tests/queries/select.rs
+++ b/src/storage/src/frontend/tests/queries/select.rs
@@ -65,8 +65,8 @@ fn select_all_from_table_with_many_columns(mut with_small_ints_table: Persistent
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["1", "2", "3"],
-        None,
     );
 
     let table_columns = with_small_ints_table
@@ -98,22 +98,22 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(mut with_small
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["1", "2", "3"],
-        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["4", "5", "6"],
-        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["7", "8", "9"],
-        None,
     );
 
     assert_eq!(
@@ -144,22 +144,22 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(mut with_small_
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["1", "2", "3"],
-        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["4", "5", "6"],
-        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["7", "8", "9"],
-        None,
     );
 
     assert_eq!(
@@ -191,22 +191,22 @@ fn select_with_column_name_duplication(mut with_small_ints_table: PersistentStor
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["1", "2", "3"],
-        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["4", "5", "6"],
-        None,
     );
     insert_into(
         &mut with_small_ints_table,
         "schema_name",
         "table_name",
+        vec![],
         vec!["7", "8", "9"],
-        None,
     );
 
     assert_eq!(
@@ -275,22 +275,22 @@ fn select_different_integer_types(mut storage: PersistentStorage) {
         &mut storage,
         "schema_name",
         "table_name",
+        vec![],
         vec!["1000", "2000000", "3000000000"],
-        None,
     );
     insert_into(
         &mut storage,
         "schema_name",
         "table_name",
+        vec![],
         vec!["4000", "5000000", "6000000000"],
-        None,
     );
     insert_into(
         &mut storage,
         "schema_name",
         "table_name",
+        vec![],
         vec!["7000", "8000000", "9000000000"],
-        None,
     );
 
     assert_eq!(
@@ -329,22 +329,22 @@ fn select_different_character_strings_types(mut storage: PersistentStorage) {
         &mut storage,
         "schema_name",
         "table_name",
+        vec![],
         vec!["1234567890", "12345678901234567890"],
-        None,
     );
     insert_into(
         &mut storage,
         "schema_name",
         "table_name",
+        vec![],
         vec!["12345", "1234567890"],
-        None,
     );
     insert_into(
         &mut storage,
         "schema_name",
         "table_name",
+        vec![],
         vec!["12345", "1234567890     "],
-        None,
     );
 
     assert_eq!(

--- a/src/storage/src/frontend/tests/queries/update.rs
+++ b/src/storage/src/frontend/tests/queries/update.rs
@@ -24,9 +24,9 @@ fn update_all_records(mut storage: PersistentStorage) {
         vec![("column_test", SqlType::SmallInt)],
     );
 
-    insert_into(&mut storage, "schema_name", "table_name", vec!["123"]);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["456"]);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["789"]);
+    insert_into(&mut storage, "schema_name", "table_name", vec!["123"], None);
+    insert_into(&mut storage, "schema_name", "table_name", vec!["456"], None);
+    insert_into(&mut storage, "schema_name", "table_name", vec!["789"], None);
 
     assert_eq!(
         storage
@@ -117,6 +117,7 @@ mod constraints {
                 "schema_name",
                 "table_name",
                 vec![vec!["100".to_owned(), "100".to_owned(), "100".to_owned()]],
+                None,
             )
             .expect("no system errors")
             .expect("record inserted");
@@ -146,6 +147,7 @@ mod constraints {
                 "schema_name",
                 "table_name",
                 vec![vec!["100".to_owned(), "100".to_owned(), "100".to_owned()]],
+                None,
             )
             .expect("no system errors")
             .expect("record inserted");
@@ -175,6 +177,7 @@ mod constraints {
                 "schema_name",
                 "table_name",
                 vec![vec!["100".to_owned(), "100".to_owned()]],
+                None,
             )
             .expect("no system errors")
             .expect("record inserted");
@@ -203,6 +206,7 @@ mod constraints {
                 "schema_name",
                 "table_name",
                 vec![vec!["100".to_owned(), "100".to_owned(), "100".to_owned()]],
+                None,
             )
             .expect("no system errors")
             .expect("records inserted");

--- a/src/storage/src/frontend/tests/queries/update.rs
+++ b/src/storage/src/frontend/tests/queries/update.rs
@@ -24,9 +24,9 @@ fn update_all_records(mut storage: PersistentStorage) {
         vec![("column_test", SqlType::SmallInt)],
     );
 
-    insert_into(&mut storage, "schema_name", "table_name", vec!["123"], None);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["456"], None);
-    insert_into(&mut storage, "schema_name", "table_name", vec!["789"], None);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["123"]);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["456"]);
+    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["789"]);
 
     assert_eq!(
         storage
@@ -116,8 +116,8 @@ mod constraints {
             .insert_into(
                 "schema_name",
                 "table_name",
+                vec![],
                 vec![vec!["100".to_owned(), "100".to_owned(), "100".to_owned()]],
-                None,
             )
             .expect("no system errors")
             .expect("record inserted");
@@ -146,8 +146,8 @@ mod constraints {
             .insert_into(
                 "schema_name",
                 "table_name",
+                vec![],
                 vec![vec!["100".to_owned(), "100".to_owned(), "100".to_owned()]],
-                None,
             )
             .expect("no system errors")
             .expect("record inserted");
@@ -176,8 +176,8 @@ mod constraints {
             .insert_into(
                 "schema_name",
                 "table_name",
+                vec![],
                 vec![vec!["100".to_owned(), "100".to_owned()]],
-                None,
             )
             .expect("no system errors")
             .expect("record inserted");
@@ -205,8 +205,8 @@ mod constraints {
             .insert_into(
                 "schema_name",
                 "table_name",
+                vec![],
                 vec![vec!["100".to_owned(), "100".to_owned(), "100".to_owned()]],
-                None,
             )
             .expect("no system errors")
             .expect("records inserted");


### PR DESCRIPTION
Fixes #103 

```
psql (12.1, server 0.0.0)
Type "help" for help.

xxx=> create schema schema_name;
CREATE SCHEMA
xxx=> create table schema_name.table_name (col1 smallint, col2 smallint, col3 smallint);
CREATE TABLE
xxx=> insert into schema_name.table_name (col3, col2, col1) values (1, 2, 3);
INSERT 0 1
xxx=> insert into schema_name.table_name (col3, col2, col1) values (4, 5, 6);
INSERT 0 1
xxx=> select * from schema_name.table_name;
 col1 | col2 | col3
------+------+------
    3 |    2 |    1
    6 |    5 |    4
(2 rows)
```

### We may need to open another two issues about insertion.

#### 1. Sets the default value or NULL for the missing columns of this inserting operation.

Our current implementation: I sets an integer `0` for the default value.

```
xxx=> create schema schema_name;
CREATE SCHEMA
xxx=> create table schema_name.table_name (col1 smallint, col2 smallint, col3 smallint);
CREATE TABLE
xxx=> insert into schema_name.table_name (col3, col2) values (1, 2);
INSERT 0 1
xxx=> select * from schema_name.table_name;
 col1 | col2 | col3
------+------+------
    0 |    2 |    1
(1 row)
```

PostgreSQL:

```
xxx=# insert into schema_name.table_name (col3, col2) values (1, 2);
INSERT 0 1
xxx=# select * from schema_name.table_name;
 col1 | col2 | col3
------+------+------
      |    2 |    1
(1 row)
```

#### 2. Handles the error if the counts of named columns and values are not equal.

Our current implementation: Same as above.

```
xxx=> insert into schema_name.table_name (col3, col2) values (1);
INSERT 0 1
xxx=> select * from schema_name.table_name;
 col1 | col2 | col3
------+------+------
    0 |    0 |    1
(1 row)

xxx=> insert into schema_name.table_name (col3) values (1, 2);
INSERT 0 1
xxx=> select * from schema_name.table_name;
 col1 | col2 | col3
------+------+------
    0 |    0 |    1
    0 |    0 |    1
(2 rows)
```

PostgreSQL:

```
xxx=# insert into schema_name.table_name (col3, col2) values (1);
ERROR:  INSERT has more target columns than expressions
LINE 1: insert into schema_name.table_name (col3, col2) values (1);

xxx=# insert into schema_name.table_name (col3) values (1, 2);
ERROR:  INSERT has more expressions than target columns
LINE 1: insert into schema_name.table_name (col3) values (1, 2);
```

