### PR TITLE
Query error restructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
 name = "sql_engine"
 version = "0.1.0"
 dependencies = [
+ "bigdecimal",
  "kernel",
  "log",
  "protocol",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Database
 
 ![Merge](https://github.com/alex-dukhno/database/workflows/Merge/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/alex-dukhno/database/badge.svg)](https://coveralls.io/github/alex-dukhno/database)
+[![Coverage Status](https://coveralls.io/repos/github/alex-dukhno/database/badge.svg?branch=master)](https://coveralls.io/github/alex-dukhno/database?branch=master)
 <a href="https://discord.gg/PUcTcfU"><img src="https://img.shields.io/discord/509773073294295082.svg?logo=discord"></a>
 
 The project doesn't have any name so let it be `database` for now.

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -447,6 +447,34 @@ mod tests {
                 )]
             )
         }
+
+        #[test]
+        fn undefined_function() {
+            assert_eq!(
+                QueryResultMapper::map(Err(QueryError::undefined_function(
+                    "||".to_owned(),
+                    "NUMBER".to_owned(),
+                    "NUMBER".to_owned()
+                ))),
+                vec![Message::ErrorResponse(
+                    Some("ERROR".to_owned()),
+                    Some("42883".to_owned()),
+                    Some("operator does not exist: (NUMBER || NUMBER)".to_owned())
+                )]
+            )
+        }
+
+        #[test]
+        fn syntax_error() {
+            assert_eq!(
+                QueryResultMapper::map(Err(QueryError::syntax_error("expression".to_owned()))),
+                vec![Message::ErrorResponse(
+                    Some("ERROR".to_owned()),
+                    Some("42601".to_owned()),
+                    Some("syntax error in expression".to_owned())
+                )]
+            )
+        }
     }
 
     #[cfg(test)]

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -222,10 +222,7 @@ mod tests {
     #[cfg(test)]
     mod mapper {
         use super::*;
-        use crate::{
-            results::{ConstraintViolation, QueryError},
-            sql_types::PostgreSqlType,
-        };
+        use crate::{results::QueryErrorBuilder, sql_types::PostgreSqlType};
 
         #[test]
         fn create_schema() {
@@ -316,7 +313,9 @@ mod tests {
         fn schema_already_exists() {
             let schema_name = "some_table_name".to_owned();
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::schema_already_exists(schema_name.clone()))),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new()
+                    .schema_already_exists(schema_name.clone())
+                    .build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42P06".to_owned()),
@@ -329,7 +328,9 @@ mod tests {
         fn schema_does_not_exists() {
             let schema_name = "some_table_name".to_owned();
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::schema_does_not_exist(schema_name.clone()))),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new()
+                    .schema_does_not_exist(schema_name.clone())
+                    .build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("3F000".to_owned()),
@@ -342,7 +343,9 @@ mod tests {
         fn table_already_exists() {
             let table_name = "some_table_name".to_owned();
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::table_already_exists(table_name.clone()))),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new()
+                    .table_already_exists(table_name.clone())
+                    .build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42P07".to_owned()),
@@ -355,7 +358,9 @@ mod tests {
         fn table_does_not_exists() {
             let table_name = "some_table_name".to_owned();
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::table_does_not_exist(table_name.clone()))),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new()
+                    .table_does_not_exist(table_name.clone())
+                    .build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42P01".to_owned()),
@@ -367,9 +372,9 @@ mod tests {
         #[test]
         fn one_column_does_not_exists() {
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::column_does_not_exist(vec![
-                    "column_not_in_table".to_owned()
-                ]))),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new()
+                    .column_does_not_exist(vec!["column_not_in_table".to_owned()])
+                    .build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42703".to_owned()),
@@ -381,10 +386,12 @@ mod tests {
         #[test]
         fn multiple_columns_does_not_exists() {
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::column_does_not_exist(vec![
-                    "column_not_in_table1".to_owned(),
-                    "column_not_in_table2".to_owned()
-                ]))),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new()
+                    .column_does_not_exist(vec![
+                        "column_not_in_table1".to_owned(),
+                        "column_not_in_table2".to_owned()
+                    ])
+                    .build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42703".to_owned()),
@@ -397,7 +404,9 @@ mod tests {
         fn operation_is_not_supported() {
             let raw_sql_query = "some SQL query".to_owned();
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::not_supported_operation(raw_sql_query.clone()))),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new()
+                    .not_supported_operation(raw_sql_query.clone())
+                    .build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42601".to_owned()),
@@ -408,10 +417,11 @@ mod tests {
 
         #[test]
         fn out_of_range_constraint_violation() {
+            let mut builder = QueryErrorBuilder::new();
+            builder.out_of_range(PostgreSqlType::SmallInt);
+
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::constraint_violations(vec![
-                    ConstraintViolation::out_of_range(PostgreSqlType::SmallInt)
-                ]))),
+                QueryResultMapper::map(Err(builder.build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("22003".to_owned()),
@@ -422,10 +432,10 @@ mod tests {
 
         #[test]
         fn type_mismatch_constraint_violation() {
+            let mut builder = QueryErrorBuilder::new();
+            builder.type_mismatch("abc", PostgreSqlType::SmallInt);
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::constraint_violations(vec![
-                    ConstraintViolation::type_mismatch("abc", PostgreSqlType::SmallInt)
-                ]))),
+                QueryResultMapper::map(Err(builder.build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("2200G".to_owned()),
@@ -436,10 +446,10 @@ mod tests {
 
         #[test]
         fn string_length_mismatch_constraint_violation() {
+            let mut builder = QueryErrorBuilder::new();
+            builder.string_length_mismatch(PostgreSqlType::Char, 5);
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::constraint_violations(vec![
-                    ConstraintViolation::string_length_mismatch(PostgreSqlType::Char, 5)
-                ]))),
+                QueryResultMapper::map(Err(builder.build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("22026".to_owned()),
@@ -451,11 +461,11 @@ mod tests {
         #[test]
         fn undefined_function() {
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::undefined_function(
+                QueryResultMapper::map(Err(QueryErrorBuilder::new().undefined_function(
                     "||".to_owned(),
                     "NUMBER".to_owned(),
                     "NUMBER".to_owned()
-                ))),
+                ).build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42883".to_owned()),
@@ -467,7 +477,7 @@ mod tests {
         #[test]
         fn syntax_error() {
             assert_eq!(
-                QueryResultMapper::map(Err(QueryError::syntax_error("expression".to_owned()))),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new().syntax_error("expression".to_owned()).build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42601".to_owned()),

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -461,11 +461,9 @@ mod tests {
         #[test]
         fn undefined_function() {
             assert_eq!(
-                QueryResultMapper::map(Err(QueryErrorBuilder::new().undefined_function(
-                    "||".to_owned(),
-                    "NUMBER".to_owned(),
-                    "NUMBER".to_owned()
-                ).build())),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new()
+                    .undefined_function("||".to_owned(), "NUMBER".to_owned(), "NUMBER".to_owned())
+                    .build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42883".to_owned()),
@@ -477,7 +475,9 @@ mod tests {
         #[test]
         fn syntax_error() {
             assert_eq!(
-                QueryResultMapper::map(Err(QueryErrorBuilder::new().syntax_error("expression".to_owned()).build())),
+                QueryResultMapper::map(Err(QueryErrorBuilder::new()
+                    .syntax_error("expression".to_owned())
+                    .build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR".to_owned()),
                     Some("42601".to_owned()),

--- a/src/protocol/src/listener.rs
+++ b/src/protocol/src/listener.rs
@@ -370,7 +370,6 @@ mod tests {
             }
 
             #[async_std::test]
-            // #[ignore]
             async fn successful_connection_handshake() -> io::Result<()> {
                 let test_case = async_io::TestCase::with_content(vec![
                     pg_frontend::Message::SslRequired.as_vec().as_slice(),

--- a/src/protocol/src/results.rs
+++ b/src/protocol/src/results.rs
@@ -75,81 +75,6 @@ impl Into<String> for Severity {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum ConstraintViolationKind {
-    NumericTypeOutOfRange(PostgreSqlType),
-    DataTypeMismatch(PostgreSqlType, String),
-    StringTypeLengthMismatch(PostgreSqlType, u64),
-}
-
-/// Represents a constraint violation during query execution
-/// It is separate from QueryError because there can be multiple
-/// of these errors for one QueryError.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ConstraintViolation {
-    severity: Severity,
-    code: String,
-    kind: ConstraintViolationKind,
-}
-
-impl ConstraintViolation {
-    /// sql error code
-    pub fn code(&self) -> Option<String> {
-        Some(self.code.clone())
-    }
-
-    /// error severity
-    pub fn severity(&self) -> Option<String> {
-        Some(self.severity.into())
-    }
-
-    /// error message
-    pub fn message(&self) -> Option<String> {
-        Some(format!("{}", self))
-    }
-
-    /// numeric out of range constructor
-    pub fn out_of_range(pg_type: PostgreSqlType) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "22003".to_owned(),
-            kind: ConstraintViolationKind::NumericTypeOutOfRange(pg_type),
-        }
-    }
-
-    /// type mismatch constructor
-    pub fn type_mismatch(value: &str, pg_type: PostgreSqlType) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "2200G".to_owned(),
-            kind: ConstraintViolationKind::DataTypeMismatch(pg_type, value.to_owned()),
-        }
-    }
-
-    /// length of string types do not match constructor
-    pub fn string_length_mismatch(pg_type: PostgreSqlType, len: u64) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "22026".to_owned(),
-            kind: ConstraintViolationKind::StringTypeLengthMismatch(pg_type, len),
-        }
-    }
-}
-
-impl Display for ConstraintViolation {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match &self.kind {
-            ConstraintViolationKind::NumericTypeOutOfRange(pg_type) => write!(f, "{} out of range", pg_type),
-            ConstraintViolationKind::DataTypeMismatch(pg_type, value) => {
-                write!(f, "invalid input syntax for type {}: \"{}\"", pg_type, value)
-            }
-            ConstraintViolationKind::StringTypeLengthMismatch(pg_type, len) => {
-                write!(f, "value too long for type {}({})", pg_type, len)
-            }
-        }
-    }
-}
-
 #[derive(Debug, PartialEq)]
 pub(crate) enum QueryErrorKind {
     SchemaAlreadyExists(String),
@@ -159,142 +84,13 @@ pub(crate) enum QueryErrorKind {
     ColumnDoesNotExist(Vec<String>),
     NotSupportedOperation(String),
     TooManyInsertExpressions,
-    ConstraintViolations(Vec<ConstraintViolation>),
+
+    NumericTypeOutOfRange(PostgreSqlType),
+    DataTypeMismatch(PostgreSqlType, String),
+    StringTypeLengthMismatch(PostgreSqlType, u64),
+
     UndefinedFunction(String, String, String),
     SyntaxError(String),
-}
-
-/// Represents error during query execution
-#[derive(Debug, PartialEq)]
-pub struct QueryError {
-    severity: Severity,
-    code: String,
-    kind: QueryErrorKind,
-}
-
-impl QueryError {
-    /// error code
-    pub fn code(&self) -> Option<String> {
-        Some(self.code.clone())
-    }
-
-    /// error severity
-    pub fn severity(&self) -> Option<String> {
-        Some(self.severity.into())
-    }
-
-    /// error message
-    pub fn message(&self) -> Option<String> {
-        Some(format!("{}", self.kind))
-    }
-
-    pub(crate) fn into_messages(self) -> Vec<Message> {
-        match self.kind {
-            QueryErrorKind::ConstraintViolations(violations) => {
-                let mut messages = Vec::with_capacity(violations.len());
-                for violation in violations {
-                    messages.push(Message::ErrorResponse(
-                        violation.severity(),
-                        violation.code(),
-                        violation.message(),
-                    ))
-                }
-                messages
-            }
-            _ => vec![Message::ErrorResponse(self.severity(), self.code(), self.message())],
-        }
-    }
-
-    /// operator or function is not found for operands
-    pub fn undefined_function(operator: String, left_type: String, right_type: String) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "42883".to_owned(),
-            kind: QueryErrorKind::UndefinedFunction(operator, left_type, right_type),
-        }
-    }
-
-    /// syntax error in the expression as part of query
-    pub fn syntax_error(expression: String) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "42601".to_owned(),
-            kind: QueryErrorKind::SyntaxError(expression),
-        }
-    }
-
-    /// schema already exists error constructor
-    pub fn schema_already_exists(schema_name: String) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "42P06".to_owned(),
-            kind: QueryErrorKind::SchemaAlreadyExists(schema_name),
-        }
-    }
-
-    /// schema does not exist error constructor
-    pub fn schema_does_not_exist(schema_name: String) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "3F000".to_owned(),
-            kind: QueryErrorKind::SchemaDoesNotExist(schema_name),
-        }
-    }
-
-    /// table already exists error constructor
-    pub fn table_already_exists(table_name: String) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "42P07".to_owned(),
-            kind: QueryErrorKind::TableAlreadyExists(table_name),
-        }
-    }
-
-    /// table does not exist error constructor
-    pub fn table_does_not_exist(table_name: String) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "42P01".to_owned(),
-            kind: QueryErrorKind::TableDoesNotExist(table_name),
-        }
-    }
-
-    /// column does not exists error constructor
-    pub fn column_does_not_exist(non_existing_columns: Vec<String>) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "42703".to_owned(),
-            kind: QueryErrorKind::ColumnDoesNotExist(non_existing_columns),
-        }
-    }
-
-    /// not supported operation error constructor
-    pub fn not_supported_operation(raw_sql_query: String) -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "42601".to_owned(),
-            kind: QueryErrorKind::NotSupportedOperation(raw_sql_query),
-        }
-    }
-
-    /// too many insert expressions errors constructor
-    pub fn too_many_insert_expressions() -> Self {
-        Self {
-            severity: Severity::Error,
-            code: "42601".to_owned(),
-            kind: QueryErrorKind::TooManyInsertExpressions,
-        }
-    }
-
-    /// constraint violation errors constructor
-    pub fn constraint_violations(violations: Vec<ConstraintViolation>) -> Self {
-        Self {
-            severity: Severity::Error,
-            // there isn't a single code fo this so I am leaving it empty.
-            code: String::new(),
-            kind: QueryErrorKind::ConstraintViolations(violations),
-        }
-    }
 }
 
 impl Display for QueryErrorKind {
@@ -314,11 +110,12 @@ impl Display for QueryErrorKind {
             Self::NotSupportedOperation(raw_sql_query) => {
                 write!(f, "Currently, Query '{}' can't be executed", raw_sql_query)
             }
-            Self::TooManyInsertExpressions => write!(f, "INSERT has more expressions then target columns"),
-            Self::ConstraintViolations(_) => {
-                log::error!("should not use Display to generate the message for Constraint Violations");
-                write!(f, "do not use display with ConstraintViolation errors")
+            Self::TooManyInsertExpressions => write!(f, "INSERT has more epxressions then target columns"),
+            Self::NumericTypeOutOfRange(pg_type) => write!(f, "{} out of range", pg_type),
+            Self::DataTypeMismatch(pg_type, value) => {
+                write!(f, "invalid input syntax for type {}: \"{}\"", pg_type, value)
             }
+            Self::StringTypeLengthMismatch(pg_type, len) => write!(f, "value too long for type {}({})", pg_type, len),
             Self::UndefinedFunction(operator, left_type, right_type) => write!(
                 f,
                 "operator does not exist: ({} {} {})",
@@ -326,5 +123,196 @@ impl Display for QueryErrorKind {
             ),
             Self::SyntaxError(expression) => write!(f, "syntax error in {}", expression),
         }
+    }
+}
+
+/// Represents error during query execution
+#[derive(Debug, PartialEq)]
+pub(crate) struct QueryErrorInner {
+    severity: Severity,
+    code: String,
+    kind: QueryErrorKind,
+}
+
+impl QueryErrorInner {
+    fn code(&self) -> Option<String> {
+        Some(self.code.clone())
+    }
+
+    fn severity(&self) -> Option<String> {
+        Some(self.severity.into())
+    }
+
+    fn message(&self) -> Option<String> {
+        Some(format!("{}", self.kind))
+    }
+}
+
+/// a container of errors that occured during query execution
+#[derive(Debug, PartialEq)]
+pub struct QueryError {
+    errors: Vec<QueryErrorInner>,
+}
+
+impl QueryError {
+    pub(crate) fn new(errors: Vec<QueryErrorInner>) -> Self {
+        Self { errors }
+    }
+
+    pub(crate) fn into_messages(self) -> Vec<Message> {
+        self.errors
+            .into_iter()
+            .map(|inner| Message::ErrorResponse(inner.severity(), inner.code(), inner.message()))
+            .collect::<Vec<_>>()
+    }
+}
+
+/// a structure for building a QueryError
+#[derive(Default, Debug)]
+pub struct QueryErrorBuilder {
+    errors: Vec<QueryErrorInner>,
+}
+
+impl QueryErrorBuilder {
+    /// constructs a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // I am not sure this is a good idea.
+    /// helper for building errors in one line.
+    pub fn build_with<Errs: FnMut(&mut Self)>(mut errs: Errs) -> QueryError {
+        let mut builder = Self::new();
+        errs(&mut builder);
+        builder.build()
+    }
+
+    /// builds a QueryError containing all of the error generated
+    pub fn build(self) -> QueryError {
+        QueryError::new(self.errors)
+    }
+
+    // these error will stop the execution of the query; therefore there will only
+    // ever be one.
+
+
+    /// schema already exists error constructor
+    pub fn schema_already_exists(mut self, schema_name: String) -> Self {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "42P06".to_owned(),
+            kind: QueryErrorKind::SchemaAlreadyExists(schema_name),
+        });
+        self
+    }
+
+    /// schema does not exist error constructor
+    pub fn schema_does_not_exist(mut self, schema_name: String) -> Self {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "3F000".to_owned(),
+            kind: QueryErrorKind::SchemaDoesNotExist(schema_name),
+        });
+        self
+    }
+
+    /// table already exists error constructor
+    pub fn table_already_exists(mut self, table_name: String) -> Self {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "42P07".to_owned(),
+            kind: QueryErrorKind::TableAlreadyExists(table_name),
+        });
+        self
+    }
+
+    /// table does not exist error constructor
+    pub fn table_does_not_exist(mut self, table_name: String) -> Self {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "42P01".to_owned(),
+            kind: QueryErrorKind::TableDoesNotExist(table_name),
+        });
+        self
+    }
+
+    /// column does not exists error constructor
+    pub fn column_does_not_exist(mut self, non_existing_columns: Vec<String>) -> Self {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "42703".to_owned(),
+            kind: QueryErrorKind::ColumnDoesNotExist(non_existing_columns),
+        });
+        self
+    }
+
+    /// not supported operation error constructor
+    pub fn not_supported_operation(mut self, raw_sql_query: String) -> Self {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "42601".to_owned(),
+            kind: QueryErrorKind::NotSupportedOperation(raw_sql_query),
+        });
+        self
+    }
+
+    /// too many insert expressions errors constructors
+    pub fn too_many_insert_expressions(mut self) -> Self {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "42601".to_owned(),
+            kind: QueryErrorKind::TooManyInsertExpressions,
+        });
+        self
+    }
+
+    /// syntax error in the expression as part of query
+    pub fn syntax_error(mut self, expression: String) -> Self {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "42601".to_owned(),
+            kind: QueryErrorKind::SyntaxError(expression),
+        });
+        self
+    }
+
+    /// operator or function is not found for operands
+    pub fn undefined_function(mut self, operator: String, left_type: String, right_type: String) -> Self {
+        self.errors.push(QueryErrorInner{
+            severity: Severity::Error,
+            code: "42883".to_owned(),
+            kind: QueryErrorKind::UndefinedFunction(operator, left_type, right_type),
+        });
+        self
+    }
+
+    // These errors can be generated multiple at a time which is why they are &mut self
+    // and the rest are mut self.
+
+    /// numeric out of range constructor
+    pub fn out_of_range(&mut self, pg_type: PostgreSqlType) {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "22003".to_owned(),
+            kind: QueryErrorKind::NumericTypeOutOfRange(pg_type),
+        });
+    }
+
+    /// type mismatch constructor
+    pub fn type_mismatch(&mut self, value: &str, pg_type: PostgreSqlType) {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "2200G".to_owned(),
+            kind: QueryErrorKind::DataTypeMismatch(pg_type, value.to_owned()),
+        });
+    }
+
+    /// length of string types do not match constructor
+    pub fn string_length_mismatch(&mut self, pg_type: PostgreSqlType, len: u64) {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            code: "22026".to_owned(),
+            kind: QueryErrorKind::StringTypeLengthMismatch(pg_type, len),
+        });
     }
 }

--- a/src/protocol/src/results.rs
+++ b/src/protocol/src/results.rs
@@ -195,7 +195,6 @@ impl QueryErrorBuilder {
     // these error will stop the execution of the query; therefore there will only
     // ever be one.
 
-
     /// schema already exists error constructor
     pub fn schema_already_exists(mut self, schema_name: String) -> Self {
         self.errors.push(QueryErrorInner {
@@ -278,7 +277,7 @@ impl QueryErrorBuilder {
 
     /// operator or function is not found for operands
     pub fn undefined_function(mut self, operator: String, left_type: String, right_type: String) -> Self {
-        self.errors.push(QueryErrorInner{
+        self.errors.push(QueryErrorInner {
             severity: Severity::Error,
             code: "42883".to_owned(),
             kind: QueryErrorKind::UndefinedFunction(operator, left_type, right_type),

--- a/src/sql_engine/Cargo.toml
+++ b/src/sql_engine/Cargo.toml
@@ -10,6 +10,7 @@ log = "0.4.8"
 kernel = { path = "../kernel" }
 storage = { path = "../storage" }
 sqlparser = { version = "0.5.1", features = ["bigdecimal"] }
+bigdecimal = "0.1.2"
 sql_types = { path = "../sql_types" }
 protocol = { path = "../protocol" }
 

--- a/src/sql_engine/src/ddl/create_schema.rs
+++ b/src/sql_engine/src/ddl/create_schema.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use kernel::SystemResult;
-use protocol::results::{QueryError, QueryEvent, QueryResult};
+use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
 use sqlparser::ast::ObjectName;
 use std::sync::{Arc, Mutex};
 use storage::{backend::BackendStorage, frontend::FrontendStorage, SchemaAlreadyExists};
@@ -32,7 +32,7 @@ impl<P: BackendStorage> CreateSchemaCommand<P> {
         let schema_name = self.schema_name.to_string();
         match (self.storage.lock().unwrap()).create_schema(&schema_name)? {
             Ok(()) => Ok(Ok(QueryEvent::SchemaCreated)),
-            Err(SchemaAlreadyExists) => Ok(Err(QueryError::schema_already_exists(schema_name))),
+            Err(SchemaAlreadyExists) => Ok(Err(QueryErrorBuilder::new().schema_already_exists(schema_name).build())),
         }
     }
 }

--- a/src/sql_engine/src/ddl/create_table.rs
+++ b/src/sql_engine/src/ddl/create_table.rs
@@ -73,7 +73,9 @@ impl<P: BackendStorage> CreateTableCommand<P> {
             }
             Err(CreateTableError::TableAlreadyExists) => {
                 // this is what the test expected. Also, there should maybe this name should already be generated somewhere.
-                Ok(Err(QueryErrorBuilder::new().table_already_exists(format!("{}.{}", schema_name, table_name)).build()))
+                Ok(Err(QueryErrorBuilder::new()
+                    .table_already_exists(format!("{}.{}", schema_name, table_name))
+                    .build()))
             }
         }
     }

--- a/src/sql_engine/src/ddl/drop_schema.rs
+++ b/src/sql_engine/src/ddl/drop_schema.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use kernel::SystemResult;
-use protocol::results::{QueryError, QueryEvent, QueryResult};
+use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
 use sqlparser::ast::ObjectName;
 use std::sync::{Arc, Mutex};
 use storage::{backend::BackendStorage, frontend::FrontendStorage, SchemaDoesNotExist};
@@ -32,7 +32,7 @@ impl<P: BackendStorage> DropSchemaCommand<P> {
         let schema_name = self.name.0[0].to_string();
         match (self.storage.lock().unwrap()).drop_schema(&schema_name)? {
             Ok(()) => Ok(Ok(QueryEvent::SchemaDropped)),
-            Err(SchemaDoesNotExist) => Ok(Err(QueryError::schema_does_not_exist(schema_name))),
+            Err(SchemaDoesNotExist) => Ok(Err(QueryErrorBuilder::new().schema_does_not_exist(schema_name).build())),
         }
     }
 }

--- a/src/sql_engine/src/dml/insert.rs
+++ b/src/sql_engine/src/dml/insert.rs
@@ -14,14 +14,14 @@
 
 use bigdecimal::BigDecimal;
 use kernel::SystemResult;
-use protocol::results::{ConstraintViolation, QueryError, QueryEvent, QueryResult};
-use sql_types::ConstraintError;
+use protocol::results::{QueryErrorBuilder, QueryError, QueryEvent, QueryResult};
+use sql_types::{ConstraintError};
 use sqlparser::ast::{BinaryOperator, DataType, Expr, Ident, ObjectName, Query, SetExpr, UnaryOperator, Value};
 use std::{
     ops::Deref,
     sync::{Arc, Mutex},
 };
-use storage::{backend::BackendStorage, frontend::FrontendStorage, ColumnDefinition, OperationOnTableError};
+use storage::{backend::BackendStorage, frontend::FrontendStorage, OperationOnTableError, ColumnDefinition};
 
 pub(crate) struct InsertCommand<'q, P: BackendStorage> {
     raw_sql_query: &'q str,
@@ -86,16 +86,16 @@ impl<P: BackendStorage> InsertCommand<'_, P> {
                                 "-".to_owned() + v.to_string().as_str()
                             }
                             (op, expr) => {
-                                return Ok(Err(QueryError::syntax_error(
+                                return Ok(Err(QueryErrorBuilder::new().syntax_error(
                                     op.to_string() + expr.to_string().as_str(),
-                                )))
+                                ).build()))
                             }
                         },
                         expr @ Expr::BinaryOp { .. } => match Self::eval(expr) {
                             Ok(expr_result) => expr_result.value(),
                             Err(e) => return Ok(Err(e)),
                         },
-                        expr => return Ok(Err(QueryError::syntax_error(expr.to_string()))),
+                        expr => return Ok(Err(QueryErrorBuilder::new().syntax_error(expr.to_string()).build())),
                     };
                     row.push(v);
                 }
@@ -106,34 +106,32 @@ impl<P: BackendStorage> InsertCommand<'_, P> {
             match (self.storage.lock().unwrap()).insert_into(&schema_name, &table_name, columns, rows)? {
                 Ok(_) => Ok(Ok(QueryEvent::RecordsInserted(len))),
                 Err(OperationOnTableError::SchemaDoesNotExist) => {
-                    Ok(Err(QueryError::schema_does_not_exist(schema_name)))
+                    Ok(Err(QueryErrorBuilder::new().schema_does_not_exist(schema_name).build()))
                 }
-                Err(OperationOnTableError::TableDoesNotExist) => Ok(Err(QueryError::table_does_not_exist(
-                    schema_name + "." + table_name.as_str(),
-                ))),
+                Err(OperationOnTableError::TableDoesNotExist) => Ok(Err(QueryErrorBuilder::new()
+                    .table_does_not_exist(schema_name + "." + table_name.as_str())
+                    .build())),
                 Err(OperationOnTableError::ColumnDoesNotExist(non_existing_columns)) => {
-                    Ok(Err(QueryError::column_does_not_exist(non_existing_columns)))
+                    Ok(Err(QueryErrorBuilder::new()
+                        .column_does_not_exist(non_existing_columns)
+                        .build()))
                 }
                 Err(OperationOnTableError::ConstraintViolations(constraint_errors)) => {
-                    let constraint_error_mapper =
-                        |(err, column_definition): &(ConstraintError, ColumnDefinition)| -> ConstraintViolation {
-                            let sql_type = column_definition.sql_type();
-                            match err {
-                                ConstraintError::OutOfRange => {
-                                    ConstraintViolation::out_of_range(sql_type.to_pg_types())
-                                }
-                                ConstraintError::TypeMismatch(value) => {
-                                    ConstraintViolation::type_mismatch(value, sql_type.to_pg_types())
-                                }
-                                ConstraintError::ValueTooLong(len) => {
-                                    ConstraintViolation::string_length_mismatch(sql_type.to_pg_types(), *len)
-                                }
-                            }
-                        };
+                    let mut builder = QueryErrorBuilder::new();
+                    let constraint_error_mapper = |(err, column_definition): &(ConstraintError, ColumnDefinition)| match err {
+                        ConstraintError::OutOfRange => {
+                            builder.out_of_range(column_definition.sql_type().to_pg_types());
+                        }
+                        ConstraintError::TypeMismatch(value) => {
+                            builder.type_mismatch(value, column_definition.sql_type().to_pg_types());
+                        }
+                        ConstraintError::ValueTooLong(len) => {
+                            builder.string_length_mismatch(column_definition.sql_type().to_pg_types(), *len);
+                        }
+                    };
 
-                    let violations = constraint_errors.iter().map(constraint_error_mapper).collect();
-
-                    Ok(Err(QueryError::constraint_violations(violations)))
+                    constraint_errors.iter().for_each(constraint_error_mapper);
+                    Ok(Err(builder.build()))
                 }
                 Err(e) => {
                     eprintln!("{:?}", e);
@@ -141,7 +139,9 @@ impl<P: BackendStorage> InsertCommand<'_, P> {
                 }
             }
         } else {
-            Ok(Err(QueryError::not_supported_operation(self.raw_sql_query.to_owned())))
+            Ok(Err(QueryErrorBuilder::new()
+                .not_supported_operation(self.raw_sql_query.to_owned())
+                .build()))
         }
     }
 
@@ -166,42 +166,42 @@ impl<P: BackendStorage> InsertCommand<'_, P> {
                         let (right, _) = right.as_bigint_and_exponent();
                         Ok(ExprResult::Number(BigDecimal::from(left | &right)))
                     }
-                    operator => Err(QueryError::undefined_function(
+                    operator => Err(QueryErrorBuilder::new().undefined_function(
                         operator.to_string(),
                         "NUMBER".to_owned(),
                         "NUMBER".to_owned(),
-                    )),
+                    ).build()),
                 },
                 (ExprResult::String(left), ExprResult::String(right)) => match op {
                     BinaryOperator::StringConcat => Ok(ExprResult::String(left + right.as_str())),
-                    operator => Err(QueryError::undefined_function(
+                    operator => Err(QueryErrorBuilder::new().undefined_function(
                         operator.to_string(),
                         "STRING".to_owned(),
                         "STRING".to_owned(),
-                    )),
+                    ).build()),
                 },
                 (ExprResult::Number(left), ExprResult::String(right)) => match op {
                     BinaryOperator::StringConcat => Ok(ExprResult::String(left.to_string() + right.as_str())),
-                    operator => Err(QueryError::undefined_function(
+                    operator => Err(QueryErrorBuilder::new().undefined_function(
                         operator.to_string(),
                         "NUMBER".to_owned(),
                         "STRING".to_owned(),
-                    )),
+                    ).build()),
                 },
                 (ExprResult::String(left), ExprResult::Number(right)) => match op {
                     BinaryOperator::StringConcat => Ok(ExprResult::String(left + right.to_string().as_str())),
-                    operator => Err(QueryError::undefined_function(
+                    operator => Err(QueryErrorBuilder::new().undefined_function(
                         operator.to_string(),
                         "STRING".to_owned(),
                         "NUMBER".to_owned(),
-                    )),
+                    ).build()),
                 },
             }
         } else {
             match expr {
                 Expr::Value(Value::Number(v)) => Ok(ExprResult::Number(v.clone())),
                 Expr::Value(Value::SingleQuotedString(v)) => Ok(ExprResult::String(v.clone())),
-                e => Err(QueryError::syntax_error(e.to_string())),
+                e => Err(QueryErrorBuilder::new().syntax_error(e.to_string()).build()),
             }
         }
     }

--- a/src/sql_engine/src/dml/insert.rs
+++ b/src/sql_engine/src/dml/insert.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bigdecimal::BigDecimal;
 use kernel::SystemResult;
 use protocol::results::{ConstraintViolation, QueryError, QueryEvent, QueryResult};
 use sql_types::ConstraintError;
@@ -67,33 +68,39 @@ impl<P: BackendStorage> InsertCommand<'_, P> {
                     .collect()
             };
 
-            let rows: Vec<Vec<String>> = values
-                .iter()
-                .map(|v| {
-                    v.iter()
-                        .map(|v| match v {
-                            Expr::Value(Value::Number(v)) => v.to_string(),
-                            Expr::Value(Value::SingleQuotedString(v)) => v.to_string(),
-                            Expr::Value(Value::Boolean(v)) => v.to_string(),
-                            Expr::Cast { expr, data_type } => match (&**expr, data_type) {
-                                (Expr::Value(Value::Boolean(v)), DataType::Boolean) => v.to_string(),
-                                (Expr::Value(Value::SingleQuotedString(v)), DataType::Boolean) => v.to_string(),
-                                _ => {
-                                    unimplemented!("Cast from {:?} to {:?} is not currently supported", expr, data_type)
-                                }
-                            },
-                            Expr::UnaryOp { op, expr } => match (op, &**expr) {
-                                (UnaryOperator::Minus, Expr::Value(Value::Number(v))) => {
-                                    "-".to_owned() + v.to_string().as_str()
-                                }
-                                (op, expr) => unimplemented!("{:?} {:?} is not currently supported", op, expr),
-                            },
-                            expr @ Expr::BinaryOp { .. } => Self::eval(expr).value(),
-                            expr => unimplemented!("{:?} is not currently supported", expr),
-                        })
-                        .collect()
-                })
-                .collect();
+            let mut rows = vec![];
+            for line in values {
+                let mut row = vec![];
+                for col in line {
+                    let v = match col {
+                        Expr::Value(Value::Number(v)) => v.to_string(),
+                        Expr::Value(Value::SingleQuotedString(v)) => v.to_string(),
+                        Expr::Value(Value::Boolean(v)) => v.to_string(),
+                        Expr::Cast { expr, data_type } => match (&**expr, data_type) {
+                            (Expr::Value(Value::Boolean(v)), DataType::Boolean) => v.to_string(),
+                            (Expr::Value(Value::SingleQuotedString(v)), DataType::Boolean) => v.to_string(),
+                            _ => unimplemented!("Cast from {:?} to {:?} is not currently supported", expr, data_type),
+                        },
+                        Expr::UnaryOp { op, expr } => match (op, &**expr) {
+                            (UnaryOperator::Minus, Expr::Value(Value::Number(v))) => {
+                                "-".to_owned() + v.to_string().as_str()
+                            }
+                            (op, expr) => {
+                                return Ok(Err(QueryError::syntax_error(
+                                    op.to_string() + expr.to_string().as_str(),
+                                )))
+                            }
+                        },
+                        expr @ Expr::BinaryOp { .. } => match Self::eval(expr) {
+                            Ok(expr_result) => expr_result.value(),
+                            Err(e) => return Ok(Err(e)),
+                        },
+                        expr => return Ok(Err(QueryError::syntax_error(expr.to_string()))),
+                    };
+                    row.push(v);
+                }
+                rows.push(row);
+            }
 
             let len = rows.len();
             match (self.storage.lock().unwrap()).insert_into(&schema_name, &table_name, columns, rows)? {
@@ -138,45 +145,79 @@ impl<P: BackendStorage> InsertCommand<'_, P> {
         }
     }
 
-    fn eval(expr: &Expr) -> ExprResult {
+    fn eval(expr: &Expr) -> Result<ExprResult, QueryError> {
         if let Expr::BinaryOp { op, left, right } = expr {
-            let left: &Expr = left.deref();
-            let right: &Expr = right.deref();
+            let left = Self::eval(left.deref())?;
+            let right = Self::eval(right.deref())?;
             match (left, right) {
-                (Expr::Value(Value::Number(left)), Expr::Value(Value::Number(right))) => match op {
-                    BinaryOperator::Plus => ExprResult::Number((left + right).to_string()),
-                    BinaryOperator::Minus => ExprResult::Number((left - right).to_string()),
-                    BinaryOperator::Multiply => ExprResult::Number((left * right).to_string()),
-                    BinaryOperator::Divide => ExprResult::Number((left / right).to_string()),
-                    BinaryOperator::Modulus => ExprResult::Number((left % right).to_string()),
+                (ExprResult::Number(left), ExprResult::Number(right)) => match op {
+                    BinaryOperator::Plus => Ok(ExprResult::Number(left + right)),
+                    BinaryOperator::Minus => Ok(ExprResult::Number(left - right)),
+                    BinaryOperator::Multiply => Ok(ExprResult::Number(left * right)),
+                    BinaryOperator::Divide => Ok(ExprResult::Number(left / right)),
+                    BinaryOperator::Modulus => Ok(ExprResult::Number(left % right)),
                     BinaryOperator::BitwiseAnd => {
                         let (left, _) = left.as_bigint_and_exponent();
                         let (right, _) = right.as_bigint_and_exponent();
-                        ExprResult::Number((left & right).to_string())
+                        Ok(ExprResult::Number(BigDecimal::from(left & &right)))
                     }
                     BinaryOperator::BitwiseOr => {
                         let (left, _) = left.as_bigint_and_exponent();
                         let (right, _) = right.as_bigint_and_exponent();
-                        ExprResult::Number((left | right).to_string())
+                        Ok(ExprResult::Number(BigDecimal::from(left | &right)))
                     }
-                    _ => unimplemented!(),
+                    operator => Err(QueryError::undefined_function(
+                        operator.to_string(),
+                        "NUMBER".to_owned(),
+                        "NUMBER".to_owned(),
+                    )),
                 },
-                e => unimplemented!("{:?} not supported", e),
+                (ExprResult::String(left), ExprResult::String(right)) => match op {
+                    BinaryOperator::StringConcat => Ok(ExprResult::String(left + right.as_str())),
+                    operator => Err(QueryError::undefined_function(
+                        operator.to_string(),
+                        "STRING".to_owned(),
+                        "STRING".to_owned(),
+                    )),
+                },
+                (ExprResult::Number(left), ExprResult::String(right)) => match op {
+                    BinaryOperator::StringConcat => Ok(ExprResult::String(left.to_string() + right.as_str())),
+                    operator => Err(QueryError::undefined_function(
+                        operator.to_string(),
+                        "NUMBER".to_owned(),
+                        "STRING".to_owned(),
+                    )),
+                },
+                (ExprResult::String(left), ExprResult::Number(right)) => match op {
+                    BinaryOperator::StringConcat => Ok(ExprResult::String(left + right.to_string().as_str())),
+                    operator => Err(QueryError::undefined_function(
+                        operator.to_string(),
+                        "STRING".to_owned(),
+                        "NUMBER".to_owned(),
+                    )),
+                },
             }
         } else {
-            unimplemented!("{:?} not supported", expr)
+            match expr {
+                Expr::Value(Value::Number(v)) => Ok(ExprResult::Number(v.clone())),
+                Expr::Value(Value::SingleQuotedString(v)) => Ok(ExprResult::String(v.clone())),
+                e => Err(QueryError::syntax_error(e.to_string())),
+            }
         }
     }
 }
 
+#[derive(Debug)]
 enum ExprResult {
-    Number(String),
+    Number(BigDecimal),
+    String(String),
 }
 
 impl ExprResult {
     fn value(self) -> String {
         match self {
-            Self::Number(v) => v,
+            Self::Number(v) => v.to_string(),
+            Self::String(v) => v,
         }
     }
 }

--- a/src/sql_engine/src/dml/select.rs
+++ b/src/sql_engine/src/dml/select.rs
@@ -14,7 +14,7 @@
 
 use kernel::SystemResult;
 use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
-use sqlparser::ast::{Query};
+use sqlparser::ast::Query;
 use std::{
     ops::Deref,
     sync::{Arc, Mutex},

--- a/src/sql_engine/src/dml/update.rs
+++ b/src/sql_engine/src/dml/update.rs
@@ -14,10 +14,10 @@
 
 use kernel::SystemResult;
 use protocol::results::{ConstraintViolation, QueryError, QueryEvent, QueryResult};
-use sql_types::{ConstraintError, SqlType};
+use sql_types::ConstraintError;
 use sqlparser::ast::{Assignment, Expr, Ident, ObjectName, UnaryOperator, Value};
 use std::sync::{Arc, Mutex};
-use storage::{backend::BackendStorage, frontend::FrontendStorage, OperationOnTableError};
+use storage::{backend::BackendStorage, frontend::FrontendStorage, ColumnDefinition, OperationOnTableError};
 
 pub(crate) struct UpdateCommand<'q, P: BackendStorage> {
     raw_sql_query: &'q str,
@@ -79,7 +79,8 @@ impl<P: BackendStorage> UpdateCommand<'_, P> {
             }
             Err(OperationOnTableError::ConstraintViolations(constraint_errors)) => {
                 let constraint_error_mapper =
-                    |(err, _, sql_type): &(ConstraintError, String, SqlType)| -> ConstraintViolation {
+                    |(err, column_definition): &(ConstraintError, ColumnDefinition)| -> ConstraintViolation {
+                        let sql_type = column_definition.sql_type();
                         match err {
                             ConstraintError::OutOfRange => ConstraintViolation::out_of_range(sql_type.to_pg_types()),
                             ConstraintError::TypeMismatch(value) => {

--- a/src/sql_engine/src/dml/update.rs
+++ b/src/sql_engine/src/dml/update.rs
@@ -14,10 +14,10 @@
 
 use kernel::SystemResult;
 use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
-use sql_types::{ConstraintError};
+use sql_types::ConstraintError;
 use sqlparser::ast::{Assignment, Expr, Ident, ObjectName, UnaryOperator, Value};
 use std::sync::{Arc, Mutex};
-use storage::{backend::BackendStorage, frontend::FrontendStorage, OperationOnTableError, ColumnDefinition};
+use storage::{backend::BackendStorage, frontend::FrontendStorage, ColumnDefinition, OperationOnTableError};
 
 pub(crate) struct UpdateCommand<'q, P: BackendStorage> {
     raw_sql_query: &'q str,
@@ -81,7 +81,8 @@ impl<P: BackendStorage> UpdateCommand<'_, P> {
                 .build())),
             Err(OperationOnTableError::ConstraintViolations(constraint_errors)) => {
                 let mut builder = QueryErrorBuilder::new();
-                let constraint_error_mapper = |(err, column_definition): &(ConstraintError, ColumnDefinition)| match err {
+                let constraint_error_mapper = |(err, column_definition): &(ConstraintError, ColumnDefinition)| match err
+                {
                     ConstraintError::OutOfRange => {
                         builder.out_of_range(column_definition.sql_type().to_pg_types());
                     }

--- a/src/sql_engine/src/dml/update.rs
+++ b/src/sql_engine/src/dml/update.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use kernel::SystemResult;
-use protocol::results::{ConstraintViolation, QueryError, QueryEvent, QueryResult};
-use sql_types::ConstraintError;
+use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
+use sql_types::{ConstraintError};
 use sqlparser::ast::{Assignment, Expr, Ident, ObjectName, UnaryOperator, Value};
 use std::sync::{Arc, Mutex};
-use storage::{backend::BackendStorage, frontend::FrontendStorage, ColumnDefinition, OperationOnTableError};
+use storage::{backend::BackendStorage, frontend::FrontendStorage, OperationOnTableError, ColumnDefinition};
 
 pub(crate) struct UpdateCommand<'q, P: BackendStorage> {
     raw_sql_query: &'q str,
@@ -70,32 +70,35 @@ impl<P: BackendStorage> UpdateCommand<'_, P> {
 
         match (self.storage.lock().unwrap()).update_all(&schema_name, &table_name, to_update)? {
             Ok(records_number) => Ok(Ok(QueryEvent::RecordsUpdated(records_number))),
-            Err(OperationOnTableError::SchemaDoesNotExist) => Ok(Err(QueryError::schema_does_not_exist(schema_name))),
-            Err(OperationOnTableError::TableDoesNotExist) => Ok(Err(QueryError::table_does_not_exist(
-                schema_name + "." + table_name.as_str(),
-            ))),
-            Err(OperationOnTableError::ColumnDoesNotExist(non_existing_columns)) => {
-                Ok(Err(QueryError::column_does_not_exist(non_existing_columns)))
+            Err(OperationOnTableError::SchemaDoesNotExist) => {
+                Ok(Err(QueryErrorBuilder::new().schema_does_not_exist(schema_name).build()))
             }
+            Err(OperationOnTableError::TableDoesNotExist) => Ok(Err(QueryErrorBuilder::new()
+                .table_does_not_exist(schema_name + "." + table_name.as_str())
+                .build())),
+            Err(OperationOnTableError::ColumnDoesNotExist(non_existing_columns)) => Ok(Err(QueryErrorBuilder::new()
+                .column_does_not_exist(non_existing_columns)
+                .build())),
             Err(OperationOnTableError::ConstraintViolations(constraint_errors)) => {
-                let constraint_error_mapper =
-                    |(err, column_definition): &(ConstraintError, ColumnDefinition)| -> ConstraintViolation {
-                        let sql_type = column_definition.sql_type();
-                        match err {
-                            ConstraintError::OutOfRange => ConstraintViolation::out_of_range(sql_type.to_pg_types()),
-                            ConstraintError::TypeMismatch(value) => {
-                                ConstraintViolation::type_mismatch(value, sql_type.to_pg_types())
-                            }
-                            ConstraintError::ValueTooLong(len) => {
-                                ConstraintViolation::string_length_mismatch(sql_type.to_pg_types(), *len)
-                            }
-                        }
-                    };
+                let mut builder = QueryErrorBuilder::new();
+                let constraint_error_mapper = |(err, column_definition): &(ConstraintError, ColumnDefinition)| match err {
+                    ConstraintError::OutOfRange => {
+                        builder.out_of_range(column_definition.sql_type().to_pg_types());
+                    }
+                    ConstraintError::TypeMismatch(value) => {
+                        builder.type_mismatch(value, column_definition.sql_type().to_pg_types());
+                    }
+                    ConstraintError::ValueTooLong(len) => {
+                        builder.string_length_mismatch(column_definition.sql_type().to_pg_types(), *len);
+                    }
+                };
 
-                let violations = constraint_errors.iter().map(constraint_error_mapper).collect();
-                Ok(Err(QueryError::constraint_violations(violations)))
+                constraint_errors.iter().for_each(constraint_error_mapper);
+                Ok(Err(builder.build()))
             }
-            _ => Ok(Err(QueryError::not_supported_operation(self.raw_sql_query.to_owned()))),
+            _ => Ok(Err(QueryErrorBuilder::new()
+                .not_supported_operation(self.raw_sql_query.to_owned())
+                .build())),
         }
     }
 }

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate bigdecimal;
 extern crate log;
 
 use crate::{

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -23,7 +23,7 @@ use crate::{
     dml::{delete::DeleteCommand, insert::InsertCommand, select::SelectCommand, update::UpdateCommand},
 };
 use kernel::SystemResult;
-use protocol::results::{QueryError, QueryEvent, QueryResult};
+use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
 
 use sqlparser::{
     ast::{ObjectType, Statement},
@@ -67,7 +67,9 @@ impl<P: BackendStorage> Handler<P> {
             Statement::Drop { object_type, names, .. } => match object_type {
                 ObjectType::Table => DropTableCommand::new(names[0].clone(), self.storage.clone()).execute(),
                 ObjectType::Schema => DropSchemaCommand::new(names[0].clone(), self.storage.clone()).execute(),
-                _ => Ok(Err(QueryError::not_supported_operation(raw_sql_query.to_owned()))),
+                _ => Ok(Err(QueryErrorBuilder::new()
+                    .not_supported_operation(raw_sql_query.to_owned())
+                    .build())),
             },
             Statement::Insert {
                 table_name,
@@ -84,7 +86,9 @@ impl<P: BackendStorage> Handler<P> {
             Statement::Delete { table_name, .. } => {
                 DeleteCommand::new(raw_sql_query, table_name, self.storage.clone()).execute()
             }
-            _ => Ok(Err(QueryError::not_supported_operation(raw_sql_query.to_owned()))),
+            _ => Ok(Err(QueryErrorBuilder::new()
+                .not_supported_operation(raw_sql_query.to_owned())
+                .build())),
         }
     }
 }

--- a/src/sql_engine/src/tests/delete.rs
+++ b/src/sql_engine/src/tests/delete.rs
@@ -21,7 +21,9 @@ fn delete_from_nonexistent_table(mut sql_engine_with_schema: InMemorySqlEngine) 
         sql_engine_with_schema
             .execute("delete from schema_name.table_name;")
             .expect("no system errors"),
-        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .table_does_not_exist("schema_name.table_name".to_owned())
+            .build())
     );
 }
 

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -26,6 +26,21 @@ fn insert_into_nonexistent_table(mut sql_engine_with_schema: InMemorySqlEngine) 
 }
 
 #[rstest::rstest]
+fn insert_value_in_non_existent_column(mut sql_engine_with_schema: InMemorySqlEngine) {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name (column_test smallint);")
+        .expect("no system errors")
+        .expect("table created");
+
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("insert into schema_name.table_name (non_existent) values (123);")
+            .expect("no system errors"),
+        Err(QueryError::column_does_not_exist(vec!["non_existent".to_owned()]))
+    );
+}
+
+#[rstest::rstest]
 fn insert_and_select_single_row(mut sql_engine_with_schema: InMemorySqlEngine) {
     sql_engine_with_schema
         .execute("create table schema_name.table_name (column_test smallint);")

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -21,7 +21,9 @@ fn insert_into_nonexistent_table(mut sql_engine_with_schema: InMemorySqlEngine) 
         sql_engine_with_schema
             .execute("insert into schema_name.table_name values (123);")
             .expect("no system errors"),
-        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .table_does_not_exist("schema_name.table_name".to_owned())
+            .build())
     );
 }
 
@@ -36,7 +38,7 @@ fn insert_value_in_non_existent_column(mut sql_engine_with_schema: InMemorySqlEn
         sql_engine_with_schema
             .execute("insert into schema_name.table_name (non_existent) values (123);")
             .expect("no system errors"),
-        Err(QueryError::column_does_not_exist(vec!["non_existent".to_owned()]))
+        Err(QueryErrorBuilder::new().column_does_not_exist(vec!["non_existent".to_owned()]).build())
     );
 }
 
@@ -707,11 +709,11 @@ mod operators {
                 with_table
                     .execute("insert into schema_name.table_name values (1 || 2);")
                     .expect("no system errors"),
-                Err(QueryError::undefined_function(
+                Err(QueryErrorBuilder::new().undefined_function(
                     "||".to_owned(),
                     "NUMBER".to_owned(),
                     "NUMBER".to_owned()
-                ))
+                ).build())
             );
         }
     }

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -250,360 +250,469 @@ fn insert_and_select_different_character_types(mut sql_engine_with_schema: InMem
     )
 }
 
+#[rstest::rstest]
+fn insert_booleans(mut sql_engine_with_schema: InMemorySqlEngine) {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name (b boolean);")
+        .expect("no system errors")
+        .expect("table created");
+
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("insert into schema_name.table_name values(true);")
+            .expect("no system errors"),
+        Ok(QueryEvent::RecordsInserted(1))
+    );
+
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("insert into schema_name.table_name values(TRUE::boolean);")
+            .expect("no system errors"),
+        Ok(QueryEvent::RecordsInserted(1))
+    );
+
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("insert into schema_name.table_name values('true'::boolean);")
+            .expect("no system errors"),
+        Ok(QueryEvent::RecordsInserted(1))
+    );
+}
+
 #[cfg(test)]
-mod mathematical_operators {
+mod operators {
     use super::*;
 
-    #[rstest::fixture]
-    fn with_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
-        sql_engine_with_schema
-            .execute("create table schema_name.table_name(column_si smallint);")
-            .expect("no system errors")
-            .expect("table created");
+    #[cfg(test)]
+    mod mathematical {
+        use super::*;
 
-        sql_engine_with_schema
+        #[cfg(test)]
+        mod integers {
+            use super::*;
+
+            #[rstest::fixture]
+            fn with_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
+                sql_engine_with_schema
+                    .execute("create table schema_name.table_name(column_si smallint);")
+                    .expect("no system errors")
+                    .expect("table created");
+
+                sql_engine_with_schema
+            }
+
+            #[rstest::rstest]
+            fn addition(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (1 + 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["3".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn subtraction(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (1 - 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["-1".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn multiplication(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (3 * 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["6".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn division(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (8 / 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["4".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn modulo(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (8 % 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["0".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO ^ is bitwise in SQL standard
+            //      # is bitwise in PostgreSQL and it does not supported in sqlparser-rs
+            fn exponentiation(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (8 ^ 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["64".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO |/<n> is square root in PostgreSQL and it does not supported in sqlparser-rs
+            fn square_root(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (|/ 16);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["4".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO ||/<n> is cube root in PostgreSQL and it does not supported in sqlparser-rs
+            fn cube_root(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (||/ 8);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["2".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO <n>! is factorial in PostgreSQL and it does not supported in sqlparser-rs
+            fn factorial(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (5!);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["120".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO !!<n> is prefix factorial in PostgreSQL and it does not supported in sqlparser-rs
+            fn prefix_factorial(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (!!5);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["120".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO @<n> is absolute value in PostgreSQL and it does not supported in sqlparser-rs
+            fn absolute_value(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (@-5);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["5".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn bitwise_and(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (5 & 1);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["1".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn bitwise_or(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (5 | 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["7".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO ~ <n> is bitwise NOT in PostgreSQL and it does not supported in sqlparser-rs
+            fn bitwise_not(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (~1);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["-2".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO <n> << <m> is bitwise SHIFT LEFT in PostgreSQL and it does not supported in sqlparser-rs
+            fn bitwise_shift_left(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (1 << 4);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["16".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO <n> >> <m> is bitwise SHIFT RIGHT in PostgreSQL and it does not supported in sqlparser-rs
+            fn bitwise_right_left(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (8 >> 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["2".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn evaluate_many_operations(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (5 & 13 % 10 + 1 * 20 - 40 / 4);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["5".to_owned()]]
+                    )))
+                );
+            }
+        }
     }
 
-    #[rstest::rstest]
-    fn addition(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (1 + 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["3".to_owned()]]
-            )))
-        );
-    }
+    #[cfg(test)]
+    mod string {
+        use super::*;
 
-    #[rstest::rstest]
-    fn subtraction(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (1 - 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["-1".to_owned()]]
-            )))
-        );
-    }
+        #[rstest::fixture]
+        fn with_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
+            sql_engine_with_schema
+                .execute("create table schema_name.table_name(strings char(5));")
+                .expect("no system errors")
+                .expect("table created");
 
-    #[rstest::rstest]
-    fn multiplication(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (3 * 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["6".to_owned()]]
-            )))
-        );
-    }
+            sql_engine_with_schema
+        }
 
-    #[rstest::rstest]
-    fn division(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (8 / 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["4".to_owned()]]
-            )))
-        );
-    }
+        #[rstest::rstest]
+        fn concatenation(mut with_table: InMemorySqlEngine) {
+            assert_eq!(
+                with_table
+                    .execute("insert into schema_name.table_name values ('123' || '45');")
+                    .expect("no system errors"),
+                Ok(QueryEvent::RecordsInserted(1))
+            );
+            assert_eq!(
+                with_table
+                    .execute("select * from schema_name.table_name;")
+                    .expect("no system errors"),
+                Ok(QueryEvent::RecordsSelected((
+                    vec![("strings".to_owned(), PostgreSqlType::Char),],
+                    vec![vec!["12345".to_owned()]]
+                )))
+            );
+        }
 
-    #[rstest::rstest]
-    fn modulo(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
+        #[rstest::rstest]
+        fn concatenation_with_number(mut with_table: InMemorySqlEngine) {
             with_table
-                .execute("insert into schema_name.table_name values (8 % 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["0".to_owned()]]
-            )))
-        );
-    }
+                .execute("insert into schema_name.table_name values (1 || '45');")
+                .expect("no system errors")
+                .expect("record inserted");
 
-    #[rstest::rstest]
-    #[ignore]
-    // TODO ^ is bitwise in SQL standard
-    //      # is bitwise in PostgreSQL and it does not supported in sqlparser-rs
-    fn exponentiation(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
             with_table
-                .execute("insert into schema_name.table_name values (8 ^ 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["64".to_owned()]]
-            )))
-        );
-    }
+                .execute("insert into schema_name.table_name values ('45' || 1);")
+                .expect("no system errors")
+                .expect("record inserted");
 
-    #[rstest::rstest]
-    #[ignore]
-    // TODO |/<n> is square root in PostgreSQL and it does not supported in sqlparser-rs
-    fn square_root(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (|/ 16);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["4".to_owned()]]
-            )))
-        );
-    }
+            assert_eq!(
+                with_table
+                    .execute("select * from schema_name.table_name;")
+                    .expect("no system errors"),
+                Ok(QueryEvent::RecordsSelected((
+                    vec![("strings".to_owned(), PostgreSqlType::Char),],
+                    vec![vec!["145".to_owned()], vec!["451".to_owned()]]
+                )))
+            );
+        }
 
-    #[rstest::rstest]
-    #[ignore]
-    // TODO ||/<n> is cube root in PostgreSQL and it does not supported in sqlparser-rs
-    fn cube_root(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (||/ 8);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["2".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO <n>! is factorial in PostgreSQL and it does not supported in sqlparser-rs
-    fn factorial(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (5!);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["120".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO !!<n> is prefix factorial in PostgreSQL and it does not supported in sqlparser-rs
-    fn prefix_factorial(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (!!5);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["120".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO @<n> is absolute value in PostgreSQL and it does not supported in sqlparser-rs
-    fn absolute_value(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (@-5);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["5".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    fn bitwise_and(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (5 & 1);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["1".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    fn bitwise_or(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (5 | 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["7".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO ~ <n> is bitwise NOT in PostgreSQL and it does not supported in sqlparser-rs
-    fn bitwise_not(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (~1);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["-2".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO <n> << <m> is bitwise SHIFT LEFT in PostgreSQL and it does not supported in sqlparser-rs
-    fn bitwise_shift_left(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (1 << 4);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["16".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO <n> >> <m> is bitwise SHIFT RIGHT in PostgreSQL and it does not supported in sqlparser-rs
-    fn bitwise_right_left(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (8 >> 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["2".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    fn bitwise_operations_have_lesser_priority_than_arithmetic(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (5 & 3 + 1);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["4".to_owned()]]
-            )))
-        );
+        #[rstest::rstest]
+        fn non_string_concatenation_not_supported(mut with_table: InMemorySqlEngine) {
+            assert_eq!(
+                with_table
+                    .execute("insert into schema_name.table_name values (1 || 2);")
+                    .expect("no system errors"),
+                Err(QueryError::undefined_function(
+                    "||".to_owned(),
+                    "NUMBER".to_owned(),
+                    "NUMBER".to_owned()
+                ))
+            );
+        }
     }
 }

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -38,7 +38,9 @@ fn insert_value_in_non_existent_column(mut sql_engine_with_schema: InMemorySqlEn
         sql_engine_with_schema
             .execute("insert into schema_name.table_name (non_existent) values (123);")
             .expect("no system errors"),
-        Err(QueryErrorBuilder::new().column_does_not_exist(vec!["non_existent".to_owned()]).build())
+        Err(QueryErrorBuilder::new()
+            .column_does_not_exist(vec!["non_existent".to_owned()])
+            .build())
     );
 }
 
@@ -709,11 +711,9 @@ mod operators {
                 with_table
                     .execute("insert into schema_name.table_name values (1 || 2);")
                     .expect("no system errors"),
-                Err(QueryErrorBuilder::new().undefined_function(
-                    "||".to_owned(),
-                    "NUMBER".to_owned(),
-                    "NUMBER".to_owned()
-                ).build())
+                Err(QueryErrorBuilder::new()
+                    .undefined_function("||".to_owned(), "NUMBER".to_owned(), "NUMBER".to_owned())
+                    .build())
             );
         }
     }

--- a/src/sql_engine/src/tests/mod.rs
+++ b/src/sql_engine/src/tests/mod.rs
@@ -23,6 +23,8 @@ mod select;
 #[cfg(test)]
 mod table;
 #[cfg(test)]
+mod type_constraints;
+#[cfg(test)]
 mod update;
 
 use super::*;

--- a/src/sql_engine/src/tests/schema.rs
+++ b/src/sql_engine/src/tests/schema.rs
@@ -25,7 +25,7 @@ fn create_same_schema(mut sql_engine: InMemorySqlEngine) {
         sql_engine
             .execute("create schema schema_name;")
             .expect("no system errors"),
-        Err(QueryError::schema_already_exists("schema_name".to_owned()))
+        Err(QueryErrorBuilder::new().schema_already_exists("schema_name".to_owned()).build())
     )
 }
 
@@ -50,7 +50,7 @@ fn drop_non_existent_schema(mut sql_engine: InMemorySqlEngine) {
         sql_engine
             .execute("drop schema non_existent;")
             .expect("no system errors"),
-        Err(QueryError::schema_does_not_exist("non_existent".to_owned()))
+        Err(QueryErrorBuilder::new().schema_does_not_exist("non_existent".to_owned()).build())
     )
 }
 
@@ -60,7 +60,9 @@ fn select_from_nonexistent_schema(mut sql_engine: InMemorySqlEngine) {
         sql_engine
             .execute("select * from non_existent.some_table;")
             .expect("no system errors"),
-        Err(QueryError::schema_does_not_exist("non_existent".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .schema_does_not_exist("non_existent".to_owned())
+            .build())
     );
 }
 
@@ -70,7 +72,9 @@ fn select_named_columns_from_nonexistent_schema(mut sql_engine: InMemorySqlEngin
         sql_engine
             .execute("select column_1 from schema_name.table_name;")
             .expect("no system errors"),
-        Err(QueryError::schema_does_not_exist("schema_name".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .schema_does_not_exist("schema_name".to_owned())
+            .build())
     );
 }
 
@@ -80,7 +84,9 @@ fn insert_into_table_in_nonexistent_schema(mut sql_engine: InMemorySqlEngine) {
         sql_engine
             .execute("insert into schema_name.table_name values (123);")
             .expect("no system errors"),
-        Err(QueryError::schema_does_not_exist("schema_name".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .schema_does_not_exist("schema_name".to_owned())
+            .build())
     );
 }
 
@@ -90,7 +96,9 @@ fn update_records_in_table_from_non_existent_schema(mut sql_engine: InMemorySqlE
         sql_engine
             .execute("update schema_name.table_name set column_test=789;")
             .expect("no system errors"),
-        Err(QueryError::schema_does_not_exist("schema_name".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .schema_does_not_exist("schema_name".to_owned())
+            .build())
     );
 }
 
@@ -100,6 +108,8 @@ fn delete_from_table_in_nonexistent_schema(mut sql_engine: InMemorySqlEngine) {
         sql_engine
             .execute("delete from schema_name.table_name;")
             .expect("no system errors"),
-        Err(QueryError::schema_does_not_exist("schema_name".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .schema_does_not_exist("schema_name".to_owned())
+            .build())
     );
 }

--- a/src/sql_engine/src/tests/schema.rs
+++ b/src/sql_engine/src/tests/schema.rs
@@ -25,7 +25,9 @@ fn create_same_schema(mut sql_engine: InMemorySqlEngine) {
         sql_engine
             .execute("create schema schema_name;")
             .expect("no system errors"),
-        Err(QueryErrorBuilder::new().schema_already_exists("schema_name".to_owned()).build())
+        Err(QueryErrorBuilder::new()
+            .schema_already_exists("schema_name".to_owned())
+            .build())
     )
 }
 
@@ -50,7 +52,9 @@ fn drop_non_existent_schema(mut sql_engine: InMemorySqlEngine) {
         sql_engine
             .execute("drop schema non_existent;")
             .expect("no system errors"),
-        Err(QueryErrorBuilder::new().schema_does_not_exist("non_existent".to_owned()).build())
+        Err(QueryErrorBuilder::new()
+            .schema_does_not_exist("non_existent".to_owned())
+            .build())
     )
 }
 

--- a/src/sql_engine/src/tests/schema.rs
+++ b/src/sql_engine/src/tests/schema.rs
@@ -15,6 +15,46 @@
 use super::*;
 
 #[rstest::rstest]
+fn create_same_schema(mut sql_engine: InMemorySqlEngine) {
+    sql_engine
+        .execute("create schema schema_name;")
+        .expect("no system errors")
+        .expect("schema created");
+
+    assert_eq!(
+        sql_engine
+            .execute("create schema schema_name;")
+            .expect("no system errors"),
+        Err(QueryError::schema_already_exists("schema_name".to_owned()))
+    )
+}
+
+#[rstest::rstest]
+fn drop_schema(mut sql_engine: InMemorySqlEngine) {
+    sql_engine
+        .execute("create schema schema_name;")
+        .expect("no system errors")
+        .expect("schema created");
+
+    assert_eq!(
+        sql_engine
+            .execute("drop schema schema_name;")
+            .expect("no system errors"),
+        Ok(QueryEvent::SchemaDropped)
+    )
+}
+
+#[rstest::rstest]
+fn drop_non_existent_schema(mut sql_engine: InMemorySqlEngine) {
+    assert_eq!(
+        sql_engine
+            .execute("drop schema non_existent;")
+            .expect("no system errors"),
+        Err(QueryError::schema_does_not_exist("non_existent".to_owned()))
+    )
+}
+
+#[rstest::rstest]
 fn select_from_nonexistent_schema(mut sql_engine: InMemorySqlEngine) {
     assert_eq!(
         sql_engine

--- a/src/sql_engine/src/tests/select.rs
+++ b/src/sql_engine/src/tests/select.rs
@@ -21,7 +21,9 @@ fn select_from_not_existed_table(mut sql_engine_with_schema: InMemorySqlEngine) 
         sql_engine_with_schema
             .execute("select * from schema_name.non_existent;")
             .expect("no system errors"),
-        Err(QueryError::table_does_not_exist("schema_name.non_existent".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .table_does_not_exist("schema_name.non_existent".to_owned())
+            .build())
     );
 }
 
@@ -31,7 +33,9 @@ fn select_named_columns_from_non_existent_table(mut sql_engine_with_schema: InMe
         sql_engine_with_schema
             .execute("select column_1 from schema_name.non_existent;")
             .expect("no system errors"),
-        Err(QueryError::table_does_not_exist("schema_name.non_existent".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .table_does_not_exist("schema_name.non_existent".to_owned())
+            .build())
     );
 }
 
@@ -101,9 +105,11 @@ fn select_non_existing_columns_from_table(mut sql_engine_with_schema: InMemorySq
         sql_engine_with_schema
             .execute("select column_not_in_table1, column_not_in_table2 from schema_name.table_name;")
             .expect("no system errors"),
-        Err(QueryError::column_does_not_exist(vec![
-            "column_not_in_table1".to_owned(),
-            "column_not_in_table2".to_owned()
-        ]))
+        Err(QueryErrorBuilder::new()
+            .column_does_not_exist(vec![
+                "column_not_in_table1".to_owned(),
+                "column_not_in_table2".to_owned()
+            ])
+            .build())
     );
 }

--- a/src/sql_engine/src/tests/table.rs
+++ b/src/sql_engine/src/tests/table.rs
@@ -50,6 +50,20 @@ fn create_table(mut sql_engine_with_schema: InMemorySqlEngine) {
 }
 
 #[rstest::rstest]
+fn create_same_table(mut sql_engine_with_schema: InMemorySqlEngine) {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name (column_name smallint);")
+        .expect("no system errors")
+        .expect("table created");
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("create table schema_name.table_name (column_name smallint);")
+            .expect("no system errors"),
+        Err(QueryError::table_already_exists("schema_name.table_name".to_owned()))
+    );
+}
+
+#[rstest::rstest]
 fn drop_table(mut sql_engine_with_schema: InMemorySqlEngine) {
     sql_engine_with_schema
         .execute("create table schema_name.table_name (column_name smallint);")
@@ -80,17 +94,68 @@ fn drop_non_existent_table(mut sql_engine_with_schema: InMemorySqlEngine) {
     );
 }
 
-#[rstest::rstest]
-fn create_table_with_different_types(mut sql_engine: InMemorySqlEngine) {
-    sql_engine
-        .execute("create schema schema_name;")
-        .expect("no system errors")
-        .expect("schema created");
+#[cfg(test)]
+mod different_types {
+    use super::*;
 
-    assert_eq!(
-        sql_engine
-            .execute("create table schema_name.table_name (column_si smallint, column_i integer, column_bi bigint, column_c char(10), column_vc varchar(10));")
-            .expect("no system errors"),
-        Ok(QueryEvent::TableCreated)
-    )
+    #[rstest::rstest]
+    fn ints(mut sql_engine_with_schema: InMemorySqlEngine) {
+        assert_eq!(
+            sql_engine_with_schema
+                .execute(
+                    "create table schema_name.table_name (\
+            column_si smallint,\
+            column_i integer,\
+            column_bi bigint
+            );"
+                )
+                .expect("no system errors"),
+            Ok(QueryEvent::TableCreated)
+        )
+    }
+
+    #[rstest::rstest]
+    fn strings(mut sql_engine_with_schema: InMemorySqlEngine) {
+        assert_eq!(
+            sql_engine_with_schema
+                .execute(
+                    "create table schema_name.table_name (\
+            column_c char(10),\
+            column_vc varchar(10)\
+            );"
+                )
+                .expect("no system errors"),
+            Ok(QueryEvent::TableCreated)
+        )
+    }
+
+    #[rstest::rstest]
+    fn boolean(mut sql_engine_with_schema: InMemorySqlEngine) {
+        assert_eq!(
+            sql_engine_with_schema
+                .execute(
+                    "create table schema_name.table_name (\
+            column_b boolean\
+            );"
+                )
+                .expect("no system errors"),
+            Ok(QueryEvent::TableCreated)
+        )
+    }
+
+    #[rstest::rstest]
+    fn serials(mut sql_engine_with_schema: InMemorySqlEngine) {
+        assert_eq!(
+            sql_engine_with_schema
+                .execute(
+                    "create table schema_name.table_name (\
+            column_smalls smallserial,\
+            column_s serial,\
+            column_bigs bigserial\
+            );"
+                )
+                .expect("no system errors"),
+            Ok(QueryEvent::TableCreated)
+        )
+    }
 }

--- a/src/sql_engine/src/tests/table.rs
+++ b/src/sql_engine/src/tests/table.rs
@@ -63,7 +63,9 @@ fn create_same_table(mut sql_engine_with_schema: InMemorySqlEngine) {
         sql_engine_with_schema
             .execute("create table schema_name.table_name (column_name smallint);")
             .expect("no system errors"),
-        Err(QueryErrorBuilder::new().table_already_exists("schema_name.table_name".to_owned()).build())
+        Err(QueryErrorBuilder::new()
+            .table_already_exists("schema_name.table_name".to_owned())
+            .build())
     );
 }
 

--- a/src/sql_engine/src/tests/table.rs
+++ b/src/sql_engine/src/tests/table.rs
@@ -24,7 +24,9 @@ mod schemaless {
             sql_engine
                 .execute("create table schema_name.table_name (column_name smallint);")
                 .expect("no system errors"),
-            Err(QueryError::schema_does_not_exist("schema_name".to_owned()))
+            Err(QueryErrorBuilder::new()
+                .schema_does_not_exist("schema_name".to_owned())
+                .build())
         );
     }
 
@@ -34,7 +36,9 @@ mod schemaless {
             sql_engine
                 .execute("drop table schema_name.table_name;")
                 .expect("no system errors"),
-            Err(QueryError::schema_does_not_exist("schema_name".to_owned()))
+            Err(QueryErrorBuilder::new()
+                .schema_does_not_exist("schema_name".to_owned())
+                .build())
         );
     }
 }
@@ -59,7 +63,7 @@ fn create_same_table(mut sql_engine_with_schema: InMemorySqlEngine) {
         sql_engine_with_schema
             .execute("create table schema_name.table_name (column_name smallint);")
             .expect("no system errors"),
-        Err(QueryError::table_already_exists("schema_name.table_name".to_owned()))
+        Err(QueryErrorBuilder::new().table_already_exists("schema_name.table_name".to_owned()).build())
     );
 }
 
@@ -90,7 +94,9 @@ fn drop_non_existent_table(mut sql_engine_with_schema: InMemorySqlEngine) {
         sql_engine_with_schema
             .execute("drop table schema_name.table_name;")
             .expect("no system errors"),
-        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .table_does_not_exist("schema_name.table_name".to_owned())
+            .build())
     );
 }
 

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::*;
-use protocol::{results::ConstraintViolation, sql_types::PostgreSqlType};
+use protocol::{sql_types::PostgreSqlType, results::QueryErrorBuilder};
 
 #[rstest::fixture]
 fn int_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
@@ -41,37 +41,39 @@ mod insert {
 
     #[rstest::rstest]
     fn out_of_range(mut int_table: InMemorySqlEngine) {
+        let mut builder = QueryErrorBuilder::new();
+        builder.out_of_range(PostgreSqlType::SmallInt);
+
         assert_eq!(
             int_table
                 .execute("insert into schema_name.table_name values (32768);")
                 .expect("no system errors"),
-            Err(QueryError::constraint_violations(vec![
-                ConstraintViolation::out_of_range(PostgreSqlType::SmallInt)
-            ]))
+            Err(builder.build())
         );
     }
 
     #[rstest::rstest]
     fn type_mismatch(mut int_table: InMemorySqlEngine) {
+        let mut builder = QueryErrorBuilder::new();
+        builder.type_mismatch("str", PostgreSqlType::SmallInt);
+
         assert_eq!(
             int_table
                 .execute("insert into schema_name.table_name values ('str');")
                 .expect("no system errors"),
-            Err(QueryError::constraint_violations(vec![
-                ConstraintViolation::type_mismatch("str", PostgreSqlType::SmallInt)
-            ]))
+            Err(builder.build())
         )
     }
 
     #[rstest::rstest]
     fn value_too_long(mut str_table: InMemorySqlEngine) {
+        let mut builder = QueryErrorBuilder::new();
+        builder.string_length_mismatch(PostgreSqlType::VarChar, 5);
         assert_eq!(
             str_table
                 .execute("insert into schema_name.table_name values ('123457890');")
                 .expect("no system errors"),
-            Err(QueryError::constraint_violations(vec![
-                ConstraintViolation::string_length_mismatch(PostgreSqlType::VarChar, 5)
-            ]))
+            Err(builder.build())
         )
     }
 }
@@ -82,6 +84,9 @@ mod update {
 
     #[rstest::rstest]
     fn out_of_range(mut int_table: InMemorySqlEngine) {
+        let mut builder = QueryErrorBuilder::new();
+        builder.out_of_range(PostgreSqlType::SmallInt);
+
         int_table
             .execute("insert into schema_name.table_name values (32767);")
             .expect("no system errors")
@@ -91,14 +96,14 @@ mod update {
             int_table
                 .execute("update schema_name.table_name set col = 32768;")
                 .expect("no system errors"),
-            Err(QueryError::constraint_violations(vec![
-                ConstraintViolation::out_of_range(PostgreSqlType::SmallInt)
-            ]))
+            Err(builder.build())
         );
     }
 
     #[rstest::rstest]
     fn type_mismatch(mut int_table: InMemorySqlEngine) {
+        let mut builder = QueryErrorBuilder::new();
+        builder.type_mismatch("str", PostgreSqlType::SmallInt);
         int_table
             .execute("insert into schema_name.table_name values (32767);")
             .expect("no system errors")
@@ -108,14 +113,15 @@ mod update {
             int_table
                 .execute("update schema_name.table_name set col = 'str';")
                 .expect("no system errors"),
-            Err(QueryError::constraint_violations(vec![
-                ConstraintViolation::type_mismatch("str", PostgreSqlType::SmallInt)
-            ]))
+            Err(builder.build())
         )
     }
 
     #[rstest::rstest]
     fn value_too_long(mut str_table: InMemorySqlEngine) {
+        let mut builder = QueryErrorBuilder::new();
+        builder.string_length_mismatch(PostgreSqlType::VarChar, 5);
+
         str_table
             .execute("insert into schema_name.table_name values ('str');")
             .expect("no system errors")
@@ -125,9 +131,7 @@ mod update {
             str_table
                 .execute("update schema_name.table_name set col = '123457890';")
                 .expect("no system errors"),
-            Err(QueryError::constraint_violations(vec![
-                ConstraintViolation::string_length_mismatch(PostgreSqlType::VarChar, 5)
-            ]))
+            Err(builder.build())
         )
     }
 }

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -1,0 +1,133 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use protocol::{results::ConstraintViolation, sql_types::PostgreSqlType};
+
+#[rstest::fixture]
+fn int_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name(col smallint);")
+        .expect("no system errors")
+        .expect("table created");
+
+    sql_engine_with_schema
+}
+
+#[rstest::fixture]
+fn str_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name(col varchar(5));")
+        .expect("no system errors")
+        .expect("table created");
+
+    sql_engine_with_schema
+}
+
+#[cfg(test)]
+mod insert {
+    use super::*;
+
+    #[rstest::rstest]
+    fn out_of_range(mut int_table: InMemorySqlEngine) {
+        assert_eq!(
+            int_table
+                .execute("insert into schema_name.table_name values (32768);")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::out_of_range(PostgreSqlType::SmallInt)
+            ]))
+        );
+    }
+
+    #[rstest::rstest]
+    fn type_mismatch(mut int_table: InMemorySqlEngine) {
+        assert_eq!(
+            int_table
+                .execute("insert into schema_name.table_name values ('str');")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::type_mismatch("str", PostgreSqlType::SmallInt)
+            ]))
+        )
+    }
+
+    #[rstest::rstest]
+    fn value_too_long(mut str_table: InMemorySqlEngine) {
+        assert_eq!(
+            str_table
+                .execute("insert into schema_name.table_name values ('123457890');")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::string_length_mismatch(PostgreSqlType::VarChar, 5)
+            ]))
+        )
+    }
+}
+
+#[cfg(test)]
+mod update {
+    use super::*;
+
+    #[rstest::rstest]
+    fn out_of_range(mut int_table: InMemorySqlEngine) {
+        int_table
+            .execute("insert into schema_name.table_name values (32767);")
+            .expect("no system errors")
+            .expect("record inserted");
+
+        assert_eq!(
+            int_table
+                .execute("update schema_name.table_name set col = 32768;")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::out_of_range(PostgreSqlType::SmallInt)
+            ]))
+        );
+    }
+
+    #[rstest::rstest]
+    fn type_mismatch(mut int_table: InMemorySqlEngine) {
+        int_table
+            .execute("insert into schema_name.table_name values (32767);")
+            .expect("no system errors")
+            .expect("record inserted");
+
+        assert_eq!(
+            int_table
+                .execute("update schema_name.table_name set col = 'str';")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::type_mismatch("str", PostgreSqlType::SmallInt)
+            ]))
+        )
+    }
+
+    #[rstest::rstest]
+    fn value_too_long(mut str_table: InMemorySqlEngine) {
+        str_table
+            .execute("insert into schema_name.table_name values ('str');")
+            .expect("no system errors")
+            .expect("record inserted");
+
+        assert_eq!(
+            str_table
+                .execute("update schema_name.table_name set col = '123457890';")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::string_length_mismatch(PostgreSqlType::VarChar, 5)
+            ]))
+        )
+    }
+}

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::*;
-use protocol::{sql_types::PostgreSqlType, results::QueryErrorBuilder};
+use protocol::{results::QueryErrorBuilder, sql_types::PostgreSqlType};
 
 #[rstest::fixture]
 fn int_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {

--- a/src/sql_engine/src/tests/update.rs
+++ b/src/sql_engine/src/tests/update.rs
@@ -21,7 +21,9 @@ fn update_records_in_non_existent_table(mut sql_engine_with_schema: InMemorySqlE
         sql_engine_with_schema
             .execute("update schema_name.table_name set column_test=789;")
             .expect("no system errors"),
-        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .table_does_not_exist("schema_name.table_name".to_owned())
+            .build())
     );
 }
 
@@ -233,7 +235,9 @@ fn update_records_in_nonexistent_table(mut sql_engine_with_schema: InMemorySqlEn
         sql_engine_with_schema
             .execute("update schema_name.table_name set column_test=789;")
             .expect("no system errors"),
-        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned()))
+        Err(QueryErrorBuilder::new()
+            .table_does_not_exist("schema_name.table_name".to_owned())
+            .build())
     );
 }
 
@@ -261,9 +265,8 @@ fn update_non_existent_columns_of_records(mut sql_engine_with_schema: InMemorySq
         sql_engine_with_schema
             .execute("update schema_name.table_name set col1=456, col2=789;")
             .expect("no system errors"),
-        Err(QueryError::column_does_not_exist(vec![
-            "col1".to_owned(),
-            "col2".to_owned()
-        ]))
+        Err(QueryErrorBuilder::new()
+            .column_does_not_exist(vec!["col1".to_owned(), "col2".to_owned()])
+            .build())
     );
 }

--- a/src/sql_types/src/lib.rs
+++ b/src/sql_types/src/lib.rs
@@ -474,6 +474,13 @@ mod tests {
                         Err(ConstraintError::TypeMismatch("str".to_owned()))
                     )
                 }
+
+                #[test]
+                fn min_bound() {
+                    let constraint = SqlType::SmallInt(0).constraint();
+
+                    assert_eq!(constraint.validate("-1"), Err(ConstraintError::OutOfRange))
+                }
             }
         }
 
@@ -541,6 +548,13 @@ mod tests {
                         constraint.validate("str"),
                         Err(ConstraintError::TypeMismatch("str".to_owned()))
                     )
+                }
+
+                #[test]
+                fn min_bound() {
+                    let constraint = SqlType::Integer(0).constraint();
+
+                    assert_eq!(constraint.validate("-1"), Err(ConstraintError::OutOfRange))
                 }
             }
         }
@@ -615,6 +629,13 @@ mod tests {
                         constraint.validate("str"),
                         Err(ConstraintError::TypeMismatch("str".to_owned()))
                     )
+                }
+
+                #[test]
+                fn min_bound() {
+                    let constraint = SqlType::BigInt(0).constraint();
+
+                    assert_eq!(constraint.validate("-1"), Err(ConstraintError::OutOfRange))
                 }
             }
         }

--- a/src/storage/src/frontend/tests/mod.rs
+++ b/src/storage/src/frontend/tests/mod.rs
@@ -23,6 +23,13 @@ mod table;
 
 type PersistentStorage = FrontendStorage<SledBackendStorage>;
 
+fn column_definition(name: &'static str, sql_type: SqlType) -> ColumnDefinition {
+    ColumnDefinition {
+        name: name.to_owned(),
+        sql_type,
+    }
+}
+
 #[rstest::fixture]
 fn storage() -> PersistentStorage {
     FrontendStorage::default().expect("no system errors")

--- a/src/storage/src/frontend/tests/queries/delete.rs
+++ b/src/storage/src/frontend/tests/queries/delete.rs
@@ -60,7 +60,7 @@ fn delete_all_from_table(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -68,7 +68,7 @@ fn delete_all_from_table(mut storage: PersistentStorage) {
             .select_all_from("schema_name", "table_name", table_columns)
             .expect("no system errors"),
         Ok((
-            vec![("column_test".to_owned(), SqlType::SmallInt(i16::min_value()))],
+            vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
             vec![]
         ))
     );

--- a/src/storage/src/frontend/tests/queries/insert.rs
+++ b/src/storage/src/frontend/tests/queries/insert.rs
@@ -53,7 +53,7 @@ fn insert_many_rows_into_table(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -61,7 +61,7 @@ fn insert_many_rows_into_table(mut storage: PersistentStorage) {
             .select_all_from("schema_name", "table_name", table_columns)
             .expect("no system errors"),
         Ok((
-            vec![("column_test".to_owned(), SqlType::SmallInt(i16::min_value()))],
+            vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
             vec![vec!["123".to_owned()], vec!["456".to_owned()]]
         ))
     );
@@ -88,7 +88,7 @@ fn insert_multiple_values_rows(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -97,9 +97,9 @@ fn insert_multiple_values_rows(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_3", SqlType::SmallInt(i16::min_value()))
             ],
             vec![
                 vec!["1".to_owned(), "2".to_owned(), "3".to_owned()],
@@ -151,7 +151,7 @@ fn insert_named_columns(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -160,9 +160,9 @@ fn insert_named_columns(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::Char(10)),
-                ("column_3".to_owned(), SqlType::BigInt(i64::min_value()))
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::Char(10)),
+                column_definition("column_3", SqlType::BigInt(i64::min_value()))
             ],
             vec![
                 vec!["3".to_owned(), "2".to_owned(), "1".to_owned()],
@@ -227,7 +227,7 @@ fn insert_row_into_table(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -235,7 +235,7 @@ fn insert_row_into_table(mut storage: PersistentStorage) {
             .select_all_from("schema_name", "table_name", table_columns)
             .expect("no system errors"),
         Ok((
-            vec![("column_test".to_owned(), SqlType::SmallInt(i16::min_value()))],
+            vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
             vec![vec!["123".to_owned()]]
         ))
     );
@@ -272,7 +272,7 @@ fn insert_too_many_expressions(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -281,9 +281,9 @@ fn insert_too_many_expressions(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::Char(10)),
-                ("column_3".to_owned(), SqlType::BigInt(i64::min_value())),
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::Char(10)),
+                column_definition("column_3", SqlType::BigInt(i64::min_value())),
             ],
             vec![]
         ))
@@ -321,7 +321,7 @@ fn insert_too_many_expressions_labeled(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -330,9 +330,9 @@ fn insert_too_many_expressions_labeled(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::Char(10)),
-                ("column_3".to_owned(), SqlType::BigInt(i64::min_value())),
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::Char(10)),
+                column_definition("column_3", SqlType::BigInt(i64::min_value())),
             ],
             vec![]
         ))
@@ -383,8 +383,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::OutOfRange,
-                "column_si".to_owned(),
-                SqlType::SmallInt(i16::min_value())
+                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
             )]))
         );
     }
@@ -402,8 +401,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::TypeMismatch("abc".to_owned()),
-                "column_si".to_owned(),
-                SqlType::SmallInt(i16::min_value())
+                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
             )]))
         )
     }
@@ -421,8 +419,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::ValueTooLong(10),
-                "column_c".to_owned(),
-                SqlType::Char(10)
+                column_definition("column_c", SqlType::Char(10))
             )]))
         )
     }
@@ -441,13 +438,11 @@ mod constraints {
             Err(OperationOnTableError::ConstraintViolations(vec![
                 (
                     ConstraintError::OutOfRange,
-                    "column_si".to_owned(),
-                    SqlType::SmallInt(i16::min_value())
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
                 ),
                 (
                     ConstraintError::OutOfRange,
-                    "column_i".to_owned(),
-                    SqlType::Integer(i32::min_value())
+                    column_definition("column_i", SqlType::Integer(i32::min_value()))
                 )
             ]))
         )
@@ -475,13 +470,11 @@ mod constraints {
             Err(OperationOnTableError::ConstraintViolations(vec![
                 (
                     ConstraintError::OutOfRange,
-                    "column_si".to_owned(),
-                    SqlType::SmallInt(i16::min_value())
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
                 ),
                 (
                     ConstraintError::OutOfRange,
-                    "column_i".to_owned(),
-                    SqlType::Integer(i32::min_value())
+                    column_definition("column_i", SqlType::Integer(i32::min_value()))
                 ),
             ]))
         )

--- a/src/storage/src/frontend/tests/queries/select.rs
+++ b/src/storage/src/frontend/tests/queries/select.rs
@@ -47,7 +47,7 @@ fn select_from_table_that_does_not_exist(mut storage: PersistentStorage) {
         .table_columns("schema_name", "not_existed")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -72,7 +72,7 @@ fn select_all_from_table_with_many_columns(mut with_small_ints_table: Persistent
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -81,9 +81,9 @@ fn select_all_from_table_with_many_columns(mut with_small_ints_table: Persistent
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_3", SqlType::SmallInt(i16::min_value()))
             ],
             vec![vec!["1".to_owned(), "2".to_owned(), "3".to_owned()]]
         ))
@@ -124,8 +124,8 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(mut with_small
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_3", SqlType::SmallInt(i16::min_value()))
             ],
             vec![
                 vec!["1".to_owned(), "3".to_owned()],
@@ -170,9 +170,9 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(mut with_small_
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_3", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value()))
             ],
             vec![
                 vec!["3".to_owned(), "1".to_owned(), "2".to_owned()],
@@ -223,11 +223,11 @@ fn select_with_column_name_duplication(mut with_small_ints_table: PersistentStor
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_3", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_3", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value()))
             ],
             vec![
                 vec![
@@ -301,9 +301,9 @@ fn select_different_integer_types(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("small_int".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("integer".to_owned(), SqlType::Integer(i32::min_value())),
-                ("big_int".to_owned(), SqlType::BigInt(i64::min_value())),
+                column_definition("small_int", SqlType::SmallInt(i16::min_value())),
+                column_definition("integer", SqlType::Integer(i32::min_value())),
+                column_definition("big_int", SqlType::BigInt(i64::min_value())),
             ],
             vec![
                 vec!["1000".to_owned(), "2000000".to_owned(), "3000000000".to_owned()],
@@ -355,8 +355,8 @@ fn select_different_character_strings_types(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("char_10".to_owned(), SqlType::Char(10)),
-                ("var_char_20".to_owned(), SqlType::VarChar(20)),
+                column_definition("char_10", SqlType::Char(10)),
+                column_definition("var_char_20", SqlType::VarChar(20)),
             ],
             vec![
                 vec!["1234567890".to_owned(), "12345678901234567890".to_owned()],

--- a/src/storage/src/frontend/tests/queries/update.rs
+++ b/src/storage/src/frontend/tests/queries/update.rs
@@ -43,7 +43,7 @@ fn update_all_records(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -51,7 +51,7 @@ fn update_all_records(mut storage: PersistentStorage) {
             .select_all_from("schema_name", "table_name", table_columns)
             .expect("no system errors"),
         Ok((
-            vec![("column_test".to_owned(), SqlType::SmallInt(i16::min_value()))],
+            vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
             vec![vec!["567".to_owned()], vec!["567".to_owned()], vec!["567".to_owned()]]
         ))
     );
@@ -135,8 +135,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::OutOfRange,
-                "column_si".to_owned(),
-                SqlType::SmallInt(i16::min_value())
+                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
             )]))
         );
     }
@@ -166,8 +165,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::TypeMismatch("abc".to_owned()),
-                "column_si".to_owned(),
-                SqlType::SmallInt(i16::min_value())
+                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
             )]))
         );
     }
@@ -196,8 +194,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::ValueTooLong(10),
-                "column_c".to_owned(),
-                SqlType::Char(10)
+                column_definition("column_c", SqlType::Char(10))
             )]))
         );
     }
@@ -229,13 +226,11 @@ mod constraints {
             Err(OperationOnTableError::ConstraintViolations(vec![
                 (
                     ConstraintError::OutOfRange,
-                    "column_si".to_owned(),
-                    SqlType::SmallInt(i16::min_value())
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
                 ),
                 (
                     ConstraintError::OutOfRange,
-                    "column_i".to_owned(),
-                    SqlType::Integer(i32::min_value())
+                    column_definition("column_i", SqlType::Integer(i32::min_value()))
                 )
             ]))
         )

--- a/src/storage/src/frontend/tests/schema.rs
+++ b/src/storage/src/frontend/tests/schema.rs
@@ -53,13 +53,13 @@ fn same_table_names_with_different_columns_in_different_schemas(mut storage: Per
         storage
             .table_columns("schema_name_1", "table_name")
             .expect("no system errors"),
-        vec![("sn_1_column".to_owned(), SqlType::SmallInt(i16::min_value()))]
+        vec![column_definition("sn_1_column", SqlType::SmallInt(i16::min_value()))]
     );
     assert_eq!(
         storage
             .table_columns("schema_name_2", "table_name")
             .expect("no system errors"),
-        vec![("sn_2_column".to_owned(), SqlType::BigInt(i64::min_value()))]
+        vec![column_definition("sn_2_column", SqlType::BigInt(i64::min_value()))]
     );
 }
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -16,12 +16,13 @@ extern crate kernel;
 extern crate log;
 extern crate sql_types;
 
+use serde::{Deserialize, Serialize};
 use sql_types::{ConstraintError, SqlType};
 
 pub mod backend;
 pub mod frontend;
 
-pub type Projection = (Vec<(String, sql_types::SqlType)>, Vec<Vec<String>>);
+pub type Projection = (Vec<ColumnDefinition>, Vec<Vec<String>>);
 
 #[derive(Debug, PartialEq)]
 pub struct SchemaAlreadyExists;
@@ -47,5 +48,25 @@ pub enum OperationOnTableError {
     InsertTooManyExpressions,
     // Returns non existing columns.
     ColumnDoesNotExist(Vec<String>),
-    ConstraintViolations(Vec<(ConstraintError, String, SqlType)>),
+    ConstraintViolations(Vec<(ConstraintError, ColumnDefinition)>),
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct ColumnDefinition {
+    name: String,
+    sql_type: SqlType,
+}
+
+impl ColumnDefinition {
+    pub fn sql_type(&self) -> SqlType {
+        self.sql_type
+    }
+
+    fn has_name(&self, other_name: &str) -> bool {
+        self.name == other_name
+    }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
 }

--- a/tests/functional/basic_queries_tests.py
+++ b/tests/functional/basic_queries_tests.py
@@ -16,18 +16,17 @@ import psycopg2 as pg
 import pytest
 
 from psycopg2.errors import DuplicateSchema, DuplicateTable
+from psycopg2._psycopg import connection, cursor
 
 
 @pytest.fixture(scope="session", autouse=True)
-def create_cursor(request):
-    cur = None
-    conn = None
+def create_cursor(request) -> cursor:
 
     conn = pg.connect(host="localhost", password="check_this_out", database="postgres")
-    assert conn is not None
+    assert isinstance(conn, connection), "Failed to connect to DB"
 
     cur = conn.cursor()
-    assert cur is not None
+    assert isinstance(cur, cursor)
 
     def close_all():
         cur.close()
@@ -39,7 +38,7 @@ def create_cursor(request):
 
 
 @pytest.fixture(scope='function')
-def create_drop_test_schema_fixture(request, create_cursor):
+def create_drop_test_schema_fixture(request, create_cursor) -> cursor:
     cur = create_cursor
     cur.execute('create schema schema_name;')
 
@@ -50,32 +49,32 @@ def create_drop_test_schema_fixture(request, create_cursor):
     return cur
 
 
-def test_create_duplicate_schema(create_drop_test_schema_fixture):
+def test_create_duplicate_schema(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     with pytest.raises(DuplicateSchema):  # Expects for DuplicateSchema exception
         cur.execute('create schema schema_name;')
 
 
-def test_create_drop_schema(create_drop_test_schema_fixture):
+def test_create_drop_schema(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create schema schema_name_new;')
     cur.execute('drop schema schema_name_new;')
 
 
-def test_create_drop_empty_table(create_drop_test_schema_fixture):
+def test_create_drop_empty_table(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.empty_table();')
     cur.execute('drop table schema_name.empty_table;')
 
 
-def test_create_duplicated_table(create_drop_test_schema_fixture):
+def test_create_duplicated_table(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     with pytest.raises(DuplicateTable):  # Expects for DuplicateTable exception
         cur.execute('create table schema_name.empty_table();')
         cur.execute('create table schema_name.empty_table();')
 
 
-def test_insert_select(create_cursor, create_drop_test_schema_fixture):
+def test_insert_select(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_column smallint);')
 
@@ -86,7 +85,7 @@ def test_insert_select(create_cursor, create_drop_test_schema_fixture):
     assert r == (1,), "fetched unexpected value"
 
 
-def test_insert_select_many(create_drop_test_schema_fixture):
+def test_insert_select_many(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_column smallint);')
 
@@ -97,7 +96,7 @@ def test_insert_select_many(create_drop_test_schema_fixture):
     assert r == [(1,), (2,), (3,)]
 
 
-def test_insert_select_update_all_select(create_drop_test_schema_fixture):
+def test_insert_select_update_all_select(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_column smallint);')
 
@@ -113,7 +112,7 @@ def test_insert_select_update_all_select(create_drop_test_schema_fixture):
     assert r == [(4,), (4,), (4,)]
 
 
-def test_insert_select_delete_all_select(create_drop_test_schema_fixture):
+def test_insert_select_delete_all_select(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_column smallint);')
 
@@ -129,24 +128,24 @@ def test_insert_select_delete_all_select(create_drop_test_schema_fixture):
     assert r == []
 
 
-def test_insert_select_many_columns(create_drop_test_schema_fixture):
+def test_insert_select_many_columns(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_column_1 smallint, si_column_2 smallint, si_column_3 smallint);')
 
-    for t in [(1, 2, 3), (4, 5, 6), (7, 8, 9)]:
-        cur.execute('insert into schema_name.table_name values (%s, %s, %s);' % t)
+    cur.executemany('insert into schema_name.table_name values (%s, %s, %s);',
+                    [(1, 2, 3), (4, 5, 6), (7, 8, 9)])
 
     cur.execute('select * from schema_name.table_name;')
     r = cur.fetchmany(3)
     assert r == [(1, 2, 3,), (4, 5, 6,), (7, 8, 9,)]
 
 
-def test_insert_update_specified_column(create_drop_test_schema_fixture):
+def test_insert_update_specified_column(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_column_1 smallint, si_column_2 smallint, si_column_3 smallint);')
 
-    for t in [(1, 2, 3), (4, 5, 6), (7, 8, 9)]:
-        cur.execute('insert into schema_name.table_name values (%s, %s, %s);' % t)
+    cur.executemany('insert into schema_name.table_name values (%s, %s, %s);',
+                    [(1, 2, 3), (4, 5, 6), (7, 8, 9)])
 
     cur.execute('select * from schema_name.table_name;')
     r = cur.fetchmany(3)
@@ -158,36 +157,36 @@ def test_insert_update_specified_column(create_drop_test_schema_fixture):
     assert r == [(1, 10, 3,), (4, 10, 6,), (7, 10, 9,)]
 
 
-def test_insert_select_reordered(create_drop_test_schema_fixture):
+def test_insert_select_reordered(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_column_1 smallint, si_column_2 smallint, si_column_3 smallint);')
 
-    for t in [(1, 2, 3), (4, 5, 6), (7, 8, 9)]:
-        cur.execute('insert into schema_name.table_name values (%s, %s, %s);' % t)
+    cur.executemany('insert into schema_name.table_name values (%s, %s, %s);',
+                [(1, 2, 3), (4, 5, 6), (7, 8, 9)])
 
     cur.execute('select si_column_3, si_column_1, si_column_2 from schema_name.table_name;')
     r = cur.fetchmany(3)
     assert r == [(3, 1, 2,), (6, 4, 5,), (9, 7, 8,)]
 
 
-def test_insert_select_same_column_many_times(create_drop_test_schema_fixture):
+def test_insert_select_same_column_many_times(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_column_1 smallint, si_column_2 smallint, si_column_3 smallint);')
 
-    for t in [(1, 2, 3), (4, 5, 6), (7, 8, 9)]:
-        cur.execute('insert into schema_name.table_name values (%s, %s, %s);' % t)
+    cur.executemany('insert into schema_name.table_name values (%s, %s, %s);',
+                [(1, 2, 3), (4, 5, 6), (7, 8, 9)])
 
     cur.execute('select si_column_3, si_column_1, si_column_2, si_column_1, si_column_3 from schema_name.table_name;')
     r = cur.fetchmany(3)
     assert r == [(3, 1, 2, 1, 3), (6, 4, 5, 4, 6,), (9, 7, 8, 7, 9,)]
 
 
-def test_insert_with_named_columns(create_drop_test_schema_fixture):
+def test_insert_with_named_columns(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_column_1 smallint, si_column_2 smallint, si_column_3 smallint);')
 
-    for t in [(1, 2, 3), (4, 5, 6), (7, 8, 9)]:
-        cur.execute('insert into schema_name.table_name (si_column_2, si_column_3, si_column_1) values (%s, %s, %s);' % t)
+    cur.executemany('insert into schema_name.table_name (si_column_2, si_column_3, si_column_1) values (%s, %s, %s);',
+                [(1, 2, 3), (4, 5, 6), (7, 8, 9)])
 
     cur.execute('select * from schema_name.table_name;')
     r = cur.fetchmany(3)

--- a/tests/functional/queries_with_sql_types.py
+++ b/tests/functional/queries_with_sql_types.py
@@ -12,20 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import psycopg2 as pg
 import pytest
+
+from psycopg2._psycopg import connection, cursor
+from psycopg2 import connect
+
+# all imports from errors are OK if you can find such exception class in docs
+# >>> https://www.psycopg.org/docs/errors.html
+from psycopg2.errors import NumericValueOutOfRange
 
 
 @pytest.fixture(scope="session", autouse=True)
-def create_cursor(request):
-    cur = None
-    conn = None
+def create_cursor(request) -> cursor:
 
-    conn = pg.connect(host="localhost", password="check_this_out", database="postgres")
-    assert conn is not None
+    conn = connect(host="localhost", password="check_this_out", database="postgres")
+    assert isinstance(conn, connection), "Failed to connect to DB"
 
     cur = conn.cursor()
-    assert cur is not None
+    assert isinstance(cur, cursor)
 
     def close_all():
         cur.close()
@@ -37,7 +41,7 @@ def create_cursor(request):
 
 
 @pytest.fixture(scope='function')
-def create_drop_test_schema_fixture(request, create_cursor):
+def create_drop_test_schema_fixture(request, create_cursor) -> cursor:
     cur = create_cursor
     cur.execute('create schema schema_name;')
 
@@ -48,130 +52,123 @@ def create_drop_test_schema_fixture(request, create_cursor):
     return cur
 
 
-def test_integer_types(create_drop_test_schema_fixture):
+def test_integer_types(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_col smallint, i_col integer, bi_col bigint);')
 
-    cur.execute('insert into schema_name.table_name values (%d, %d, %d);' % (-32768, -2147483648, -9223372036854775808))
-    cur.execute('insert into schema_name.table_name values (%d, %d, %d);' % (32767, 2147483647, 9223372036854775807))
+    args = [(-32768, -2147483648, -9223372036854775808),
+            (32767, 2147483647, 9223372036854775807)]
+    cur.executemany('insert into schema_name.table_name values (%s, %s, %s)', args)
 
     cur.execute('select * from schema_name.table_name;')
     r = cur.fetchmany(2)
     assert r == [(-32768, -2147483648, -9223372036854775808,), (32767, 2147483647, 9223372036854775807,)]
 
 
-def test_character_types(create_drop_test_schema_fixture):
+def test_character_types(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute(
-        'create table schema_name.table_name(\
-            col_no_len_chars char,\
-            col_with_len_chars char(10),\
-            col_var_char_smallest varchar(1),\
-            col_var_char_large    varchar(20)\
-            );')
-
-    cur.execute(
-        'insert into schema_name.table_name values (\'%s\', \'%s\', \'%s\', \'%s\');' % ('c', '1234567890', 'c', '12345678901234567890'))
-    cur.execute(
-        'insert into schema_name.table_name values (\'%s\', \'%s\', \'%s\', \'%s\');' % ('1', '1234567   ', 'c', '1234567890'))
+        '''create table schema_name.table_name(
+            col_no_len_chars char,
+            col_with_len_chars char(10),
+            col_var_char_smallest varchar(1),
+            col_var_char_large    varchar(20)
+            );''')
+    args = [('c', '1234567890', 'c', '12345678901234567890'),
+            ('1', '1234567   ', 'c', '1234567890')]
+    query = 'insert into schema_name.table_name values (%s, %s, %s, %s);'
+    cur.executemany(query, args)
 
     cur.execute('select * from schema_name.table_name;')
     r = cur.fetchmany(2)
     assert r == [('c', '1234567890', 'c', '12345678901234567890',), ('1', '1234567', 'c', '1234567890',)]
 
 
-def test_boolean_types(create_cursor):
+def test_boolean_types(create_drop_test_schema_fixture):
     import random
-    cur = create_cursor
-    try:
-        cur.execute('create schema schema_name;');
-        cur.execute(
-            'CREATE TABLE schema_name.table_name('
-            '   col boolean'
-            ');'
-        )
+    cur = create_drop_test_schema_fixture
 
-        word_to_value = {
-            "TRUE": True,
-            "FALSE": False,
-            "'true'": True,
-            "'false'": False,
-            "'t'": True,
-            "'f'": False,
-            "'yes'": True,
-            "'no'": False,
-            "'y'": True,
-            "'n'": False,
-            "'on'": True,
-            "'off'": False,
-            "'1'": True,
-            "'0'": False,
-            "TRUE::boolean": True,
-            "FALSE::boolean": False,
-            "'yes'::boolean": True,
-            "'no'::boolean": False,
-        }
+    cur.execute(
+        'CREATE TABLE schema_name.table_name('
+        '   col boolean'
+        ');'
+    )
 
-        for (w, outcome) in word_to_value.items():
-            # it should work regardless of case so we randomly generate
-            # a string, which have both upper and lower case letters
-            random_case_w = "".join(random.choice([k.upper(), k]) for k in w)
-            cur.execute('INSERT INTO schema_name.table_name VALUES(%s);' % random_case_w)
-            cur.execute('SELECT * FROM schema_name.table_name;')
-            r = cur.fetchmany(1)
-            assert r == [(outcome, )], "Failed for value: %s" % random_case_w
-            cur.execute('DELETE FROM schema_name.table_name;')
+    word_to_value = {
+        "TRUE": True,
+        "FALSE": False,
+        "'true'": True,
+        "'false'": False,
+        "'t'": True,
+        "'f'": False,
+        "'yes'": True,
+        "'no'": False,
+        "'y'": True,
+        "'n'": False,
+        "'on'": True,
+        "'off'": False,
+        "'1'": True,
+        "'0'": False,
+        "TRUE::boolean": True,
+        "FALSE::boolean": False,
+        "'yes'::boolean": True,
+        "'no'::boolean": False,
+    }
 
-    finally:
-        cur.execute('drop table schema_name.table_name;')
-        cur.execute('drop schema schema_name;')
+    for (w, outcome) in word_to_value.items():
+        # it should work regardless of case so we randomly generate
+        # a string, which have both upper and lower case letters
+        random_case_w = "".join(random.choice([k.upper(), k]) for k in w)
+        cur.execute('INSERT INTO schema_name.table_name VALUES(%s);' % random_case_w)
+        cur.execute('SELECT * FROM schema_name.table_name;')
+        r = cur.fetchmany(1)
+        assert r == [(outcome, )], "Failed for value: %s" % random_case_w
+        cur.execute('DELETE FROM schema_name.table_name;')
 
 
-def test_numeric_constraint_violations(create_drop_test_schema_fixture):
+def test_numeric_constraint_violations(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_col smallint, i_col integer, bi_col bigint);')
-    cur.execute('insert into schema_name.table_name values (%d, %d, %d);' % (-32768, -2147483648, -9223372036854775808))
-    cur.execute('insert into schema_name.table_name values (%d, %d, %d);' % (32767, 2147483647, 9223372036854775807))
+    args = [(-32768, -2147483648, -9223372036854775808),
+            (32767, 2147483647, 9223372036854775807)]
+    cur.executemany('insert into schema_name.table_name values (%s, %s, %s)', args)
 
-    try:
-        cur.execute('insert into schema_name.table_name values (%d, %d, %d);' % (32767, 2147483647, 9223372036854775809))
-    except pg.errors.NumericValueOutOfRange as e:
-        assert e.pgcode == '22003'
-        # assert e.pgerror == "ERROR: bigint out of range"
-    except pg.Error:
-        assert False
+    # await for NumericValueOutOfRange, will throw an error on different exception
+    with pytest.raises(NumericValueOutOfRange) as e:
+        cur.execute('insert into schema_name.table_name values (%d, %d, %d);' %
+                    (32767, 2147483647, 9223372036854775809))
+    assert e.value.pgcode == '22003'  # check for specific exception code
 
     cur.execute('select * from schema_name.table_name;')
     r = cur.fetchall()
     assert r == [(-32768, -2147483648, -9223372036854775808,), (32767, 2147483647, 9223372036854775807,)]
 
 
-def test_many_numeric_constraint_violations(create_drop_test_schema_fixture):
+def test_many_numeric_constraint_violations(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_col smallint, i_col integer, bi_col bigint);')
-    cur.execute('insert into schema_name.table_name values (%d, %d, %d);' % (-32768, -2147483648, -9223372036854775808))
-    cur.execute('insert into schema_name.table_name values (%d, %d, %d);' % (32767, 2147483647, 9223372036854775807))
+    args = [(-32768, -2147483648, -9223372036854775808),
+            (32767, 2147483647, 9223372036854775807)]
+    cur.executemany('insert into schema_name.table_name values (%s, %s, %s)', args)
 
-    try:
-        cur.execute('insert into schema_name.table_name values (%d, %d, %d);' % (33767, 2147483647, 9223372036854775809))
-    except pg.errors.NumericValueOutOfRange as e:
-        #  This is generating two error messages but it seems it this script only sees the first one.
-        assert e.pgcode == '22003'
-    except pg.Error:
-        assert False
+    # await for NumericValueOutOfRange, will throw an error on different exception
+    with pytest.raises(NumericValueOutOfRange) as e:
+        cur.execute('insert into schema_name.table_name values (%d, %d, %d);' %
+                    (33767, 2147483647, 9223372036854775809))
+    assert e.value.pgcode == '22003'  # check for specific exception code
 
     cur.execute('select * from schema_name.table_name;')
     r = cur.fetchall()
     assert r == [(-32768, -2147483648, -9223372036854775808,), (32767, 2147483647, 9223372036854775807,)]
 
 
-def test_math_operations_in_insert(create_drop_test_schema_fixture):
+def test_math_operations_in_insert(create_drop_test_schema_fixture: cursor):
     cur = create_drop_test_schema_fixture
     cur.execute('create table schema_name.table_name(si_col smallint);')
-    cur.execute('insert into schema_name.table_name values (%d + %d);' % (3, 5))
-    cur.execute('insert into schema_name.table_name values (%d - %d);' % (3, 5))
-    cur.execute('insert into schema_name.table_name values (%d * %d);' % (3, 5))
-    cur.execute('insert into schema_name.table_name values (%d / %d);' % (15, 5))
+    query = 'insert into schema_name.table_name values (%d %s %d)'
+    args = [(3, '+', 5), (3, '-', 5), (3, '*', 5), (15, '/', 5)]
+    for arg in args:
+        cur.execute(query % arg)
 
     cur.execute('select * from schema_name.table_name;')
     r = cur.fetchall()


### PR DESCRIPTION
Closes #150 

#### Description
Restructured QueryError and introduced new types:
-  QueryErrorBuilder: a helper for building errors.
- QueryErrorInner: Represents the actual error that occurred.

I think there are some things I should point out that I particularly want comments one.
- How the QueryErrorBuilder is used in the dml and ddl. Do you think this is a good way to use it? For another way it can be used, look at the test code. I wrote a helper function `QueryErrorBuilder::build_with` that can be used to construct a QueryError in one line.

#### Client output
Nothing changed. This was an internal restructure.

Thank you.