### PR TITLE
Constraint error order

### DIFF
--- a/src/sql_engine/src/dml/update.rs
+++ b/src/sql_engine/src/dml/update.rs
@@ -14,7 +14,7 @@
 
 use kernel::SystemResult;
 use protocol::results::{ConstraintViolation, QueryError, QueryEvent, QueryResult};
-use sql_types::ConstraintError;
+use sql_types::{ConstraintError, SqlType};
 use sqlparser::ast::{Assignment, Expr, Ident, ObjectName, UnaryOperator, Value};
 use std::sync::{Arc, Mutex};
 use storage::{backend::BackendStorage, frontend::FrontendStorage, OperationOnTableError};
@@ -77,31 +77,25 @@ impl<P: BackendStorage> UpdateCommand<'_, P> {
             Err(OperationOnTableError::ColumnDoesNotExist(non_existing_columns)) => {
                 Ok(Err(QueryError::column_does_not_exist(non_existing_columns)))
             }
-            Err(OperationOnTableError::ConstraintViolation(constraint_errors)) => {
-                let mut violations = Vec::new();
-                for (err, infos) in constraint_errors.into_iter() {
-                    for info in infos {
-                        for (_, sql_type) in info {
-                            let violation = match err {
-                                ConstraintError::OutOfRange => {
-                                    ConstraintViolation::out_of_range(sql_type.to_pg_types())
+            Err(OperationOnTableError::ConstraintViolations(constraint_errors)) => {
+                let constraint_error_mapper =
+                    |(err, _, sql_type): &(ConstraintError, String, SqlType)| -> ConstraintViolation {
+                        match err {
+                            ConstraintError::OutOfRange => ConstraintViolation::out_of_range(sql_type.to_pg_types()),
+                            ConstraintError::NotAnInt => ConstraintViolation::type_mismatch(sql_type.to_pg_types()),
+                            ConstraintError::NotABool => ConstraintViolation::type_mismatch(sql_type.to_pg_types()),
+                            ConstraintError::ValueTooLong => {
+                                if let Some(len) = sql_type.string_type_length() {
+                                    ConstraintViolation::string_length_mismatch(sql_type.to_pg_types(), len)
+                                } else {
+                                    // there error should only occur with string types
+                                    unreachable!()
                                 }
-                                ConstraintError::NotAnInt => ConstraintViolation::type_mismatch(sql_type.to_pg_types()),
-                                ConstraintError::NotABool => ConstraintViolation::type_mismatch(sql_type.to_pg_types()),
-                                ConstraintError::ValueTooLong => {
-                                    if let Some(len) = sql_type.string_type_length() {
-                                        ConstraintViolation::string_length_mismatch(sql_type.to_pg_types(), len)
-                                    } else {
-                                        // there error should only occur with string types
-                                        unreachable!()
-                                    }
-                                }
-                            };
-
-                            violations.push(violation);
+                            }
                         }
-                    }
-                }
+                    };
+
+                let violations = constraint_errors.iter().map(constraint_error_mapper).collect();
                 Ok(Err(QueryError::constraint_violations(violations)))
             }
             _ => Ok(Err(QueryError::not_supported_operation(self.raw_sql_query.to_owned()))),

--- a/src/storage/src/frontend/tests/queries/update.rs
+++ b/src/storage/src/frontend/tests/queries/update.rs
@@ -82,6 +82,7 @@ fn update_non_existent_schema(mut storage: PersistentStorage) {
 #[cfg(test)]
 mod constraints {
     use super::*;
+    use sql_types::ConstraintError;
 
     #[rstest::fixture]
     fn storage_with_ints_table(mut storage: PersistentStorage) -> PersistentStorage {
@@ -132,10 +133,11 @@ mod constraints {
                     ]
                 )
                 .expect("no system errors"),
-            Err(constraint_violations(
+            Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::OutOfRange,
-                vec![vec![("column_si".to_owned(), SqlType::SmallInt)]]
-            ))
+                "column_si".to_owned(),
+                SqlType::SmallInt
+            )]))
         );
     }
 
@@ -162,10 +164,11 @@ mod constraints {
                     ]
                 )
                 .expect("no system errors"),
-            Err(constraint_violations(
+            Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::NotAnInt,
-                vec![vec![("column_si".to_owned(), SqlType::SmallInt)]]
-            ))
+                "column_si".to_owned(),
+                SqlType::SmallInt
+            )]))
         );
     }
 
@@ -191,10 +194,11 @@ mod constraints {
                     ]
                 )
                 .expect("no system errors"),
-            Err(constraint_violations(
+            Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::ValueTooLong,
-                vec![vec![("column_c".to_owned(), SqlType::Char(10))]]
-            ))
+                "column_c".to_owned(),
+                SqlType::Char(10)
+            )]))
         );
     }
 
@@ -222,19 +226,10 @@ mod constraints {
                     ]
                 )
                 .expect("no system errors"),
-            Err(constraint_violations(
-                ConstraintError::OutOfRange,
-                vec![vec![
-                    ("column_si".to_owned(), SqlType::SmallInt),
-                    ("column_i".to_owned(), SqlType::Integer)
-                ]]
-            ))
+            Err(OperationOnTableError::ConstraintViolations(vec![
+                (ConstraintError::OutOfRange, "column_si".to_owned(), SqlType::SmallInt),
+                (ConstraintError::OutOfRange, "column_i".to_owned(), SqlType::Integer)
+            ]))
         )
-    }
-
-    fn constraint_violations(error: ConstraintError, columns: Vec<Vec<(String, SqlType)>>) -> OperationOnTableError {
-        let mut map = HashMap::new();
-        map.insert(error, columns);
-        OperationOnTableError::ConstraintViolation(map)
     }
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -17,7 +17,6 @@ extern crate log;
 extern crate sql_types;
 
 use sql_types::{ConstraintError, SqlType};
-use std::collections::HashMap;
 
 pub mod backend;
 pub mod frontend;
@@ -48,5 +47,5 @@ pub enum OperationOnTableError {
     InsertTooManyExpressions,
     // Returns non existing columns.
     ColumnDoesNotExist(Vec<String>),
-    ConstraintViolation(HashMap<ConstraintError, Vec<Vec<(String, SqlType)>>>),
+    ConstraintViolations(Vec<(ConstraintError, String, SqlType)>),
 }


### PR DESCRIPTION
Changed the ConstraintViolations variant of QueryError to contain a vector of all ConstraintErrors that occurred during query execution. This change was to maintain the order of errors as they occur.

Resolves #148 