### PR TITLE
Implement abstract Channel for both TCP and TLS

### DIFF
--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -13,32 +13,87 @@
 // limitations under the License.
 
 use crate::query_listener::SmolQueryListener;
-use protocol::{listener::Secure, QueryListener};
-use std::env;
+use protocol::{listener::ProtocolConfiguration, Command, QueryListener};
+use smol::Task;
+use sql_engine::Handler;
+use std::{
+    env,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc, Mutex,
+    },
+};
+use storage::{backend::SledBackendStorage, frontend::FrontendStorage};
 
 const PORT: usize = 5432;
 const HOST: &str = "0.0.0.0";
 
+pub const RUNNING: u8 = 0;
+pub const STOPPED: u8 = 1;
+
 pub fn start() {
-    let local_address = format!("{}:{}", HOST, PORT);
-    log::debug!("Starting server on {}", local_address);
-
     smol::run(async {
-        let secure = match env::var("SECURE") {
-            Ok(s) => match s.to_lowercase().as_str() {
-                "ssl_only" => Secure::ssl_only(),
-                "gssenc_only" => Secure::gssenc_only(),
-                "both" => Secure::both(),
-                _ => Secure::none(),
-            },
-            _ => Secure::none(),
-        };
+        let local_address = format!("{}:{}", HOST, PORT);
+        log::debug!("Starting server on {}", local_address);
 
-        let listener = SmolQueryListener::bind(local_address, secure)
+        let listener = SmolQueryListener::bind(local_address, protocol_configuration())
             .await
             .expect("open server connection");
 
-        log::debug!("start server");
-        listener.start().await.unwrap().unwrap();
+        let state = Arc::new(AtomicU8::new(RUNNING));
+        let storage: Arc<Mutex<FrontendStorage<SledBackendStorage>>> =
+            Arc::new(Mutex::new(FrontendStorage::default().unwrap()));
+
+        while let Ok(mut connection) = listener.accept().await.expect("no io errors") {
+            if state.load(Ordering::SeqCst) == STOPPED {
+                return;
+            }
+
+            let state = state.clone();
+            let storage = storage.clone();
+            Task::spawn(async move {
+                let mut sql_handler = Handler::new(storage.clone());
+                log::debug!("ready to handle query");
+
+                loop {
+                    match connection.receive().await {
+                        Err(e) => {
+                            log::error!("UNEXPECTED ERROR: {:?}", e);
+                            state.store(STOPPED, Ordering::SeqCst);
+                            return;
+                        }
+                        Ok(Err(e)) => {
+                            log::error!("UNEXPECTED ERROR: {:?}", e);
+                            state.store(STOPPED, Ordering::SeqCst);
+                            return;
+                        }
+                        Ok(Ok(Command::Terminate)) => {
+                            log::debug!("Closing connection with client");
+                            break;
+                        }
+                        Ok(Ok(Command::Query(sql_query))) => {
+                            let response = sql_handler.execute(sql_query.as_str()).expect("no system error");
+                            match connection.send(response).await {
+                                Ok(()) => {}
+                                Err(error) => eprintln!("{:?}", error), // break Err(SystemError::io(error)),
+                            }
+                        }
+                    }
+                }
+            })
+            .detach();
+        }
     });
+}
+
+fn protocol_configuration() -> ProtocolConfiguration {
+    match env::var("SECURE") {
+        Ok(s) => match s.to_lowercase().as_str() {
+            "ssl_only" => ProtocolConfiguration::ssl_only(),
+            "gssenc_only" => ProtocolConfiguration::gssenc_only(),
+            "both" => ProtocolConfiguration::both(),
+            _ => ProtocolConfiguration::none(),
+        },
+        _ => ProtocolConfiguration::none(),
+    }
 }

--- a/src/protocol/src/messages.rs
+++ b/src/protocol/src/messages.rs
@@ -15,30 +15,32 @@
 use crate::ColumnMetadata;
 use bytes::{Buf, BufMut, BytesMut};
 
-// const PARSE_COMPLETE: u8 = b'1';
-// const BIND_COMPLETE: u8 = b'2';
-// const CLOSE_COMPLETE: u8 = b'3';
-// const NOTIFICATION_RESPONSE: u8 = b'A';
-// const COPY_DONE: u8 = b'c';
 const COMMAND_COMPLETE: u8 = b'C';
-// const COPY_DATA: u8 = b'd';
 const DATA_ROW: u8 = b'D';
 const ERROR_RESPONSE: u8 = b'E';
 const SEVERITY: u8 = b'S';
 const CODE: u8 = b'C';
 const MESSAGE: u8 = b'M';
-// const COPY_IN_RESPONSE: u8 = b'G';
-// const COPY_OUT_RESPONSE: u8 = b'H';
 const EMPTY_QUERY_RESPONSE: u8 = b'I';
-// const BACKEND_KEY_DATA: u8 = b'K';
-// const NO_DATA: u8 = b'n';
 const NOTICE_RESPONSE: u8 = b'N';
 const AUTHENTICATION: u8 = b'R';
-// const PORTAL_SUSPENDED: u8 = b's';
 const PARAMETER_STATUS: u8 = b'S';
-// const PARAMETER_DESCRIPTION: u8 = b't';
 const ROW_DESCRIPTION: u8 = b'T';
 const READY_FOR_QUERY: u8 = b'Z';
+
+pub(crate) enum Encryption {
+    AcceptSsl,
+    RejectSsl,
+}
+
+impl Into<&'_ [u8]> for Encryption {
+    fn into(self) -> &'static [u8] {
+        match self {
+            Self::AcceptSsl => &[b'S'],
+            Self::RejectSsl => &[b'N'],
+        }
+    }
+}
 
 /// Backend PostgreSQL Wire Protocol messages
 /// see https://www.postgresql.org/docs/12/protocol-flow.html


### PR DESCRIPTION
Closes #172 

#### Description

1. Adds abstract Trait `Channel` for both TCP and TLS streams.

1. Moves major Server associating code from `protocol` to `node`.

1. Deletes `QueryListener` method `handle_connection`. Since the connection returns from `accept` to `node`. (We will think about and implement callback function `handle_command` later).

1. Improves some code based on PR #171 and #175 .
