### PR TITLE
update constraints error messages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 Closes #(issue number)
 
-####Description
+#### Description
 short description what was changed
 
-####Client output
+#### Client output
 
 e.g. for `psql`
 

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -49,3 +49,28 @@ jobs:
       - name: run-tests
         run: |
           pytest -v tests/functional/*
+
+  coverage:
+    needs:
+      - functional-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install tarpaulin
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-tarpaulin
+          version: 0.14.0
+          use-tool-cache: true
+      - name: unit-tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --lib --all
+      - name: code-coverage
+        run: cargo tarpaulin --exclude-files proof-of-concepts/ -o Lcov --output-dir ./coverage
+      - name: coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/protocol/src/sql_types.rs
+++ b/src/protocol/src/sql_types.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::{self, Display, Formatter};
+
 /// Represents PostgreSQL data type and methods to send over wire
 #[allow(missing_docs)]
 #[derive(PartialEq, Debug, Copy, Clone, PartialOrd, Eq)]
@@ -77,24 +79,24 @@ impl PostgreSqlType {
     }
 }
 
-impl std::string::ToString for PostgreSqlType {
-    fn to_string(&self) -> String {
+impl Display for PostgreSqlType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Bool => "bool".to_string(),
-            Self::Char => "char".to_string(),
-            Self::BigInt => "bigint".to_string(),
-            Self::SmallInt => "smallint".to_string(),
-            Self::Integer => "integer".to_string(),
-            Self::Real => "real".to_string(),
-            Self::DoublePrecision => "double".to_string(),
-            Self::VarChar => "varchar".to_string(),
-            Self::Date => "date".to_string(),
-            Self::Time => "time".to_string(),
-            Self::Timestamp => "timestamp".to_string(),
-            Self::TimestampWithTimeZone => "timestampwithtimezone".to_string(),
-            Self::Interval => "interval".to_string(),
-            Self::TimeWithTimeZone => "datewithtimezone".to_string(),
-            Self::Decimal => "decimal".to_string(),
+            Self::Bool => write!(f, "bool"),
+            Self::Char => write!(f, "character"),
+            Self::BigInt => write!(f, "bigint"),
+            Self::SmallInt => write!(f, "smallint"),
+            Self::Integer => write!(f, "integer"),
+            Self::Real => write!(f, "real"),
+            Self::DoublePrecision => write!(f, "double"),
+            Self::VarChar => write!(f, "variable character"),
+            Self::Date => write!(f, "date"),
+            Self::Time => write!(f, "time"),
+            Self::TimeWithTimeZone => write!(f, "time with timezone"),
+            Self::Timestamp => write!(f, "timestamp"),
+            Self::TimestampWithTimeZone => write!(f, "timestamp with timezone"),
+            Self::Interval => write!(f, "interval"),
+            Self::Decimal => write!(f, "decimal"),
         }
     }
 }

--- a/src/sql_engine/src/dml/insert.rs
+++ b/src/sql_engine/src/dml/insert.rs
@@ -114,15 +114,11 @@ impl<P: BackendStorage> InsertCommand<'_, P> {
                                 ConstraintError::OutOfRange => {
                                     ConstraintViolation::out_of_range(sql_type.to_pg_types())
                                 }
-                                ConstraintError::NotAnInt => ConstraintViolation::type_mismatch(sql_type.to_pg_types()),
-                                ConstraintError::NotABool => ConstraintViolation::type_mismatch(sql_type.to_pg_types()),
-                                ConstraintError::ValueTooLong => {
-                                    if let Some(len) = sql_type.string_type_length() {
-                                        ConstraintViolation::string_length_mismatch(sql_type.to_pg_types(), len)
-                                    } else {
-                                        // there error should only occur with string types
-                                        unreachable!()
-                                    }
+                                ConstraintError::TypeMismatch(value) => {
+                                    ConstraintViolation::type_mismatch(value, sql_type.to_pg_types())
+                                }
+                                ConstraintError::ValueTooLong(len) => {
+                                    ConstraintViolation::string_length_mismatch(sql_type.to_pg_types(), *len)
                                 }
                             }
                         };

--- a/src/sql_engine/src/dml/update.rs
+++ b/src/sql_engine/src/dml/update.rs
@@ -82,15 +82,11 @@ impl<P: BackendStorage> UpdateCommand<'_, P> {
                     |(err, _, sql_type): &(ConstraintError, String, SqlType)| -> ConstraintViolation {
                         match err {
                             ConstraintError::OutOfRange => ConstraintViolation::out_of_range(sql_type.to_pg_types()),
-                            ConstraintError::NotAnInt => ConstraintViolation::type_mismatch(sql_type.to_pg_types()),
-                            ConstraintError::NotABool => ConstraintViolation::type_mismatch(sql_type.to_pg_types()),
-                            ConstraintError::ValueTooLong => {
-                                if let Some(len) = sql_type.string_type_length() {
-                                    ConstraintViolation::string_length_mismatch(sql_type.to_pg_types(), len)
-                                } else {
-                                    // there error should only occur with string types
-                                    unreachable!()
-                                }
+                            ConstraintError::TypeMismatch(value) => {
+                                ConstraintViolation::type_mismatch(value, sql_type.to_pg_types())
+                            }
+                            ConstraintError::ValueTooLong(len) => {
+                                ConstraintViolation::string_length_mismatch(sql_type.to_pg_types(), *len)
                             }
                         }
                     };

--- a/src/storage/src/frontend/tests/queries/insert.rs
+++ b/src/storage/src/frontend/tests/queries/insert.rs
@@ -401,7 +401,7 @@ mod constraints {
                 )
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::NotAnInt,
+                ConstraintError::TypeMismatch("abc".to_owned()),
                 "column_si".to_owned(),
                 SqlType::SmallInt(i16::min_value())
             )]))
@@ -420,7 +420,7 @@ mod constraints {
                 )
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::ValueTooLong,
+                ConstraintError::ValueTooLong(10),
                 "column_c".to_owned(),
                 SqlType::Char(10)
             )]))

--- a/src/storage/src/frontend/tests/queries/update.rs
+++ b/src/storage/src/frontend/tests/queries/update.rs
@@ -165,7 +165,7 @@ mod constraints {
                 )
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::NotAnInt,
+                ConstraintError::TypeMismatch("abc".to_owned()),
                 "column_si".to_owned(),
                 SqlType::SmallInt(i16::min_value())
             )]))
@@ -195,7 +195,7 @@ mod constraints {
                 )
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::ValueTooLong,
+                ConstraintError::ValueTooLong(10),
                 "column_c".to_owned(),
                 SqlType::Char(10)
             )]))


### PR DESCRIPTION
#### Description
updates message for constraint violations

#### Client output

e.g. for `psql`

```
xxx=> insert into schema_n.tab1 values ('123456', 123.4);
ERROR:  smallint out of range
ERROR:  invalid input syntax for type smallint: "123.4"

xxx=> insert into schema_n.tab values ('123456');
ERROR:  value too long for type character(5)
```

