### PR TITLE
Frontend Storage tests improvements (#141)

### DIFF
--- a/src/storage/src/frontend/tests/mod.rs
+++ b/src/storage/src/frontend/tests/mod.rs
@@ -23,16 +23,20 @@ mod table;
 
 type PersistentStorage = FrontendStorage<SledBackendStorage>;
 
-fn column_definition(name: &'static str, sql_type: SqlType) -> ColumnDefinition {
-    ColumnDefinition {
-        name: name.to_owned(),
-        sql_type,
-    }
+#[rstest::fixture]
+fn default_schema_name() -> &'static str {
+    "schema_name"
 }
 
 #[rstest::fixture]
 fn storage() -> PersistentStorage {
     FrontendStorage::default().expect("no system errors")
+}
+
+#[rstest::fixture]
+fn storage_with_schema(mut storage: PersistentStorage, default_schema_name: &str) -> PersistentStorage {
+    create_schema(&mut storage, default_schema_name);
+    storage
 }
 
 fn create_schema<P: backend::BackendStorage>(storage: &mut FrontendStorage<P>, schema_name: &str) {
@@ -61,14 +65,11 @@ fn create_table<P: backend::BackendStorage>(
         .expect("table is created");
 }
 
-fn create_schema_with_table<P: backend::BackendStorage>(
-    storage: &mut FrontendStorage<P>,
-    schema_name: &str,
-    table_name: &str,
-    columns: Vec<(&str, SqlType)>,
-) {
-    create_schema(storage, schema_name);
-    create_table(storage, schema_name, table_name, columns)
+fn column_definition(name: &'static str, sql_type: SqlType) -> ColumnDefinition {
+    ColumnDefinition {
+        name: name.to_owned(),
+        sql_type,
+    }
 }
 
 fn insert_into<P: backend::BackendStorage>(

--- a/src/storage/src/frontend/tests/queries/delete.rs
+++ b/src/storage/src/frontend/tests/queries/delete.rs
@@ -26,45 +26,62 @@ fn delete_all_from_non_existent_schema(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn delete_all_from_not_existed_table(mut storage: PersistentStorage) {
-    create_schema(&mut storage, "schema_name");
-
+fn delete_all_from_not_existed_table(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
     assert_eq!(
-        storage
-            .delete_all_from("schema_name", "table_name")
+        storage_with_schema
+            .delete_all_from(default_schema_name, "table_name")
             .expect("no system errors"),
         Err(OperationOnTableError::TableDoesNotExist)
     );
 }
 
 #[rstest::rstest]
-fn delete_all_from_table(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn delete_all_from_table(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![("column_test", SqlType::SmallInt(i16::min_value()))],
     );
-    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["123"]);
-    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["456"]);
-    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["789"]);
+
+    insert_into(
+        &mut storage_with_schema,
+        default_schema_name,
+        "table_name",
+        vec![],
+        vec!["123"],
+    );
+    insert_into(
+        &mut storage_with_schema,
+        default_schema_name,
+        "table_name",
+        vec![],
+        vec!["456"],
+    );
+    insert_into(
+        &mut storage_with_schema,
+        default_schema_name,
+        "table_name",
+        vec![],
+        vec!["789"],
+    );
 
     assert_eq!(
-        storage
-            .delete_all_from("schema_name", "table_name")
+        storage_with_schema
+            .delete_all_from(default_schema_name, "table_name")
             .expect("no system errors"),
         Ok(3)
     );
 
-    let table_columns = storage
-        .table_columns("schema_name", "table_name")
+    let table_columns = storage_with_schema
+        .table_columns(default_schema_name, "table_name")
         .expect("no system errors")
         .into_iter()
         .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
-        storage
+        storage_with_schema
             .select_all_from("schema_name", "table_name", table_columns)
             .expect("no system errors"),
         Ok((

--- a/src/storage/src/frontend/tests/queries/insert.rs
+++ b/src/storage/src/frontend/tests/queries/insert.rs
@@ -26,39 +26,49 @@ fn insert_into_non_existent_schema(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn insert_into_non_existent_table(mut storage: PersistentStorage) {
-    create_schema(&mut storage, "schema_name");
-
+fn insert_into_non_existent_table(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
     assert_eq!(
-        storage
-            .insert_into("schema_name", "not_existed", vec![], vec![vec!["123".to_owned()]])
+        storage_with_schema
+            .insert_into(default_schema_name, "not_existed", vec![], vec![vec!["123".to_owned()]])
             .expect("no system errors"),
         Err(OperationOnTableError::TableDoesNotExist)
     );
 }
 
 #[rstest::rstest]
-fn insert_many_rows_into_table(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn insert_many_rows_into_table(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![("column_test", SqlType::SmallInt(i16::min_value()))],
     );
 
-    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["123"]);
-    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["456"]);
+    insert_into(
+        &mut storage_with_schema,
+        default_schema_name,
+        "table_name",
+        vec![],
+        vec!["123"],
+    );
+    insert_into(
+        &mut storage_with_schema,
+        default_schema_name,
+        "table_name",
+        vec![],
+        vec!["456"],
+    );
 
-    let table_columns = storage
-        .table_columns("schema_name", "table_name")
+    let table_columns = storage_with_schema
+        .table_columns(default_schema_name, "table_name")
         .expect("no system errors")
         .into_iter()
         .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
-        storage
-            .select_all_from("schema_name", "table_name", table_columns)
+        storage_with_schema
+            .select_all_from(default_schema_name, "table_name", table_columns)
             .expect("no system errors"),
         Ok((
             vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
@@ -68,10 +78,10 @@ fn insert_many_rows_into_table(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn insert_multiple_values_rows(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn insert_multiple_values_rows(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![
             ("column_1", SqlType::SmallInt(i16::min_value())),
@@ -80,20 +90,38 @@ fn insert_multiple_values_rows(mut storage: PersistentStorage) {
         ],
     );
 
-    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["1", "2", "3"]);
-    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["4", "5", "6"]);
-    insert_into(&mut storage, "schema_name", "table_name", vec![], vec!["7", "8", "9"]);
+    insert_into(
+        &mut storage_with_schema,
+        default_schema_name,
+        "table_name",
+        vec![],
+        vec!["1", "2", "3"],
+    );
+    insert_into(
+        &mut storage_with_schema,
+        default_schema_name,
+        "table_name",
+        vec![],
+        vec!["4", "5", "6"],
+    );
+    insert_into(
+        &mut storage_with_schema,
+        default_schema_name,
+        "table_name",
+        vec![],
+        vec!["7", "8", "9"],
+    );
 
-    let table_columns = storage
-        .table_columns("schema_name", "table_name")
+    let table_columns = storage_with_schema
+        .table_columns(default_schema_name, "table_name")
         .expect("no system errors")
         .into_iter()
         .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
-        storage
-            .select_all_from("schema_name", "table_name", table_columns)
+        storage_with_schema
+            .select_all_from(default_schema_name, "table_name", table_columns)
             .expect("no system errors"),
         Ok((
             vec![
@@ -111,10 +139,10 @@ fn insert_multiple_values_rows(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn insert_named_columns(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn insert_named_columns(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![
             ("column_1", SqlType::SmallInt(i16::min_value())),
@@ -126,37 +154,37 @@ fn insert_named_columns(mut storage: PersistentStorage) {
     let columns = vec!["column_3", "column_2", "column_1"];
 
     insert_into(
-        &mut storage,
-        "schema_name",
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         columns.clone(),
         vec!["1", "2", "3"],
     );
     insert_into(
-        &mut storage,
-        "schema_name",
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         columns.clone(),
         vec!["4", "5", "6"],
     );
     insert_into(
-        &mut storage,
-        "schema_name",
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         columns.clone(),
         vec!["7", "8", "9"],
     );
 
-    let table_columns = storage
-        .table_columns("schema_name", "table_name")
+    let table_columns = storage_with_schema
+        .table_columns(default_schema_name, "table_name")
         .expect("no system errors")
         .into_iter()
         .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
-        storage
-            .select_all_from("schema_name", "table_name", table_columns)
+        storage_with_schema
+            .select_all_from(default_schema_name, "table_name", table_columns)
             .expect("no system errors"),
         Ok((
             vec![
@@ -174,10 +202,10 @@ fn insert_named_columns(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn insert_named_not_existed_column(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn insert_named_not_existed_column(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![
             ("column_1", SqlType::SmallInt(i16::min_value())),
@@ -194,9 +222,9 @@ fn insert_named_not_existed_column(mut storage: PersistentStorage) {
     ];
 
     assert_eq!(
-        storage
+        storage_with_schema
             .insert_into(
-                "schema_name",
+                default_schema_name,
                 "table_name",
                 columns,
                 vec![vec!["1".to_owned(), "2".to_owned(), "3".to_owned(), "4".to_owned()]],
@@ -209,30 +237,31 @@ fn insert_named_not_existed_column(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn insert_row_into_table(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn insert_row_into_table(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![("column_test", SqlType::SmallInt(i16::min_value()))],
     );
+
     assert_eq!(
-        storage
-            .insert_into("schema_name", "table_name", vec![], vec![vec!["123".to_owned()]])
+        storage_with_schema
+            .insert_into(default_schema_name, "table_name", vec![], vec![vec!["123".to_owned()]])
             .expect("no system errors"),
         Ok(())
     );
 
-    let table_columns = storage
-        .table_columns("schema_name", "table_name")
+    let table_columns = storage_with_schema
+        .table_columns(default_schema_name, "table_name")
         .expect("no system errors")
         .into_iter()
         .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
-        storage
-            .select_all_from("schema_name", "table_name", table_columns)
+        storage_with_schema
+            .select_all_from(default_schema_name, "table_name", table_columns)
             .expect("no system errors"),
         Ok((
             vec![column_definition("column_test", SqlType::SmallInt(i16::min_value()))],
@@ -242,10 +271,10 @@ fn insert_row_into_table(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn insert_too_many_expressions(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn insert_too_many_expressions(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![
             ("column_1", SqlType::SmallInt(i16::min_value())),
@@ -257,9 +286,9 @@ fn insert_too_many_expressions(mut storage: PersistentStorage) {
     let columns = vec![];
 
     assert_eq!(
-        storage
+        storage_with_schema
             .insert_into(
-                "schema_name",
+                default_schema_name,
                 "table_name",
                 columns,
                 vec![vec!["1".to_owned(), "2".to_owned(), "3".to_owned(), "4".to_owned()]],
@@ -268,16 +297,16 @@ fn insert_too_many_expressions(mut storage: PersistentStorage) {
         Err(OperationOnTableError::InsertTooManyExpressions)
     );
 
-    let table_columns = storage
-        .table_columns("schema_name", "table_name")
+    let table_columns = storage_with_schema
+        .table_columns(default_schema_name, "table_name")
         .expect("no system errors")
         .into_iter()
         .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
-        storage
-            .select_all_from("schema_name", "table_name", table_columns)
+        storage_with_schema
+            .select_all_from(default_schema_name, "table_name", table_columns)
             .expect("no system errors"),
         Ok((
             vec![
@@ -291,10 +320,10 @@ fn insert_too_many_expressions(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn insert_too_many_expressions_labeled(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn insert_too_many_expressions_labeled(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![
             ("column_1", SqlType::SmallInt(i16::min_value())),
@@ -306,9 +335,9 @@ fn insert_too_many_expressions_labeled(mut storage: PersistentStorage) {
     let columns = vec!["column_3".to_owned(), "column_2".to_owned(), "column_1".to_owned()];
 
     assert_eq!(
-        storage
+        storage_with_schema
             .insert_into(
-                "schema_name",
+                default_schema_name,
                 "table_name",
                 columns,
                 vec![vec!["1".to_owned(), "2".to_owned(), "3".to_owned(), "4".to_owned()]],
@@ -317,16 +346,16 @@ fn insert_too_many_expressions_labeled(mut storage: PersistentStorage) {
         Err(OperationOnTableError::InsertTooManyExpressions)
     );
 
-    let table_columns = storage
-        .table_columns("schema_name", "table_name")
+    let table_columns = storage_with_schema
+        .table_columns(default_schema_name, "table_name")
         .expect("no system errors")
         .into_iter()
         .map(|column_definition| column_definition.name())
         .collect();
 
     assert_eq!(
-        storage
-            .select_all_from("schema_name", "table_name", table_columns)
+        storage_with_schema
+            .select_all_from(default_schema_name, "table_name", table_columns)
             .expect("no system errors"),
         Ok((
             vec![
@@ -345,10 +374,13 @@ mod constraints {
     use sql_types::ConstraintError;
 
     #[rstest::fixture]
-    fn storage_with_ints_table(mut storage: PersistentStorage) -> PersistentStorage {
-        create_schema_with_table(
-            &mut storage,
-            "schema_name",
+    fn storage_with_ints_table(
+        default_schema_name: &str,
+        mut storage_with_schema: PersistentStorage,
+    ) -> PersistentStorage {
+        create_table(
+            &mut storage_with_schema,
+            default_schema_name,
             "table_name",
             vec![
                 ("column_si", SqlType::SmallInt(i16::min_value())),
@@ -356,26 +388,29 @@ mod constraints {
                 ("column_bi", SqlType::BigInt(i64::min_value())),
             ],
         );
-        storage
+        storage_with_schema
     }
 
     #[rstest::fixture]
-    fn storage_with_chars_table(mut storage: PersistentStorage) -> PersistentStorage {
-        create_schema_with_table(
-            &mut storage,
-            "schema_name",
+    fn storage_with_chars_table(
+        default_schema_name: &str,
+        mut storage_with_schema: PersistentStorage,
+    ) -> PersistentStorage {
+        create_table(
+            &mut storage_with_schema,
+            default_schema_name,
             "table_name",
             vec![("column_c", SqlType::Char(10)), ("column_vc", SqlType::VarChar(10))],
         );
-        storage
+        storage_with_schema
     }
 
     #[rstest::rstest]
-    fn out_of_range_violation(mut storage_with_ints_table: PersistentStorage) {
+    fn out_of_range_violation(default_schema_name: &str, mut storage_with_ints_table: PersistentStorage) {
         assert_eq!(
             storage_with_ints_table
                 .insert_into(
-                    "schema_name",
+                    default_schema_name,
                     "table_name",
                     vec![],
                     vec![vec!["-32769".to_owned(), "100".to_owned(), "100".to_owned()]],
@@ -389,11 +424,11 @@ mod constraints {
     }
 
     #[rstest::rstest]
-    fn not_an_int_violation(mut storage_with_ints_table: PersistentStorage) {
+    fn not_an_int_violation(default_schema_name: &str, mut storage_with_ints_table: PersistentStorage) {
         assert_eq!(
             storage_with_ints_table
                 .insert_into(
-                    "schema_name",
+                    default_schema_name,
                     "table_name",
                     vec![],
                     vec![vec!["abc".to_owned(), "100".to_owned(), "100".to_owned()]],
@@ -407,11 +442,11 @@ mod constraints {
     }
 
     #[rstest::rstest]
-    fn value_too_long_violation(mut storage_with_chars_table: PersistentStorage) {
+    fn value_too_long_violation(default_schema_name: &str, mut storage_with_chars_table: PersistentStorage) {
         assert_eq!(
             storage_with_chars_table
                 .insert_into(
-                    "schema_name",
+                    default_schema_name,
                     "table_name",
                     vec![],
                     vec![vec!["12345678901".to_owned(), "100".to_owned()]],
@@ -425,11 +460,14 @@ mod constraints {
     }
 
     #[rstest::rstest]
-    fn multiple_columns_single_row_violation(mut storage_with_ints_table: PersistentStorage) {
+    fn multiple_columns_single_row_violation(
+        default_schema_name: &str,
+        mut storage_with_ints_table: PersistentStorage,
+    ) {
         assert_eq!(
             storage_with_ints_table
                 .insert_into(
-                    "schema_name",
+                    default_schema_name,
                     "table_name",
                     vec![],
                     vec![vec!["-32769".to_owned(), "-2147483649".to_owned(), "100".to_owned()]],
@@ -449,11 +487,14 @@ mod constraints {
     }
 
     #[rstest::rstest]
-    fn multiple_columns_multiple_row_violation(mut storage_with_ints_table: PersistentStorage) {
+    fn multiple_columns_multiple_row_violation(
+        default_schema_name: &str,
+        mut storage_with_ints_table: PersistentStorage,
+    ) {
         assert_eq!(
             storage_with_ints_table
                 .insert_into(
-                    "schema_name",
+                    default_schema_name,
                     "table_name",
                     vec![],
                     vec![

--- a/src/storage/src/frontend/tests/table.rs
+++ b/src/storage/src/frontend/tests/table.rs
@@ -16,13 +16,11 @@ use super::*;
 use sql_types::SqlType;
 
 #[rstest::rstest]
-fn create_tables_with_different_names(mut storage: PersistentStorage) {
-    create_schema(&mut storage, "schema_name");
-
+fn create_tables_with_different_names(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
     assert_eq!(
-        storage
+        storage_with_schema
             .create_table(
-                "schema_name",
+                default_schema_name,
                 "table_name_1",
                 vec![("column_rstest::rstest".to_owned(), SqlType::SmallInt(i16::min_value()))]
             )
@@ -30,9 +28,9 @@ fn create_tables_with_different_names(mut storage: PersistentStorage) {
         Ok(())
     );
     assert_eq!(
-        storage
+        storage_with_schema
             .create_table(
-                "schema_name",
+                default_schema_name,
                 "table_name_2",
                 vec![("column_rstest::rstest".to_owned(), SqlType::SmallInt(i16::min_value()))]
             )
@@ -42,18 +40,18 @@ fn create_tables_with_different_names(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn create_table_with_the_same_name(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn create_table_with_the_same_name(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![("column_rstest::rstest", SqlType::SmallInt(i16::min_value()))],
     );
 
     assert_eq!(
-        storage
+        storage_with_schema
             .create_table(
-                "schema_name",
+                default_schema_name,
                 "table_name",
                 vec![("column_rstest::rstest".to_owned(), SqlType::SmallInt(i16::min_value()))]
             )
@@ -89,23 +87,23 @@ fn create_table_with_the_same_name_in_different_schemas(mut storage: PersistentS
 }
 
 #[rstest::rstest]
-fn drop_table(mut storage: PersistentStorage) {
-    create_schema_with_table(
-        &mut storage,
-        "schema_name",
+fn drop_table(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(
+        &mut storage_with_schema,
+        default_schema_name,
         "table_name",
         vec![("column_rstest::rstest", SqlType::SmallInt(i16::min_value()))],
     );
     assert_eq!(
-        storage
-            .drop_table("schema_name", "table_name")
+        storage_with_schema
+            .drop_table(default_schema_name, "table_name")
             .expect("no system errors"),
         Ok(())
     );
     assert_eq!(
-        storage
+        storage_with_schema
             .create_table(
-                "schema_name",
+                default_schema_name,
                 "table_name",
                 vec![("column_rstest::rstest".to_owned(), SqlType::SmallInt(i16::min_value()))]
             )
@@ -115,23 +113,22 @@ fn drop_table(mut storage: PersistentStorage) {
 }
 
 #[rstest::rstest]
-fn table_columns_on_empty_table(mut storage: PersistentStorage) {
-    create_schema_with_table(&mut storage, "schema_name", "table_name", vec![]);
+fn table_columns_on_empty_table(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
+    create_table(&mut storage_with_schema, default_schema_name, "table_name", vec![]);
 
     assert_eq!(
-        storage
-            .table_columns("schema_name", "table_name")
+        storage_with_schema
+            .table_columns(default_schema_name, "table_name")
             .expect("no system errors"),
         vec![]
     )
 }
 
 #[rstest::rstest]
-fn drop_not_created_table(mut storage: PersistentStorage) {
-    create_schema(&mut storage, "schema_name");
+fn drop_not_created_table(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
     assert_eq!(
-        storage
-            .drop_table("schema_name", "not_existed_table")
+        storage_with_schema
+            .drop_table(default_schema_name, "not_existed_table")
             .expect("no system errors"),
         Err(DropTableError::TableDoesNotExist)
     );


### PR DESCRIPTION
Closes #141 

#### Description
* Added fixture for `default_schema_name`, which is `"schema_name"`. 
* Added fixture for `storage_with_schema` that initialize storage with `default_schema_name`.
* Updated tests in `Frontend` to use new introduced fixtures.

#### Future improvements
* Should we add fixture`default_table_name` for `"table_name"`? It's duplicated all over the place.
* Might be useful to add fixtures for different types of columns. Instead of having fixtures for concrete tables (like [`storage_with_ints_table`](https://github.com/alex-dukhno/database/blob/master/src/storage/src/frontend/tests/queries/update.rs#L103)), I would rather have something like:

```
#[rstest::fixture]
fn ints_columns() -> Vec<(&str, SqlType)> {
            vec![
                ("column_si", SqlType::SmallInt(i16::min_value())),
                ("column_i", SqlType::Integer(i32::min_value())),
                ("column_bi", SqlType::BigInt(i64::min_value())),
            ]
}

#[rstest::rstest]
fn test(default_schema_name: &str, mut storage_with_schema: PersistentStorage, ints_columns: Vec<(&str, SqlType)> {
      create_table(
        &mut storage_with_schema,
        default_schema_name,
        "table_name",
        ints_columns
    );
....
}

```

I guess it will give us much more flexibility and remove duplication.