### PR TITLE
migrate create and drop schema to QueryProcessor

### DIFF
--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -15,7 +15,7 @@
 use crate::query_listener::SmolQueryListener;
 use protocol::{listener::ProtocolConfiguration, Command, QueryListener};
 use smol::Task;
-use sql_engine::Handler;
+use sql_engine::QueryExecutor;
 use std::{
     env,
     sync::{
@@ -52,7 +52,7 @@ pub fn start() {
             let state = state.clone();
             let storage = storage.clone();
             Task::spawn(async move {
-                let mut sql_handler = Handler::new(storage.clone());
+                let mut sql_handler = QueryExecutor::new(storage.clone());
                 log::debug!("ready to handle query");
 
                 loop {

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -21,11 +21,12 @@ mod tests;
 
 use crate::messages::Message;
 use byteorder::{ByteOrder, NetworkEndian};
-use futures_util::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+use futures_util::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use std::{
+    io,
+    pin::Pin,
     task::{Context, Poll},
 };
-use std::{io, pin::Pin};
 
 use crate::results::QueryResult;
 pub use listener::{QueryListener, ServerListener};

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -25,10 +25,11 @@ use crate::{
 use kernel::SystemResult;
 use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
 
-use crate::query::plan::Plan;
-use crate::query::plan::PlanError;
-use crate::query::transform::QueryProcessor;
-use crate::query::TransformError;
+use crate::query::{
+    plan::{Plan, PlanError},
+    transform::QueryProcessor,
+    TransformError,
+};
 use sqlparser::{
     ast::{ObjectType, Statement},
     dialect::PostgreSqlDialect,
@@ -50,7 +51,7 @@ impl<P: BackendStorage> QueryExecutor<P> {
     pub fn new(storage: Arc<Mutex<FrontendStorage<P>>>) -> Self {
         Self {
             storage: storage.clone(),
-            processor: QueryProcessor::new(storage.clone()),
+            processor: QueryProcessor::new(storage),
         }
     }
 

--- a/src/sql_engine/src/query/mod.rs
+++ b/src/sql_engine/src/query/mod.rs
@@ -1,0 +1,47 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///! Module for representing how a query will be executed and values represented
+///! during runtime.
+pub mod plan;
+pub mod transform;
+
+use crate::query::plan::PlanError;
+use sqlparser::ast::Statement;
+
+/// represents a schema uniquely
+///
+/// this would be a u32
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct SchemaId(String);
+
+impl SchemaId {
+    pub fn name(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Debug)]
+pub enum TransformError {
+    SyntaxError(String),
+    PlanError(PlanError),
+    NotProcessed(Statement), // This is temporary WA to handle processed and unprocessed statements
+                             // ExprError(ExprError), ??
+}
+
+impl From<PlanError> for TransformError {
+    fn from(other: PlanError) -> TransformError {
+        TransformError::PlanError(other)
+    }
+}

--- a/src/sql_engine/src/query/plan.rs
+++ b/src/sql_engine/src/query/plan.rs
@@ -1,0 +1,33 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///! represents a plan to be executed by the engine.
+use crate::query::SchemaId;
+
+#[derive(Debug)]
+pub enum PlanError {
+    SchemaAlreadyExists(String),
+    InvalidSchema(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct SchemaCreationInfo {
+    pub schema_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum Plan {
+    CreateSchema(SchemaCreationInfo),
+    DropSchemas(Vec<SchemaId>),
+}

--- a/src/sql_engine/src/query/transform.rs
+++ b/src/sql_engine/src/query/transform.rs
@@ -1,0 +1,83 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///! Module for transforming the input Query AST into representation the engine can proecess.
+use crate::query::plan::SchemaCreationInfo;
+use crate::query::plan::{Plan, PlanError};
+use crate::query::{SchemaId, TransformError};
+use sqlparser::ast::{ObjectName, ObjectType, Statement};
+use std::sync::{Arc, Mutex};
+use storage::backend::BackendStorage;
+use storage::frontend::FrontendStorage;
+
+type Result<T> = ::std::result::Result<T, TransformError>;
+
+/// structure for maintaining state while transforming the input statement.
+pub struct QueryProcessor<B: BackendStorage> {
+    /// access to table and schema information.
+    storage: Arc<Mutex<FrontendStorage<B>>>,
+}
+
+fn schema_from_object(object: &ObjectName) -> Result<SchemaId> {
+    if object.0.len() != 1 {
+        Err(TransformError::SyntaxError(format!(
+            "only unqualified schema names are supported, '{}'",
+            object.to_string()
+        )))
+    } else {
+        let schema_name = object.to_string();
+        Ok(SchemaId(schema_name))
+    }
+}
+
+impl<B: BackendStorage> QueryProcessor<B> {
+    pub fn new(storage: Arc<Mutex<FrontendStorage<B>>>) -> Self {
+        Self { storage }
+    }
+
+    pub fn process(&mut self, stmt: Statement) -> Result<Plan> {
+        match stmt {
+            Statement::CreateSchema { schema_name, .. } => {
+                let schema_id = schema_from_object(&schema_name)?;
+                if (self.storage.lock().unwrap()).schema_exists(schema_id.name()) {
+                    Err(TransformError::from(PlanError::SchemaAlreadyExists(
+                        schema_id.name().to_string(),
+                    )))
+                } else {
+                    Ok(Plan::CreateSchema(SchemaCreationInfo {
+                        schema_name: schema_id.name().to_string(),
+                    }))
+                }
+            }
+            Statement::Drop {
+                object_type: ObjectType::Schema,
+                names,
+                ..
+            } => {
+                let mut schema_names = Vec::with_capacity(names.len());
+                for name in names {
+                    let schema_id = schema_from_object(&name)?;
+                    if !(self.storage.lock().unwrap()).schema_exists(schema_id.name()) {
+                        return Err(TransformError::from(PlanError::InvalidSchema(
+                            schema_id.name().to_string(),
+                        )));
+                    }
+                    schema_names.push(schema_id);
+                }
+                Ok(Plan::DropSchemas(schema_names))
+            }
+            other => Err(TransformError::NotProcessed(other)),
+        }
+    }
+}

--- a/src/sql_engine/src/query/transform.rs
+++ b/src/sql_engine/src/query/transform.rs
@@ -14,12 +14,13 @@
 
 ///! Module for transforming the input Query AST into representation the engine can proecess.
 use crate::query::plan::SchemaCreationInfo;
-use crate::query::plan::{Plan, PlanError};
-use crate::query::{SchemaId, TransformError};
+use crate::query::{
+    plan::{Plan, PlanError},
+    SchemaId, TransformError,
+};
 use sqlparser::ast::{ObjectName, ObjectType, Statement};
 use std::sync::{Arc, Mutex};
-use storage::backend::BackendStorage;
-use storage::frontend::FrontendStorage;
+use storage::{backend::BackendStorage, frontend::FrontendStorage};
 
 type Result<T> = ::std::result::Result<T, TransformError>;
 

--- a/src/sql_engine/src/tests/in_memory_backend_storage.rs
+++ b/src/sql_engine/src/tests/in_memory_backend_storage.rs
@@ -68,6 +68,10 @@ impl BackendStorage for InMemoryStorage {
         }
     }
 
+    fn is_schema_exists(&self, namespace: &str) -> bool {
+        self.namespaces.contains_key(namespace)
+    }
+
     fn drop_namespace(&mut self, namespace: &str) -> SystemResult<Result<(), NamespaceDoesNotExist>> {
         match self.namespaces.remove(namespace) {
             Some(_namespace) => Ok(Ok(())),

--- a/src/sql_engine/src/tests/mod.rs
+++ b/src/sql_engine/src/tests/mod.rs
@@ -30,7 +30,7 @@ mod type_constraints;
 mod update;
 
 use super::*;
-use crate::Handler;
+use crate::QueryExecutor;
 use in_memory_backend_storage::InMemoryStorage;
 use std::sync::{Arc, Mutex};
 use storage::frontend::FrontendStorage;
@@ -39,11 +39,11 @@ fn in_memory_storage() -> Arc<Mutex<FrontendStorage<InMemoryStorage>>> {
     Arc::new(Mutex::new(FrontendStorage::new(InMemoryStorage::default()).unwrap()))
 }
 
-type InMemorySqlEngine = Handler<InMemoryStorage>;
+type InMemorySqlEngine = QueryExecutor<InMemoryStorage>;
 
 #[rstest::fixture]
 fn sql_engine() -> InMemorySqlEngine {
-    Handler::new(in_memory_storage())
+    QueryExecutor::new(in_memory_storage())
 }
 
 #[rstest::fixture]

--- a/src/sql_engine/src/tests/schema.rs
+++ b/src/sql_engine/src/tests/schema.rs
@@ -15,6 +15,16 @@
 use super::*;
 
 #[rstest::rstest]
+fn create_schema(mut sql_engine: InMemorySqlEngine) {
+    assert_eq!(
+        sql_engine
+            .execute("create schema schema_name;")
+            .expect("no system errors"),
+        Ok(QueryEvent::SchemaCreated)
+    )
+}
+
+#[rstest::rstest]
 fn create_same_schema(mut sql_engine: InMemorySqlEngine) {
     sql_engine
         .execute("create schema schema_name;")

--- a/src/storage/src/backend.rs
+++ b/src/storage/src/backend.rs
@@ -55,6 +55,8 @@ pub trait BackendStorage {
 
     fn create_namespace(&mut self, namespace: &str) -> SystemResult<Result<(), NamespaceAlreadyExists>>;
 
+    fn is_schema_exists(&self, namespace: &str) -> bool;
+
     fn drop_namespace(&mut self, namespace: &str) -> SystemResult<Result<(), NamespaceDoesNotExist>>;
 
     fn create_object(&mut self, namespace: &str, object_name: &str) -> SystemResult<Result<(), CreateObjectError>>;
@@ -162,6 +164,10 @@ impl BackendStorage for SledBackendStorage {
         } else {
             self.new_namespace(namespace).map(|_| Ok(()))
         }
+    }
+
+    fn is_schema_exists(&self, namespace: &str) -> bool {
+        self.namespaces.contains_key(namespace)
     }
 
     fn drop_namespace(&mut self, namespace: &str) -> SystemResult<Result<(), NamespaceDoesNotExist>> {

--- a/src/storage/src/frontend/mod.rs
+++ b/src/storage/src/frontend/mod.rs
@@ -77,6 +77,10 @@ impl<P: BackendStorage> FrontendStorage<P> {
         }
     }
 
+    pub fn schema_exists(&self, schema_name: &str) -> bool {
+        self.persistent.is_schema_exists(schema_name)
+    }
+
     pub fn drop_schema(&mut self, schema_name: &str) -> SystemResult<Result<(), SchemaDoesNotExist>> {
         match self.persistent.drop_namespace(schema_name)? {
             Ok(()) => Ok(Ok(())),


### PR DESCRIPTION
No issue to close

#### Description
extracts `QueryProcessor` from #183 (there it called `QueryTransform`)
changes `create schema` and `drop schema` queries to use new `QueryProcessor`

#### Client output
no changes to output
