### PR TITLE
math expression with integers and strings concatenation evaluation in insert queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
 name = "sql_engine"
 version = "0.1.0"
 dependencies = [
+ "bigdecimal",
  "kernel",
  "log",
  "protocol",

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -447,6 +447,34 @@ mod tests {
                 )]
             )
         }
+
+        #[test]
+        fn undefined_function() {
+            assert_eq!(
+                QueryResultMapper::map(Err(QueryError::undefined_function(
+                    "||".to_owned(),
+                    "NUMBER".to_owned(),
+                    "NUMBER".to_owned()
+                ))),
+                vec![Message::ErrorResponse(
+                    Some("ERROR".to_owned()),
+                    Some("42883".to_owned()),
+                    Some("operator does not exist: (NUMBER || NUMBER)".to_owned())
+                )]
+            )
+        }
+
+        #[test]
+        fn syntax_error() {
+            assert_eq!(
+                QueryResultMapper::map(Err(QueryError::syntax_error("expression".to_owned()))),
+                vec![Message::ErrorResponse(
+                    Some("ERROR".to_owned()),
+                    Some("42601".to_owned()),
+                    Some("syntax error in expression".to_owned())
+                )]
+            )
+        }
     }
 
     #[cfg(test)]

--- a/src/protocol/src/listener.rs
+++ b/src/protocol/src/listener.rs
@@ -370,7 +370,6 @@ mod tests {
             }
 
             #[async_std::test]
-            // #[ignore]
             async fn successful_connection_handshake() -> io::Result<()> {
                 let test_case = async_io::TestCase::with_content(vec![
                     pg_frontend::Message::SslRequired.as_vec().as_slice(),

--- a/src/protocol/src/results.rs
+++ b/src/protocol/src/results.rs
@@ -319,8 +319,12 @@ impl Display for QueryErrorKind {
                 log::error!("should not use Display to generate the message for Constraint Violations");
                 write!(f, "do not use display with ConstraintViolation errors")
             }
-            Self::UndefinedFunction(_, _, _) => panic!(),
-            Self::SyntaxError(_) => panic!(),
+            Self::UndefinedFunction(operator, left_type, right_type) => write!(
+                f,
+                "operator does not exist: ({} {} {})",
+                left_type, operator, right_type
+            ),
+            Self::SyntaxError(expression) => write!(f, "syntax error in {}", expression),
         }
     }
 }

--- a/src/protocol/src/results.rs
+++ b/src/protocol/src/results.rs
@@ -159,9 +159,9 @@ pub(crate) enum QueryErrorKind {
     ColumnDoesNotExist(Vec<String>),
     NotSupportedOperation(String),
     TooManyInsertExpressions,
-
-    // type constraint errors.
     ConstraintViolations(Vec<ConstraintViolation>),
+    UndefinedFunction(String, String, String),
+    SyntaxError(String),
 }
 
 /// Represents error during query execution
@@ -202,6 +202,24 @@ impl QueryError {
                 messages
             }
             _ => vec![Message::ErrorResponse(self.severity(), self.code(), self.message())],
+        }
+    }
+
+    /// operator or function is not found for operands
+    pub fn undefined_function(operator: String, left_type: String, right_type: String) -> Self {
+        Self {
+            severity: Severity::Error,
+            code: "42883".to_owned(),
+            kind: QueryErrorKind::UndefinedFunction(operator, left_type, right_type),
+        }
+    }
+
+    /// syntax error in the expression as part of query
+    pub fn syntax_error(expression: String) -> Self {
+        Self {
+            severity: Severity::Error,
+            code: "42601".to_owned(),
+            kind: QueryErrorKind::SyntaxError(expression),
         }
     }
 
@@ -296,11 +314,13 @@ impl Display for QueryErrorKind {
             Self::NotSupportedOperation(raw_sql_query) => {
                 write!(f, "Currently, Query '{}' can't be executed", raw_sql_query)
             }
-            Self::TooManyInsertExpressions => write!(f, "INSERT has more epxressions then target columns"),
+            Self::TooManyInsertExpressions => write!(f, "INSERT has more expressions then target columns"),
             Self::ConstraintViolations(_) => {
                 log::error!("should not use Display to generate the message for Constraint Violations");
                 write!(f, "do not use display with ConstraintViolation errors")
             }
+            Self::UndefinedFunction(_, _, _) => panic!(),
+            Self::SyntaxError(_) => panic!(),
         }
     }
 }

--- a/src/sql_engine/Cargo.toml
+++ b/src/sql_engine/Cargo.toml
@@ -10,6 +10,7 @@ log = "0.4.8"
 kernel = { path = "../kernel" }
 storage = { path = "../storage" }
 sqlparser = { version = "0.5.1", features = ["bigdecimal"] }
+bigdecimal = "0.1.2"
 sql_types = { path = "../sql_types" }
 protocol = { path = "../protocol" }
 

--- a/src/sql_engine/src/dml/insert.rs
+++ b/src/sql_engine/src/dml/insert.rs
@@ -166,50 +166,42 @@ impl<P: BackendStorage> InsertCommand<'_, P> {
                         let (right, _) = right.as_bigint_and_exponent();
                         Ok(ExprResult::Number(BigDecimal::from(left | &right)))
                     }
-                    operator => {
-                        return Err(QueryError::undefined_function(
-                            operator.to_string(),
-                            "NUMBER".to_owned(),
-                            "NUMBER".to_owned(),
-                        ))
-                    }
+                    operator => Err(QueryError::undefined_function(
+                        operator.to_string(),
+                        "NUMBER".to_owned(),
+                        "NUMBER".to_owned(),
+                    )),
                 },
                 (ExprResult::String(left), ExprResult::String(right)) => match op {
                     BinaryOperator::StringConcat => Ok(ExprResult::String(left + right.as_str())),
-                    operator => {
-                        return Err(QueryError::undefined_function(
-                            operator.to_string(),
-                            "STRING".to_owned(),
-                            "STRING".to_owned(),
-                        ))
-                    }
+                    operator => Err(QueryError::undefined_function(
+                        operator.to_string(),
+                        "STRING".to_owned(),
+                        "STRING".to_owned(),
+                    )),
                 },
                 (ExprResult::Number(left), ExprResult::String(right)) => match op {
                     BinaryOperator::StringConcat => Ok(ExprResult::String(left.to_string() + right.as_str())),
-                    operator => {
-                        return Err(QueryError::undefined_function(
-                            operator.to_string(),
-                            "NUMBER".to_owned(),
-                            "STRING".to_owned(),
-                        ))
-                    }
+                    operator => Err(QueryError::undefined_function(
+                        operator.to_string(),
+                        "NUMBER".to_owned(),
+                        "STRING".to_owned(),
+                    )),
                 },
                 (ExprResult::String(left), ExprResult::Number(right)) => match op {
                     BinaryOperator::StringConcat => Ok(ExprResult::String(left + right.to_string().as_str())),
-                    operator => {
-                        return Err(QueryError::undefined_function(
-                            operator.to_string(),
-                            "STRING".to_owned(),
-                            "NUMBER".to_owned(),
-                        ))
-                    }
+                    operator => Err(QueryError::undefined_function(
+                        operator.to_string(),
+                        "STRING".to_owned(),
+                        "NUMBER".to_owned(),
+                    )),
                 },
             }
         } else {
             match expr {
                 Expr::Value(Value::Number(v)) => Ok(ExprResult::Number(v.clone())),
                 Expr::Value(Value::SingleQuotedString(v)) => Ok(ExprResult::String(v.clone())),
-                e => return Err(QueryError::syntax_error(e.to_string())),
+                e => Err(QueryError::syntax_error(e.to_string())),
             }
         }
     }

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate bigdecimal;
 extern crate log;
 
 use crate::{

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -250,360 +250,469 @@ fn insert_and_select_different_character_types(mut sql_engine_with_schema: InMem
     )
 }
 
+#[rstest::rstest]
+fn insert_booleans(mut sql_engine_with_schema: InMemorySqlEngine) {
+    sql_engine_with_schema
+        .execute("create table schema_name.table_name (b boolean);")
+        .expect("no system errors")
+        .expect("table created");
+
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("insert into schema_name.table_name values(true);")
+            .expect("no system errors"),
+        Ok(QueryEvent::RecordsInserted(1))
+    );
+
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("insert into schema_name.table_name values(TRUE::boolean);")
+            .expect("no system errors"),
+        Ok(QueryEvent::RecordsInserted(1))
+    );
+
+    assert_eq!(
+        sql_engine_with_schema
+            .execute("insert into schema_name.table_name values('true'::boolean);")
+            .expect("no system errors"),
+        Ok(QueryEvent::RecordsInserted(1))
+    );
+}
+
 #[cfg(test)]
-mod mathematical_operators {
+mod operators {
     use super::*;
 
-    #[rstest::fixture]
-    fn with_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
-        sql_engine_with_schema
-            .execute("create table schema_name.table_name(column_si smallint);")
-            .expect("no system errors")
-            .expect("table created");
+    #[cfg(test)]
+    mod mathematical {
+        use super::*;
 
-        sql_engine_with_schema
+        #[cfg(test)]
+        mod integers {
+            use super::*;
+
+            #[rstest::fixture]
+            fn with_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
+                sql_engine_with_schema
+                    .execute("create table schema_name.table_name(column_si smallint);")
+                    .expect("no system errors")
+                    .expect("table created");
+
+                sql_engine_with_schema
+            }
+
+            #[rstest::rstest]
+            fn addition(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (1 + 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["3".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn subtraction(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (1 - 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["-1".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn multiplication(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (3 * 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["6".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn division(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (8 / 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["4".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn modulo(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (8 % 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["0".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO ^ is bitwise in SQL standard
+            //      # is bitwise in PostgreSQL and it does not supported in sqlparser-rs
+            fn exponentiation(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (8 ^ 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["64".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO |/<n> is square root in PostgreSQL and it does not supported in sqlparser-rs
+            fn square_root(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (|/ 16);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["4".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO ||/<n> is cube root in PostgreSQL and it does not supported in sqlparser-rs
+            fn cube_root(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (||/ 8);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["2".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO <n>! is factorial in PostgreSQL and it does not supported in sqlparser-rs
+            fn factorial(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (5!);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["120".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO !!<n> is prefix factorial in PostgreSQL and it does not supported in sqlparser-rs
+            fn prefix_factorial(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (!!5);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["120".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO @<n> is absolute value in PostgreSQL and it does not supported in sqlparser-rs
+            fn absolute_value(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (@-5);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["5".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn bitwise_and(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (5 & 1);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["1".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn bitwise_or(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (5 | 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["7".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO ~ <n> is bitwise NOT in PostgreSQL and it does not supported in sqlparser-rs
+            fn bitwise_not(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (~1);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["-2".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO <n> << <m> is bitwise SHIFT LEFT in PostgreSQL and it does not supported in sqlparser-rs
+            fn bitwise_shift_left(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (1 << 4);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["16".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            #[ignore]
+            // TODO <n> >> <m> is bitwise SHIFT RIGHT in PostgreSQL and it does not supported in sqlparser-rs
+            fn bitwise_right_left(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (8 >> 2);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["2".to_owned()]]
+                    )))
+                );
+            }
+
+            #[rstest::rstest]
+            fn evaluate_many_operations(mut with_table: InMemorySqlEngine) {
+                assert_eq!(
+                    with_table
+                        .execute("insert into schema_name.table_name values (5 & 13 % 10 + 1 * 20 - 40 / 4);")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsInserted(1))
+                );
+                assert_eq!(
+                    with_table
+                        .execute("select * from schema_name.table_name;")
+                        .expect("no system errors"),
+                    Ok(QueryEvent::RecordsSelected((
+                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
+                        vec![vec!["5".to_owned()]]
+                    )))
+                );
+            }
+        }
     }
 
-    #[rstest::rstest]
-    fn addition(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (1 + 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["3".to_owned()]]
-            )))
-        );
-    }
+    #[cfg(test)]
+    mod string {
+        use super::*;
 
-    #[rstest::rstest]
-    fn subtraction(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (1 - 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["-1".to_owned()]]
-            )))
-        );
-    }
+        #[rstest::fixture]
+        fn with_table(mut sql_engine_with_schema: InMemorySqlEngine) -> InMemorySqlEngine {
+            sql_engine_with_schema
+                .execute("create table schema_name.table_name(strings char(5));")
+                .expect("no system errors")
+                .expect("table created");
 
-    #[rstest::rstest]
-    fn multiplication(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (3 * 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["6".to_owned()]]
-            )))
-        );
-    }
+            sql_engine_with_schema
+        }
 
-    #[rstest::rstest]
-    fn division(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (8 / 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["4".to_owned()]]
-            )))
-        );
-    }
+        #[rstest::rstest]
+        fn concatenation(mut with_table: InMemorySqlEngine) {
+            assert_eq!(
+                with_table
+                    .execute("insert into schema_name.table_name values ('123' || '45');")
+                    .expect("no system errors"),
+                Ok(QueryEvent::RecordsInserted(1))
+            );
+            assert_eq!(
+                with_table
+                    .execute("select * from schema_name.table_name;")
+                    .expect("no system errors"),
+                Ok(QueryEvent::RecordsSelected((
+                    vec![("strings".to_owned(), PostgreSqlType::Char),],
+                    vec![vec!["12345".to_owned()]]
+                )))
+            );
+        }
 
-    #[rstest::rstest]
-    fn modulo(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
+        #[rstest::rstest]
+        fn concatenation_with_number(mut with_table: InMemorySqlEngine) {
             with_table
-                .execute("insert into schema_name.table_name values (8 % 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["0".to_owned()]]
-            )))
-        );
-    }
+                .execute("insert into schema_name.table_name values (1 || '45');")
+                .expect("no system errors")
+                .expect("record inserted");
 
-    #[rstest::rstest]
-    #[ignore]
-    // TODO ^ is bitwise in SQL standard
-    //      # is bitwise in PostgreSQL and it does not supported in sqlparser-rs
-    fn exponentiation(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
             with_table
-                .execute("insert into schema_name.table_name values (8 ^ 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["64".to_owned()]]
-            )))
-        );
-    }
+                .execute("insert into schema_name.table_name values ('45' || 1);")
+                .expect("no system errors")
+                .expect("record inserted");
 
-    #[rstest::rstest]
-    #[ignore]
-    // TODO |/<n> is square root in PostgreSQL and it does not supported in sqlparser-rs
-    fn square_root(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (|/ 16);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["4".to_owned()]]
-            )))
-        );
-    }
+            assert_eq!(
+                with_table
+                    .execute("select * from schema_name.table_name;")
+                    .expect("no system errors"),
+                Ok(QueryEvent::RecordsSelected((
+                    vec![("strings".to_owned(), PostgreSqlType::Char),],
+                    vec![vec!["145".to_owned()], vec!["451".to_owned()]]
+                )))
+            );
+        }
 
-    #[rstest::rstest]
-    #[ignore]
-    // TODO ||/<n> is cube root in PostgreSQL and it does not supported in sqlparser-rs
-    fn cube_root(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (||/ 8);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["2".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO <n>! is factorial in PostgreSQL and it does not supported in sqlparser-rs
-    fn factorial(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (5!);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["120".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO !!<n> is prefix factorial in PostgreSQL and it does not supported in sqlparser-rs
-    fn prefix_factorial(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (!!5);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["120".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO @<n> is absolute value in PostgreSQL and it does not supported in sqlparser-rs
-    fn absolute_value(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (@-5);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["5".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    fn bitwise_and(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (5 & 1);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["1".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    fn bitwise_or(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (5 | 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["7".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO ~ <n> is bitwise NOT in PostgreSQL and it does not supported in sqlparser-rs
-    fn bitwise_not(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (~1);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["-2".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO <n> << <m> is bitwise SHIFT LEFT in PostgreSQL and it does not supported in sqlparser-rs
-    fn bitwise_shift_left(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (1 << 4);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["16".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    // TODO <n> >> <m> is bitwise SHIFT RIGHT in PostgreSQL and it does not supported in sqlparser-rs
-    fn bitwise_right_left(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (8 >> 2);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["2".to_owned()]]
-            )))
-        );
-    }
-
-    #[rstest::rstest]
-    #[ignore]
-    fn bitwise_operations_have_lesser_priority_than_arithmetic(mut with_table: InMemorySqlEngine) {
-        assert_eq!(
-            with_table
-                .execute("insert into schema_name.table_name values (5 & 3 + 1);")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsInserted(1))
-        );
-        assert_eq!(
-            with_table
-                .execute("select * from schema_name.table_name;")
-                .expect("no system errors"),
-            Ok(QueryEvent::RecordsSelected((
-                vec![("column_si".to_owned(), PostgreSqlType::SmallInt),],
-                vec![vec!["4".to_owned()]]
-            )))
-        );
+        #[rstest::rstest]
+        fn non_string_concatenation_not_supported(mut with_table: InMemorySqlEngine) {
+            assert_eq!(
+                with_table
+                    .execute("insert into schema_name.table_name values (1 || 2);")
+                    .expect("no system errors"),
+                Err(QueryError::undefined_function(
+                    "||".to_owned(),
+                    "NUMBER".to_owned(),
+                    "NUMBER".to_owned()
+                ))
+            );
+        }
     }
 }


### PR DESCRIPTION
Does not close any issue, however, it is a part of #127 

#### Description
PR adds code to evaluate **supported** math expression for integers and concatenation for strings
* by supported I mean that some operators are not supported by https://github.com/ballista-compute/sqlparser-rs

#### Client output

e.g. for `psql`

```
psql (12.2, server 0.0.0)
Type "help" for help.

alex-dukhno=> create schema schema_name;
CREATE SCHEMA
alex-dukhno=> create table schema_name.table_name (s smallint);
CREATE TABLE
alex-dukhno=> insert into schema_name.table_name values (10 + 20 * 2 - 30 / 3);
INSERT 0 1
alex-dukhno=> select * from schema_name.table_name;
 s
----
 40
(1 row)

alex-dukhno=> insert into schema_name.table_name values (10 || 20);
ERROR:  operator does not exist: (NUMBER || NUMBER)
```

