### PR TITLE
Issue 154

### DIFF
--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -465,7 +465,7 @@ mod tests {
                 vec![Message::ErrorResponse(
                     Some("ERROR"),
                     Some("22026"),
-                    Some("value too long for type character for column 'col1' at row 1 (5)".to_owned())
+                    Some("value too long for type character(5) for column 'col1' at row 1".to_owned())
                 )]
             )
         }

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -430,14 +430,14 @@ mod tests {
         #[test]
         fn out_of_range_constraint_violation() {
             let mut builder = QueryErrorBuilder::new();
-            builder.out_of_range(PostgreSqlType::SmallInt);
+            builder.out_of_range(PostgreSqlType::SmallInt, "col1".to_string(), 1);
 
             assert_eq!(
                 QueryResultMapper::map(Err(builder.build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR"),
                     Some("22003"),
-                    Some("smallint out of range".to_owned())
+                    Some("smallint is out of range for column 'col1' at row 1".to_owned())
                 )]
             )
         }
@@ -445,13 +445,13 @@ mod tests {
         #[test]
         fn type_mismatch_constraint_violation() {
             let mut builder = QueryErrorBuilder::new();
-            builder.type_mismatch("abc", PostgreSqlType::SmallInt);
+            builder.type_mismatch("abc", PostgreSqlType::SmallInt, "col1".to_string(), 1);
             assert_eq!(
                 QueryResultMapper::map(Err(builder.build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR"),
                     Some("2200G"),
-                    Some("invalid input syntax for type smallint: \"abc\"".to_owned())
+                    Some("invalid input syntax for type smallint for column 'col1' at row 1: \"abc\"".to_owned())
                 )]
             )
         }
@@ -459,13 +459,13 @@ mod tests {
         #[test]
         fn string_length_mismatch_constraint_violation() {
             let mut builder = QueryErrorBuilder::new();
-            builder.string_length_mismatch(PostgreSqlType::Char, 5);
+            builder.string_length_mismatch(PostgreSqlType::Char, 5, "col1".to_string(), 1);
             assert_eq!(
                 QueryResultMapper::map(Err(builder.build())),
                 vec![Message::ErrorResponse(
                     Some("ERROR"),
                     Some("22026"),
-                    Some("value too long for type character(5)".to_owned())
+                    Some("value too long for type character for column 'col1' at row 1 (5)".to_owned())
                 )]
             )
         }

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -422,7 +422,7 @@ mod tests {
                 vec![Message::ErrorResponse(
                     Some("ERROR"),
                     Some("42601"),
-                    Some("INSERT has more expressions then target columns".to_owned()),
+                    Some("INSERT has more expressions than target columns".to_owned()),
                 )]
             )
         }

--- a/src/protocol/src/results.rs
+++ b/src/protocol/src/results.rs
@@ -142,8 +142,8 @@ impl Display for QueryErrorKind {
             ),
             Self::StringTypeLengthMismatch(pg_type, len, column_name, row_index) => write!(
                 f,
-                "value too long for type {} for column '{}' at row {} ({})",
-                pg_type, column_name, row_index, len
+                "value too long for type {}({}) for column '{}' at row {}",
+                pg_type, len, column_name, row_index
             ),
             Self::UndefinedFunction(operator, left_type, right_type) => write!(
                 f,

--- a/src/protocol/src/results.rs
+++ b/src/protocol/src/results.rs
@@ -129,7 +129,7 @@ impl Display for QueryErrorKind {
             Self::FeatureNotSupported(raw_sql_query) => {
                 write!(f, "Currently, Query '{}' can't be executed", raw_sql_query)
             }
-            Self::TooManyInsertExpressions => write!(f, "INSERT has more expressions then target columns"),
+            Self::TooManyInsertExpressions => write!(f, "INSERT has more expressions than target columns"),
             Self::NumericTypeOutOfRange(pg_type) => write!(f, "{} out of range", pg_type),
             Self::DataTypeMismatch(pg_type, value) => {
                 write!(f, "invalid input syntax for type {}: \"{}\"", pg_type, value)

--- a/src/protocol/src/results.rs
+++ b/src/protocol/src/results.rs
@@ -85,9 +85,9 @@ pub(crate) enum QueryErrorKind {
     FeatureNotSupported(String),
     TooManyInsertExpressions,
 
-    NumericTypeOutOfRange(PostgreSqlType),
-    DataTypeMismatch(PostgreSqlType, String),
-    StringTypeLengthMismatch(PostgreSqlType, u64),
+    NumericTypeOutOfRange(PostgreSqlType, String, usize),
+    DataTypeMismatch(PostgreSqlType, String, String, usize),
+    StringTypeLengthMismatch(PostgreSqlType, u64, String, usize),
 
     UndefinedFunction(String, String, String),
     SyntaxError(String),
@@ -103,9 +103,9 @@ impl QueryErrorKind {
             Self::ColumnDoesNotExist(_) => "42703",
             Self::FeatureNotSupported(_) => "0A000",
             Self::TooManyInsertExpressions => "42601",
-            Self::NumericTypeOutOfRange(_) => "22003",
-            Self::DataTypeMismatch(_, _) => "2200G",
-            Self::StringTypeLengthMismatch(_, _) => "22026",
+            Self::NumericTypeOutOfRange(_, _, _) => "22003",
+            Self::DataTypeMismatch(_, _, _, _) => "2200G",
+            Self::StringTypeLengthMismatch(_, _, _, _) => "22026",
             Self::UndefinedFunction(_, _, _) => "42883",
             Self::SyntaxError(_) => "42601",
         }
@@ -130,11 +130,21 @@ impl Display for QueryErrorKind {
                 write!(f, "Currently, Query '{}' can't be executed", raw_sql_query)
             }
             Self::TooManyInsertExpressions => write!(f, "INSERT has more expressions than target columns"),
-            Self::NumericTypeOutOfRange(pg_type) => write!(f, "{} out of range", pg_type),
-            Self::DataTypeMismatch(pg_type, value) => {
-                write!(f, "invalid input syntax for type {}: \"{}\"", pg_type, value)
-            }
-            Self::StringTypeLengthMismatch(pg_type, len) => write!(f, "value too long for type {}({})", pg_type, len),
+            Self::NumericTypeOutOfRange(pg_type, column_name, row_index) => write!(
+                f,
+                "{} is out of range for column '{}' at row {}",
+                pg_type, column_name, row_index
+            ),
+            Self::DataTypeMismatch(pg_type, value, column_name, row_index) => write!(
+                f,
+                "invalid input syntax for type {} for column '{}' at row {}: \"{}\"",
+                pg_type, column_name, row_index, value
+            ),
+            Self::StringTypeLengthMismatch(pg_type, len, column_name, row_index) => write!(
+                f,
+                "value too long for type {} for column '{}' at row {} ({})",
+                pg_type, column_name, row_index, len
+            ),
             Self::UndefinedFunction(operator, left_type, right_type) => write!(
                 f,
                 "operator does not exist: ({} {} {})",
@@ -291,26 +301,26 @@ impl QueryErrorBuilder {
     // and the rest are mut self.
 
     /// numeric out of range constructor
-    pub fn out_of_range(&mut self, pg_type: PostgreSqlType) {
+    pub fn out_of_range(&mut self, pg_type: PostgreSqlType, column_name: String, row_index: usize) {
         self.errors.push(QueryErrorInner {
             severity: Severity::Error,
-            kind: QueryErrorKind::NumericTypeOutOfRange(pg_type),
+            kind: QueryErrorKind::NumericTypeOutOfRange(pg_type, column_name, row_index),
         });
     }
 
     /// type mismatch constructor
-    pub fn type_mismatch(&mut self, value: &str, pg_type: PostgreSqlType) {
+    pub fn type_mismatch(&mut self, value: &str, pg_type: PostgreSqlType, column_name: String, row_index: usize) {
         self.errors.push(QueryErrorInner {
             severity: Severity::Error,
-            kind: QueryErrorKind::DataTypeMismatch(pg_type, value.to_owned()),
+            kind: QueryErrorKind::DataTypeMismatch(pg_type, value.to_owned(), column_name, row_index),
         });
     }
 
     /// length of string types do not match constructor
-    pub fn string_length_mismatch(&mut self, pg_type: PostgreSqlType, len: u64) {
+    pub fn string_length_mismatch(&mut self, pg_type: PostgreSqlType, len: u64, column_name: String, row_index: usize) {
         self.errors.push(QueryErrorInner {
             severity: Severity::Error,
-            kind: QueryErrorKind::StringTypeLengthMismatch(pg_type, len),
+            kind: QueryErrorKind::StringTypeLengthMismatch(pg_type, len, column_name, row_index),
         });
     }
 }

--- a/src/sql_engine/src/dml/insert.rs
+++ b/src/sql_engine/src/dml/insert.rs
@@ -120,22 +120,38 @@ impl<P: BackendStorage> InsertCommand<'_, P> {
                         .column_does_not_exist(non_existing_columns)
                         .build()))
                 }
-                Err(OperationOnTableError::ConstraintViolations(constraint_errors)) => {
+                Err(OperationOnTableError::ConstraintViolations(constraint_errors, row_index)) => {
                     let mut builder = QueryErrorBuilder::new();
-                    let constraint_error_mapper =
-                        |(err, column_definition): &(ConstraintError, ColumnDefinition)| match err {
+                    let mut constraint_error_mapper =
+                        |err: &ConstraintError, column_definition: &ColumnDefinition, row_index: usize| match err {
                             ConstraintError::OutOfRange => {
-                                builder.out_of_range(column_definition.sql_type().to_pg_types());
+                                builder.out_of_range(
+                                    column_definition.sql_type().to_pg_types(),
+                                    column_definition.name(),
+                                    row_index,
+                                );
                             }
                             ConstraintError::TypeMismatch(value) => {
-                                builder.type_mismatch(value, column_definition.sql_type().to_pg_types());
+                                builder.type_mismatch(
+                                    value,
+                                    column_definition.sql_type().to_pg_types(),
+                                    column_definition.name(),
+                                    row_index,
+                                );
                             }
                             ConstraintError::ValueTooLong(len) => {
-                                builder.string_length_mismatch(column_definition.sql_type().to_pg_types(), *len);
+                                builder.string_length_mismatch(
+                                    column_definition.sql_type().to_pg_types(),
+                                    *len,
+                                    column_definition.name(),
+                                    row_index,
+                                );
                             }
                         };
 
-                    constraint_errors.iter().for_each(constraint_error_mapper);
+                    constraint_errors.iter().for_each(|(err, column_definition)| {
+                        constraint_error_mapper(err, column_definition, row_index)
+                    });
                     Ok(Err(builder.build()))
                 }
                 Err(OperationOnTableError::InsertTooManyExpressions) => {

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -42,7 +42,7 @@ mod insert {
     #[rstest::rstest]
     fn out_of_range(mut int_table: InMemorySqlEngine) {
         let mut builder = QueryErrorBuilder::new();
-        builder.out_of_range(PostgreSqlType::SmallInt);
+        builder.out_of_range(PostgreSqlType::SmallInt, "col".to_string(), 1);
 
         assert_eq!(
             int_table
@@ -55,7 +55,7 @@ mod insert {
     #[rstest::rstest]
     fn type_mismatch(mut int_table: InMemorySqlEngine) {
         let mut builder = QueryErrorBuilder::new();
-        builder.type_mismatch("str", PostgreSqlType::SmallInt);
+        builder.type_mismatch("str", PostgreSqlType::SmallInt, "col".to_string(), 1);
 
         assert_eq!(
             int_table
@@ -68,7 +68,7 @@ mod insert {
     #[rstest::rstest]
     fn value_too_long(mut str_table: InMemorySqlEngine) {
         let mut builder = QueryErrorBuilder::new();
-        builder.string_length_mismatch(PostgreSqlType::VarChar, 5);
+        builder.string_length_mismatch(PostgreSqlType::VarChar, 5, "col".to_string(), 1);
         assert_eq!(
             str_table
                 .execute("insert into schema_name.table_name values ('123457890');")
@@ -85,7 +85,7 @@ mod update {
     #[rstest::rstest]
     fn out_of_range(mut int_table: InMemorySqlEngine) {
         let mut builder = QueryErrorBuilder::new();
-        builder.out_of_range(PostgreSqlType::SmallInt);
+        builder.out_of_range(PostgreSqlType::SmallInt, "col".to_string(), 1);
 
         int_table
             .execute("insert into schema_name.table_name values (32767);")
@@ -103,7 +103,7 @@ mod update {
     #[rstest::rstest]
     fn type_mismatch(mut int_table: InMemorySqlEngine) {
         let mut builder = QueryErrorBuilder::new();
-        builder.type_mismatch("str", PostgreSqlType::SmallInt);
+        builder.type_mismatch("str", PostgreSqlType::SmallInt, "col".to_string(), 1);
         int_table
             .execute("insert into schema_name.table_name values (32767);")
             .expect("no system errors")
@@ -120,7 +120,7 @@ mod update {
     #[rstest::rstest]
     fn value_too_long(mut str_table: InMemorySqlEngine) {
         let mut builder = QueryErrorBuilder::new();
-        builder.string_length_mismatch(PostgreSqlType::VarChar, 5);
+        builder.string_length_mismatch(PostgreSqlType::VarChar, 5, "col".to_string(), 1);
 
         str_table
             .execute("insert into schema_name.table_name values ('str');")

--- a/src/storage/src/frontend/mod.rs
+++ b/src/storage/src/frontend/mod.rs
@@ -204,7 +204,7 @@ impl<P: BackendStorage> FrontendStorage<P> {
         if self.persistent.is_table_exists(schema_name, table_name) {
             let mut errors = Vec::new();
 
-            for row in rows {
+            for (row_index, row) in rows.iter().enumerate() {
                 if row.len() > all_columns.len() {
                     // clear anything that could have been processed already.
                     to_write.clear();
@@ -228,7 +228,8 @@ impl<P: BackendStorage> FrontendStorage<P> {
 
                 // if there was an error then exit the loop.
                 if !errors.is_empty() {
-                    return Ok(Err(OperationOnTableError::ConstraintViolations(errors)));
+                    // In SQL indexes start from 1, not 0.
+                    return Ok(Err(OperationOnTableError::ConstraintViolations(errors, row_index + 1)));
                 }
 
                 to_write.push((key, record.join(&b'|')));
@@ -346,7 +347,8 @@ impl<P: BackendStorage> FrontendStorage<P> {
                     )));
                 }
                 if !errors.is_empty() {
-                    return Ok(Err(OperationOnTableError::ConstraintViolations(errors)));
+                    // Index will always be 1.
+                    return Ok(Err(OperationOnTableError::ConstraintViolations(errors, 1)));
                 }
                 let to_update: Vec<Row> = reads
                     .map(backend::Result::unwrap)

--- a/src/storage/src/frontend/tests/queries/insert.rs
+++ b/src/storage/src/frontend/tests/queries/insert.rs
@@ -416,10 +416,13 @@ mod constraints {
                     vec![vec!["-32769".to_owned(), "100".to_owned(), "100".to_owned()]],
                 )
                 .expect("no system errors"),
-            Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::OutOfRange,
-                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
-            )]))
+            Err(OperationOnTableError::ConstraintViolations(
+                vec![(
+                    ConstraintError::OutOfRange,
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
+                )],
+                1
+            ))
         );
     }
 
@@ -434,10 +437,13 @@ mod constraints {
                     vec![vec!["abc".to_owned(), "100".to_owned(), "100".to_owned()]],
                 )
                 .expect("no system errors"),
-            Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::TypeMismatch("abc".to_owned()),
-                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
-            )]))
+            Err(OperationOnTableError::ConstraintViolations(
+                vec![(
+                    ConstraintError::TypeMismatch("abc".to_owned()),
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
+                )],
+                1
+            ))
         )
     }
 
@@ -452,10 +458,13 @@ mod constraints {
                     vec![vec!["12345678901".to_owned(), "100".to_owned()]],
                 )
                 .expect("no system errors"),
-            Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::ValueTooLong(10),
-                column_definition("column_c", SqlType::Char(10))
-            )]))
+            Err(OperationOnTableError::ConstraintViolations(
+                vec![(
+                    ConstraintError::ValueTooLong(10),
+                    column_definition("column_c", SqlType::Char(10))
+                )],
+                1
+            ))
         )
     }
 
@@ -473,16 +482,19 @@ mod constraints {
                     vec![vec!["-32769".to_owned(), "-2147483649".to_owned(), "100".to_owned()]],
                 )
                 .expect("no system errors"),
-            Err(OperationOnTableError::ConstraintViolations(vec![
-                (
-                    ConstraintError::OutOfRange,
-                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
-                ),
-                (
-                    ConstraintError::OutOfRange,
-                    column_definition("column_i", SqlType::Integer(i32::min_value()))
-                )
-            ]))
+            Err(OperationOnTableError::ConstraintViolations(
+                vec![
+                    (
+                        ConstraintError::OutOfRange,
+                        column_definition("column_si", SqlType::SmallInt(i16::min_value()))
+                    ),
+                    (
+                        ConstraintError::OutOfRange,
+                        column_definition("column_i", SqlType::Integer(i32::min_value()))
+                    )
+                ],
+                1
+            ))
         )
     }
 
@@ -508,16 +520,19 @@ mod constraints {
                 )
                 .expect("no system errors"),
             // we should only get the errors from the first row.
-            Err(OperationOnTableError::ConstraintViolations(vec![
-                (
-                    ConstraintError::OutOfRange,
-                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
-                ),
-                (
-                    ConstraintError::OutOfRange,
-                    column_definition("column_i", SqlType::Integer(i32::min_value()))
-                ),
-            ]))
+            Err(OperationOnTableError::ConstraintViolations(
+                vec![
+                    (
+                        ConstraintError::OutOfRange,
+                        column_definition("column_si", SqlType::SmallInt(i16::min_value()))
+                    ),
+                    (
+                        ConstraintError::OutOfRange,
+                        column_definition("column_i", SqlType::Integer(i32::min_value()))
+                    ),
+                ],
+                1
+            ))
         )
     }
 }

--- a/src/storage/src/frontend/tests/queries/update.rs
+++ b/src/storage/src/frontend/tests/queries/update.rs
@@ -155,10 +155,13 @@ mod constraints {
                     ]
                 )
                 .expect("no system errors"),
-            Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::OutOfRange,
-                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
-            )]))
+            Err(OperationOnTableError::ConstraintViolations(
+                vec![(
+                    ConstraintError::OutOfRange,
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
+                )],
+                1
+            ))
         );
     }
 
@@ -185,10 +188,13 @@ mod constraints {
                     ]
                 )
                 .expect("no system errors"),
-            Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::TypeMismatch("abc".to_owned()),
-                column_definition("column_si", SqlType::SmallInt(i16::min_value()))
-            )]))
+            Err(OperationOnTableError::ConstraintViolations(
+                vec![(
+                    ConstraintError::TypeMismatch("abc".to_owned()),
+                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
+                )],
+                1
+            ))
         );
     }
 
@@ -214,10 +220,13 @@ mod constraints {
                     ]
                 )
                 .expect("no system errors"),
-            Err(OperationOnTableError::ConstraintViolations(vec![(
-                ConstraintError::ValueTooLong(10),
-                column_definition("column_c", SqlType::Char(10))
-            )]))
+            Err(OperationOnTableError::ConstraintViolations(
+                vec![(
+                    ConstraintError::ValueTooLong(10),
+                    column_definition("column_c", SqlType::Char(10))
+                )],
+                1
+            ))
         );
     }
 
@@ -245,16 +254,19 @@ mod constraints {
                     ]
                 )
                 .expect("no system errors"),
-            Err(OperationOnTableError::ConstraintViolations(vec![
-                (
-                    ConstraintError::OutOfRange,
-                    column_definition("column_si", SqlType::SmallInt(i16::min_value()))
-                ),
-                (
-                    ConstraintError::OutOfRange,
-                    column_definition("column_i", SqlType::Integer(i32::min_value()))
-                )
-            ]))
+            Err(OperationOnTableError::ConstraintViolations(
+                vec![
+                    (
+                        ConstraintError::OutOfRange,
+                        column_definition("column_si", SqlType::SmallInt(i16::min_value()))
+                    ),
+                    (
+                        ConstraintError::OutOfRange,
+                        column_definition("column_i", SqlType::Integer(i32::min_value()))
+                    )
+                ],
+                1
+            ))
         )
     }
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -48,7 +48,8 @@ pub enum OperationOnTableError {
     InsertTooManyExpressions,
     // Returns non existing columns.
     ColumnDoesNotExist(Vec<String>),
-    ConstraintViolations(Vec<(ConstraintError, ColumnDefinition)>),
+    // Returns vector of (error, column) and a row index.
+    ConstraintViolations(Vec<(ConstraintError, ColumnDefinition)>, usize),
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Closes #154 

#### Description
Improved constrained violation error messages by returning `row_index` and `column_name` back to customer.

Example or error message:

```
smallint is out of range for column 'col1' at row 1
```
```
invalid input syntax for type smallint for column 'col1' at row 1: \"abc\"
```
```
value too long for type character for column 'col1' at row 1 (5)
```

#### Client output

e.g. for `psql`

```
psql (12.1, server 0.0.0)
Type "help" for help.

tolledo=> create schema SMOKE_TYPES;
CREATE SCHEMA
tolledo=> create table SMOKE_TYPES.NUMERIC_TYPES
tolledo-> (
tolledo(>     column_small_int        smallint,
tolledo(>     column_integer          integer,
tolledo(>     column_big_int          bigint
tolledo(> );
CREATE TABLE
tolledo=> insert into SMOKE_TYPES.NUMERIC_TYPES
tolledo-> values (-32768, -2147483648, -9223372036854775808);
INSERT 0 1
tolledo=> insert into SMOKE_TYPES.NUMERIC_TYPES
values (32768, -2147483648, -9223372036854775808);
ERROR:  smallint is out of range for column 'column_small_int' at row 1
```

