### PR TITLE
Abort insert when constraint error occurs.

### DIFF
--- a/src/storage/src/frontend/mod.rs
+++ b/src/storage/src/frontend/mod.rs
@@ -208,7 +208,7 @@ impl<P: BackendStorage> FrontendStorage<P> {
                             // we do not break from the outer loop here because we want to
                             // collect all errors from the current row.
                             constraint_error = true;
-                        },
+                        }
                     }
                 }
 

--- a/src/storage/src/frontend/tests/queries/insert.rs
+++ b/src/storage/src/frontend/tests/queries/insert.rs
@@ -471,6 +471,7 @@ mod constraints {
                     ],
                 )
                 .expect("no system errors"),
+            // we should only get the errors from the first row.
             Err(OperationOnTableError::ConstraintViolations(vec![
                 (
                     ConstraintError::OutOfRange,
@@ -481,16 +482,6 @@ mod constraints {
                     ConstraintError::OutOfRange,
                     "column_i".to_owned(),
                     SqlType::Integer(i32::min_value())
-                ),
-                (
-                    ConstraintError::OutOfRange,
-                    "column_i".to_owned(),
-                    SqlType::Integer(i32::min_value())
-                ),
-                (
-                    ConstraintError::OutOfRange,
-                    "column_bi".to_owned(),
-                    SqlType::BigInt(i64::min_value())
                 ),
             ]))
         )


### PR DESCRIPTION
Resolves #153 

This PR changes how errors are reported during an insert operation. When a constraint violation occurs during inserting the current row is finished and the remaining rows are ignored.

Update behavior was not changed.

What are your thoughts? 