### PR TITLE
added column definition struct

### DIFF
--- a/src/sql_engine/src/dml/update.rs
+++ b/src/sql_engine/src/dml/update.rs
@@ -14,10 +14,10 @@
 
 use kernel::SystemResult;
 use protocol::results::{ConstraintViolation, QueryError, QueryEvent, QueryResult};
-use sql_types::{ConstraintError, SqlType};
+use sql_types::ConstraintError;
 use sqlparser::ast::{Assignment, Expr, Ident, ObjectName, UnaryOperator, Value};
 use std::sync::{Arc, Mutex};
-use storage::{backend::BackendStorage, frontend::FrontendStorage, OperationOnTableError};
+use storage::{backend::BackendStorage, frontend::FrontendStorage, ColumnDefinition, OperationOnTableError};
 
 pub(crate) struct UpdateCommand<'q, P: BackendStorage> {
     raw_sql_query: &'q str,
@@ -79,7 +79,8 @@ impl<P: BackendStorage> UpdateCommand<'_, P> {
             }
             Err(OperationOnTableError::ConstraintViolations(constraint_errors)) => {
                 let constraint_error_mapper =
-                    |(err, _, sql_type): &(ConstraintError, String, SqlType)| -> ConstraintViolation {
+                    |(err, column_definition): &(ConstraintError, ColumnDefinition)| -> ConstraintViolation {
+                        let sql_type = column_definition.sql_type();
                         match err {
                             ConstraintError::OutOfRange => ConstraintViolation::out_of_range(sql_type.to_pg_types()),
                             ConstraintError::TypeMismatch(value) => {

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -26,6 +26,21 @@ fn insert_into_nonexistent_table(mut sql_engine_with_schema: InMemorySqlEngine) 
 }
 
 #[rstest::rstest]
+fn insert_value_in_non_existent_column(mut sql_engine_with_schema: InMemorySqlEngine) {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name (column_test smallint);")
+        .expect("no system errors")
+        .expect("table created");
+
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("insert into schema_name.table_name (non_existent) values (123);")
+            .expect("no system errors"),
+        Err(QueryError::column_does_not_exist(vec!["non_existent".to_owned()]))
+    );
+}
+
+#[rstest::rstest]
 fn insert_and_select_single_row(mut sql_engine_with_schema: InMemorySqlEngine) {
     sql_engine_with_schema
         .execute("create table schema_name.table_name (column_test smallint);")

--- a/src/sql_engine/src/tests/mod.rs
+++ b/src/sql_engine/src/tests/mod.rs
@@ -23,6 +23,8 @@ mod select;
 #[cfg(test)]
 mod table;
 #[cfg(test)]
+mod type_constraints;
+#[cfg(test)]
 mod update;
 
 use super::*;

--- a/src/sql_engine/src/tests/schema.rs
+++ b/src/sql_engine/src/tests/schema.rs
@@ -15,6 +15,46 @@
 use super::*;
 
 #[rstest::rstest]
+fn create_same_schema(mut sql_engine: InMemorySqlEngine) {
+    sql_engine
+        .execute("create schema schema_name;")
+        .expect("no system errors")
+        .expect("schema created");
+
+    assert_eq!(
+        sql_engine
+            .execute("create schema schema_name;")
+            .expect("no system errors"),
+        Err(QueryError::schema_already_exists("schema_name".to_owned()))
+    )
+}
+
+#[rstest::rstest]
+fn drop_schema(mut sql_engine: InMemorySqlEngine) {
+    sql_engine
+        .execute("create schema schema_name;")
+        .expect("no system errors")
+        .expect("schema created");
+
+    assert_eq!(
+        sql_engine
+            .execute("drop schema schema_name;")
+            .expect("no system errors"),
+        Ok(QueryEvent::SchemaDropped)
+    )
+}
+
+#[rstest::rstest]
+fn drop_non_existent_schema(mut sql_engine: InMemorySqlEngine) {
+    assert_eq!(
+        sql_engine
+            .execute("drop schema non_existent;")
+            .expect("no system errors"),
+        Err(QueryError::schema_does_not_exist("non_existent".to_owned()))
+    )
+}
+
+#[rstest::rstest]
 fn select_from_nonexistent_schema(mut sql_engine: InMemorySqlEngine) {
     assert_eq!(
         sql_engine

--- a/src/sql_engine/src/tests/table.rs
+++ b/src/sql_engine/src/tests/table.rs
@@ -50,6 +50,20 @@ fn create_table(mut sql_engine_with_schema: InMemorySqlEngine) {
 }
 
 #[rstest::rstest]
+fn create_same_table(mut sql_engine_with_schema: InMemorySqlEngine) {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name (column_name smallint);")
+        .expect("no system errors")
+        .expect("table created");
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("create table schema_name.table_name (column_name smallint);")
+            .expect("no system errors"),
+        Err(QueryError::table_already_exists("schema_name.table_name".to_owned()))
+    );
+}
+
+#[rstest::rstest]
 fn drop_table(mut sql_engine_with_schema: InMemorySqlEngine) {
     sql_engine_with_schema
         .execute("create table schema_name.table_name (column_name smallint);")
@@ -89,7 +103,19 @@ fn create_table_with_different_types(mut sql_engine: InMemorySqlEngine) {
 
     assert_eq!(
         sql_engine
-            .execute("create table schema_name.table_name (column_si smallint, column_i integer, column_bi bigint, column_c char(10), column_vc varchar(10));")
+            .execute(
+                "create table schema_name.table_name (\
+            column_si smallint,\
+            column_i integer,\
+            column_bi bigint,\
+            column_c char(10),\
+            column_vc varchar(10),\
+            column_b boolean,\
+            column_smalls smallserial,\
+            column_s serial,\
+            column_bigs bigserial\
+            );"
+            )
             .expect("no system errors"),
         Ok(QueryEvent::TableCreated)
     )

--- a/src/sql_engine/src/tests/table.rs
+++ b/src/sql_engine/src/tests/table.rs
@@ -94,29 +94,68 @@ fn drop_non_existent_table(mut sql_engine_with_schema: InMemorySqlEngine) {
     );
 }
 
-#[rstest::rstest]
-fn create_table_with_different_types(mut sql_engine: InMemorySqlEngine) {
-    sql_engine
-        .execute("create schema schema_name;")
-        .expect("no system errors")
-        .expect("schema created");
+#[cfg(test)]
+mod different_types {
+    use super::*;
 
-    assert_eq!(
-        sql_engine
-            .execute(
-                "create table schema_name.table_name (\
+    #[rstest::rstest]
+    fn ints(mut sql_engine_with_schema: InMemorySqlEngine) {
+        assert_eq!(
+            sql_engine_with_schema
+                .execute(
+                    "create table schema_name.table_name (\
             column_si smallint,\
             column_i integer,\
-            column_bi bigint,\
+            column_bi bigint
+            );"
+                )
+                .expect("no system errors"),
+            Ok(QueryEvent::TableCreated)
+        )
+    }
+
+    #[rstest::rstest]
+    fn strings(mut sql_engine_with_schema: InMemorySqlEngine) {
+        assert_eq!(
+            sql_engine_with_schema
+                .execute(
+                    "create table schema_name.table_name (\
             column_c char(10),\
-            column_vc varchar(10),\
-            column_b boolean,\
+            column_vc varchar(10)\
+            );"
+                )
+                .expect("no system errors"),
+            Ok(QueryEvent::TableCreated)
+        )
+    }
+
+    #[rstest::rstest]
+    fn boolean(mut sql_engine_with_schema: InMemorySqlEngine) {
+        assert_eq!(
+            sql_engine_with_schema
+                .execute(
+                    "create table schema_name.table_name (\
+            column_b boolean\
+            );"
+                )
+                .expect("no system errors"),
+            Ok(QueryEvent::TableCreated)
+        )
+    }
+
+    #[rstest::rstest]
+    fn serials(mut sql_engine_with_schema: InMemorySqlEngine) {
+        assert_eq!(
+            sql_engine_with_schema
+                .execute(
+                    "create table schema_name.table_name (\
             column_smalls smallserial,\
             column_s serial,\
             column_bigs bigserial\
             );"
-            )
-            .expect("no system errors"),
-        Ok(QueryEvent::TableCreated)
-    )
+                )
+                .expect("no system errors"),
+            Ok(QueryEvent::TableCreated)
+        )
+    }
 }

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -1,0 +1,133 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use protocol::{results::ConstraintViolation, sql_types::PostgreSqlType};
+
+#[rstest::fixture]
+fn int_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name(col smallint);")
+        .expect("no system errors")
+        .expect("table created");
+
+    sql_engine_with_schema
+}
+
+#[rstest::fixture]
+fn str_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name(col varchar(5));")
+        .expect("no system errors")
+        .expect("table created");
+
+    sql_engine_with_schema
+}
+
+#[cfg(test)]
+mod insert {
+    use super::*;
+
+    #[rstest::rstest]
+    fn out_of_range(mut int_table: InMemorySqlEngine) {
+        assert_eq!(
+            int_table
+                .execute("insert into schema_name.table_name values (32768);")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::out_of_range(PostgreSqlType::SmallInt)
+            ]))
+        );
+    }
+
+    #[rstest::rstest]
+    fn type_mismatch(mut int_table: InMemorySqlEngine) {
+        assert_eq!(
+            int_table
+                .execute("insert into schema_name.table_name values ('str');")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::type_mismatch("str", PostgreSqlType::SmallInt)
+            ]))
+        )
+    }
+
+    #[rstest::rstest]
+    fn value_too_long(mut str_table: InMemorySqlEngine) {
+        assert_eq!(
+            str_table
+                .execute("insert into schema_name.table_name values ('123457890');")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::string_length_mismatch(PostgreSqlType::VarChar, 5)
+            ]))
+        )
+    }
+}
+
+#[cfg(test)]
+mod update {
+    use super::*;
+
+    #[rstest::rstest]
+    fn out_of_range(mut int_table: InMemorySqlEngine) {
+        int_table
+            .execute("insert into schema_name.table_name values (32767);")
+            .expect("no system errors")
+            .expect("record inserted");
+
+        assert_eq!(
+            int_table
+                .execute("update schema_name.table_name set col = 32768;")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::out_of_range(PostgreSqlType::SmallInt)
+            ]))
+        );
+    }
+
+    #[rstest::rstest]
+    fn type_mismatch(mut int_table: InMemorySqlEngine) {
+        int_table
+            .execute("insert into schema_name.table_name values (32767);")
+            .expect("no system errors")
+            .expect("record inserted");
+
+        assert_eq!(
+            int_table
+                .execute("update schema_name.table_name set col = 'str';")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::type_mismatch("str", PostgreSqlType::SmallInt)
+            ]))
+        )
+    }
+
+    #[rstest::rstest]
+    fn value_too_long(mut str_table: InMemorySqlEngine) {
+        str_table
+            .execute("insert into schema_name.table_name values ('str');")
+            .expect("no system errors")
+            .expect("record inserted");
+
+        assert_eq!(
+            str_table
+                .execute("update schema_name.table_name set col = '123457890';")
+                .expect("no system errors"),
+            Err(QueryError::constraint_violations(vec![
+                ConstraintViolation::string_length_mismatch(PostgreSqlType::VarChar, 5)
+            ]))
+        )
+    }
+}

--- a/src/sql_types/src/lib.rs
+++ b/src/sql_types/src/lib.rs
@@ -474,6 +474,13 @@ mod tests {
                         Err(ConstraintError::TypeMismatch("str".to_owned()))
                     )
                 }
+
+                #[test]
+                fn min_bound() {
+                    let constraint = SqlType::SmallInt(0).constraint();
+
+                    assert_eq!(constraint.validate("-1"), Err(ConstraintError::OutOfRange))
+                }
             }
         }
 
@@ -541,6 +548,13 @@ mod tests {
                         constraint.validate("str"),
                         Err(ConstraintError::TypeMismatch("str".to_owned()))
                     )
+                }
+
+                #[test]
+                fn min_bound() {
+                    let constraint = SqlType::Integer(0).constraint();
+
+                    assert_eq!(constraint.validate("-1"), Err(ConstraintError::OutOfRange))
                 }
             }
         }
@@ -615,6 +629,13 @@ mod tests {
                         constraint.validate("str"),
                         Err(ConstraintError::TypeMismatch("str".to_owned()))
                     )
+                }
+
+                #[test]
+                fn min_bound() {
+                    let constraint = SqlType::BigInt(0).constraint();
+
+                    assert_eq!(constraint.validate("-1"), Err(ConstraintError::OutOfRange))
                 }
             }
         }

--- a/src/storage/src/frontend/tests/mod.rs
+++ b/src/storage/src/frontend/tests/mod.rs
@@ -23,6 +23,13 @@ mod table;
 
 type PersistentStorage = FrontendStorage<SledBackendStorage>;
 
+fn column_definition(name: &'static str, sql_type: SqlType) -> ColumnDefinition {
+    ColumnDefinition {
+        name: name.to_owned(),
+        sql_type,
+    }
+}
+
 #[rstest::fixture]
 fn storage() -> PersistentStorage {
     FrontendStorage::default().expect("no system errors")

--- a/src/storage/src/frontend/tests/queries/delete.rs
+++ b/src/storage/src/frontend/tests/queries/delete.rs
@@ -60,7 +60,7 @@ fn delete_all_from_table(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -68,7 +68,7 @@ fn delete_all_from_table(mut storage: PersistentStorage) {
             .select_all_from("schema_name", "table_name", table_columns)
             .expect("no system errors"),
         Ok((
-            vec![("column_test".to_owned(), SqlType::SmallInt(i16::min_value()))],
+            vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
             vec![]
         ))
     );

--- a/src/storage/src/frontend/tests/queries/insert.rs
+++ b/src/storage/src/frontend/tests/queries/insert.rs
@@ -53,7 +53,7 @@ fn insert_many_rows_into_table(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -61,7 +61,7 @@ fn insert_many_rows_into_table(mut storage: PersistentStorage) {
             .select_all_from("schema_name", "table_name", table_columns)
             .expect("no system errors"),
         Ok((
-            vec![("column_test".to_owned(), SqlType::SmallInt(i16::min_value()))],
+            vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
             vec![vec!["123".to_owned()], vec!["456".to_owned()]]
         ))
     );
@@ -88,7 +88,7 @@ fn insert_multiple_values_rows(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -97,9 +97,9 @@ fn insert_multiple_values_rows(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_3", SqlType::SmallInt(i16::min_value()))
             ],
             vec![
                 vec!["1".to_owned(), "2".to_owned(), "3".to_owned()],
@@ -151,7 +151,7 @@ fn insert_named_columns(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -160,9 +160,9 @@ fn insert_named_columns(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::Char(10)),
-                ("column_3".to_owned(), SqlType::BigInt(i64::min_value()))
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::Char(10)),
+                column_definition("column_3", SqlType::BigInt(i64::min_value()))
             ],
             vec![
                 vec!["3".to_owned(), "2".to_owned(), "1".to_owned()],
@@ -227,7 +227,7 @@ fn insert_row_into_table(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -235,7 +235,7 @@ fn insert_row_into_table(mut storage: PersistentStorage) {
             .select_all_from("schema_name", "table_name", table_columns)
             .expect("no system errors"),
         Ok((
-            vec![("column_test".to_owned(), SqlType::SmallInt(i16::min_value()))],
+            vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
             vec![vec!["123".to_owned()]]
         ))
     );
@@ -272,7 +272,7 @@ fn insert_too_many_expressions(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -281,9 +281,9 @@ fn insert_too_many_expressions(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::Char(10)),
-                ("column_3".to_owned(), SqlType::BigInt(i64::min_value())),
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::Char(10)),
+                column_definition("column_3", SqlType::BigInt(i64::min_value())),
             ],
             vec![]
         ))
@@ -321,7 +321,7 @@ fn insert_too_many_expressions_labeled(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -330,9 +330,9 @@ fn insert_too_many_expressions_labeled(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::Char(10)),
-                ("column_3".to_owned(), SqlType::BigInt(i64::min_value())),
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::Char(10)),
+                column_definition("column_3", SqlType::BigInt(i64::min_value())),
             ],
             vec![]
         ))
@@ -383,8 +383,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::OutOfRange,
-                "column_si".to_owned(),
-                SqlType::SmallInt(i16::min_value())
+                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
             )]))
         );
     }
@@ -402,8 +401,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::TypeMismatch("abc".to_owned()),
-                "column_si".to_owned(),
-                SqlType::SmallInt(i16::min_value())
+                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
             )]))
         )
     }
@@ -421,8 +419,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::ValueTooLong(10),
-                "column_c".to_owned(),
-                SqlType::Char(10)
+                column_definition("column_c", SqlType::Char(10))
             )]))
         )
     }
@@ -441,13 +438,11 @@ mod constraints {
             Err(OperationOnTableError::ConstraintViolations(vec![
                 (
                     ConstraintError::OutOfRange,
-                    "column_si".to_owned(),
-                    SqlType::SmallInt(i16::min_value())
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
                 ),
                 (
                     ConstraintError::OutOfRange,
-                    "column_i".to_owned(),
-                    SqlType::Integer(i32::min_value())
+                    column_definition("column_i", SqlType::Integer(i32::min_value()))
                 )
             ]))
         )
@@ -475,13 +470,11 @@ mod constraints {
             Err(OperationOnTableError::ConstraintViolations(vec![
                 (
                     ConstraintError::OutOfRange,
-                    "column_si".to_owned(),
-                    SqlType::SmallInt(i16::min_value())
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
                 ),
                 (
                     ConstraintError::OutOfRange,
-                    "column_i".to_owned(),
-                    SqlType::Integer(i32::min_value())
+                    column_definition("column_i", SqlType::Integer(i32::min_value()))
                 ),
             ]))
         )

--- a/src/storage/src/frontend/tests/queries/select.rs
+++ b/src/storage/src/frontend/tests/queries/select.rs
@@ -47,7 +47,7 @@ fn select_from_table_that_does_not_exist(mut storage: PersistentStorage) {
         .table_columns("schema_name", "not_existed")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -72,7 +72,7 @@ fn select_all_from_table_with_many_columns(mut with_small_ints_table: Persistent
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -81,9 +81,9 @@ fn select_all_from_table_with_many_columns(mut with_small_ints_table: Persistent
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_3", SqlType::SmallInt(i16::min_value()))
             ],
             vec![vec!["1".to_owned(), "2".to_owned(), "3".to_owned()]]
         ))
@@ -124,8 +124,8 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(mut with_small
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_3", SqlType::SmallInt(i16::min_value()))
             ],
             vec![
                 vec!["1".to_owned(), "3".to_owned()],
@@ -170,9 +170,9 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(mut with_small_
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_3", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value()))
             ],
             vec![
                 vec!["3".to_owned(), "1".to_owned(), "2".to_owned()],
@@ -223,11 +223,11 @@ fn select_with_column_name_duplication(mut with_small_ints_table: PersistentStor
             .expect("no system errors"),
         Ok((
             vec![
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_1".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_3".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("column_2".to_owned(), SqlType::SmallInt(i16::min_value()))
+                column_definition("column_3", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_1", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_3", SqlType::SmallInt(i16::min_value())),
+                column_definition("column_2", SqlType::SmallInt(i16::min_value()))
             ],
             vec![
                 vec![
@@ -301,9 +301,9 @@ fn select_different_integer_types(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("small_int".to_owned(), SqlType::SmallInt(i16::min_value())),
-                ("integer".to_owned(), SqlType::Integer(i32::min_value())),
-                ("big_int".to_owned(), SqlType::BigInt(i64::min_value())),
+                column_definition("small_int", SqlType::SmallInt(i16::min_value())),
+                column_definition("integer", SqlType::Integer(i32::min_value())),
+                column_definition("big_int", SqlType::BigInt(i64::min_value())),
             ],
             vec![
                 vec!["1000".to_owned(), "2000000".to_owned(), "3000000000".to_owned()],
@@ -355,8 +355,8 @@ fn select_different_character_strings_types(mut storage: PersistentStorage) {
             .expect("no system errors"),
         Ok((
             vec![
-                ("char_10".to_owned(), SqlType::Char(10)),
-                ("var_char_20".to_owned(), SqlType::VarChar(20)),
+                column_definition("char_10", SqlType::Char(10)),
+                column_definition("var_char_20", SqlType::VarChar(20)),
             ],
             vec![
                 vec!["1234567890".to_owned(), "12345678901234567890".to_owned()],

--- a/src/storage/src/frontend/tests/queries/update.rs
+++ b/src/storage/src/frontend/tests/queries/update.rs
@@ -43,7 +43,7 @@ fn update_all_records(mut storage: PersistentStorage) {
         .table_columns("schema_name", "table_name")
         .expect("no system errors")
         .into_iter()
-        .map(|(name, _sql_type)| name)
+        .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
@@ -51,7 +51,7 @@ fn update_all_records(mut storage: PersistentStorage) {
             .select_all_from("schema_name", "table_name", table_columns)
             .expect("no system errors"),
         Ok((
-            vec![("column_test".to_owned(), SqlType::SmallInt(i16::min_value()))],
+            vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
             vec![vec!["567".to_owned()], vec!["567".to_owned()], vec!["567".to_owned()]]
         ))
     );
@@ -135,8 +135,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::OutOfRange,
-                "column_si".to_owned(),
-                SqlType::SmallInt(i16::min_value())
+                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
             )]))
         );
     }
@@ -166,8 +165,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::TypeMismatch("abc".to_owned()),
-                "column_si".to_owned(),
-                SqlType::SmallInt(i16::min_value())
+                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
             )]))
         );
     }
@@ -196,8 +194,7 @@ mod constraints {
                 .expect("no system errors"),
             Err(OperationOnTableError::ConstraintViolations(vec![(
                 ConstraintError::ValueTooLong(10),
-                "column_c".to_owned(),
-                SqlType::Char(10)
+                column_definition("column_c", SqlType::Char(10))
             )]))
         );
     }
@@ -229,13 +226,11 @@ mod constraints {
             Err(OperationOnTableError::ConstraintViolations(vec![
                 (
                     ConstraintError::OutOfRange,
-                    "column_si".to_owned(),
-                    SqlType::SmallInt(i16::min_value())
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
                 ),
                 (
                     ConstraintError::OutOfRange,
-                    "column_i".to_owned(),
-                    SqlType::Integer(i32::min_value())
+                    column_definition("column_i", SqlType::Integer(i32::min_value()))
                 )
             ]))
         )

--- a/src/storage/src/frontend/tests/schema.rs
+++ b/src/storage/src/frontend/tests/schema.rs
@@ -53,13 +53,13 @@ fn same_table_names_with_different_columns_in_different_schemas(mut storage: Per
         storage
             .table_columns("schema_name_1", "table_name")
             .expect("no system errors"),
-        vec![("sn_1_column".to_owned(), SqlType::SmallInt(i16::min_value()))]
+        vec![column_definition("sn_1_column", SqlType::SmallInt(i16::min_value()))]
     );
     assert_eq!(
         storage
             .table_columns("schema_name_2", "table_name")
             .expect("no system errors"),
-        vec![("sn_2_column".to_owned(), SqlType::BigInt(i64::min_value()))]
+        vec![column_definition("sn_2_column", SqlType::BigInt(i64::min_value()))]
     );
 }
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -16,12 +16,13 @@ extern crate kernel;
 extern crate log;
 extern crate sql_types;
 
+use serde::{Deserialize, Serialize};
 use sql_types::{ConstraintError, SqlType};
 
 pub mod backend;
 pub mod frontend;
 
-pub type Projection = (Vec<(String, sql_types::SqlType)>, Vec<Vec<String>>);
+pub type Projection = (Vec<ColumnDefinition>, Vec<Vec<String>>);
 
 #[derive(Debug, PartialEq)]
 pub struct SchemaAlreadyExists;
@@ -47,5 +48,25 @@ pub enum OperationOnTableError {
     InsertTooManyExpressions,
     // Returns non existing columns.
     ColumnDoesNotExist(Vec<String>),
-    ConstraintViolations(Vec<(ConstraintError, String, SqlType)>),
+    ConstraintViolations(Vec<(ConstraintError, ColumnDefinition)>),
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct ColumnDefinition {
+    name: String,
+    sql_type: SqlType,
+}
+
+impl ColumnDefinition {
+    pub fn sql_type(&self) -> SqlType {
+        self.sql_type
+    }
+
+    fn has_name(&self, other_name: &str) -> bool {
+        self.name == other_name
+    }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
 }


### PR DESCRIPTION
Ongoing work

#### Description
PR introduces `ColumnDefinition` struct with `name` and `sql_type` to work with instead of `(String, SqlType)` tuple

#### Client output
Nothing is changed
