### PR TITLE
Migrate to Table Insert to QueryProcessor

### DIFF
--- a/src/sql_engine/src/dml/insert.rs
+++ b/src/sql_engine/src/dml/insert.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::query::TableInserts;
 use crate::dml::ExpressionEvaluation;
 use kernel::SystemResult;
 use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
@@ -22,146 +23,24 @@ use storage::{backend::BackendStorage, frontend::FrontendStorage, ColumnDefiniti
 
 pub(crate) struct InsertCommand<'q, P: BackendStorage> {
     raw_sql_query: &'q str,
-    name: ObjectName,
-    columns: Vec<Ident>,
-    source: Box<Query>,
+    table_inserts: TableInserts,
     storage: Arc<Mutex<FrontendStorage<P>>>,
 }
 
 impl<P: BackendStorage> InsertCommand<'_, P> {
     pub(crate) fn new(
         raw_sql_query: &'_ str,
-        name: ObjectName,
-        columns: Vec<Ident>,
-        source: Box<Query>,
+        table_inserts: TableInserts,
         storage: Arc<Mutex<FrontendStorage<P>>>,
     ) -> InsertCommand<P> {
         InsertCommand {
             raw_sql_query,
-            name,
-            columns,
-            source,
+            table_inserts,
             storage,
         }
     }
 
     pub(crate) fn execute(&mut self) -> SystemResult<QueryResult> {
-        let table_name = self.name.0.pop().unwrap().to_string();
-        let schema_name = self.name.0.pop().unwrap().to_string();
-        let Query { body, .. } = &*self.source;
-        if let SetExpr::Values(values) = &body {
-            let values = &values.0;
-
-            let columns = if self.columns.is_empty() {
-                vec![]
-            } else {
-                self.columns
-                    .clone()
-                    .into_iter()
-                    .map(|id| {
-                        let sqlparser::ast::Ident { value, .. } = id;
-                        value
-                    })
-                    .collect()
-            };
-
-            let mut rows = vec![];
-            for line in values {
-                let mut row = vec![];
-                for col in line {
-                    let v = match col {
-                        Expr::Value(Value::Number(v)) => v.to_string(),
-                        Expr::Value(Value::SingleQuotedString(v)) => v.to_string(),
-                        Expr::Value(Value::Boolean(v)) => v.to_string(),
-                        Expr::Cast { expr, data_type } => match (&**expr, data_type) {
-                            (Expr::Value(Value::Boolean(v)), DataType::Boolean) => v.to_string(),
-                            (Expr::Value(Value::SingleQuotedString(v)), DataType::Boolean) => v.to_string(),
-                            _ => {
-                                return Ok(Err(QueryErrorBuilder::new()
-                                    .syntax_error(format!(
-                                        "Cast from {:?} to {:?} is not currently supported",
-                                        expr, data_type
-                                    ))
-                                    .build()))
-                            }
-                        },
-                        Expr::UnaryOp { op, expr } => match (op, &**expr) {
-                            (UnaryOperator::Minus, Expr::Value(Value::Number(v))) => {
-                                "-".to_owned() + v.to_string().as_str()
-                            }
-                            (op, expr) => {
-                                return Ok(Err(QueryErrorBuilder::new()
-                                    .syntax_error(op.to_string() + expr.to_string().as_str())
-                                    .build()))
-                            }
-                        },
-                        expr @ Expr::BinaryOp { .. } => match ExpressionEvaluation::eval(expr) {
-                            Ok(expr_result) => expr_result.value(),
-                            Err(e) => return Ok(Err(e)),
-                        },
-                        expr => return Ok(Err(QueryErrorBuilder::new().syntax_error(expr.to_string()).build())),
-                    };
-                    row.push(v);
-                }
-                rows.push(row);
-            }
-
-            let len = rows.len();
-            match (self.storage.lock().unwrap()).insert_into(&schema_name, &table_name, columns, rows)? {
-                Ok(_) => Ok(Ok(QueryEvent::RecordsInserted(len))),
-                Err(OperationOnTableError::SchemaDoesNotExist) => {
-                    Ok(Err(QueryErrorBuilder::new().schema_does_not_exist(schema_name).build()))
-                }
-                Err(OperationOnTableError::TableDoesNotExist) => Ok(Err(QueryErrorBuilder::new()
-                    .table_does_not_exist(schema_name + "." + table_name.as_str())
-                    .build())),
-                Err(OperationOnTableError::ColumnDoesNotExist(non_existing_columns)) => {
-                    Ok(Err(QueryErrorBuilder::new()
-                        .column_does_not_exist(non_existing_columns)
-                        .build()))
-                }
-                Err(OperationOnTableError::ConstraintViolations(constraint_errors, row_index)) => {
-                    let mut builder = QueryErrorBuilder::new();
-                    let mut constraint_error_mapper =
-                        |err: &ConstraintError, column_definition: &ColumnDefinition, row_index: usize| match err {
-                            ConstraintError::OutOfRange => {
-                                builder.out_of_range(
-                                    column_definition.sql_type().to_pg_types(),
-                                    column_definition.name(),
-                                    row_index,
-                                );
-                            }
-                            ConstraintError::TypeMismatch(value) => {
-                                builder.type_mismatch(
-                                    value,
-                                    column_definition.sql_type().to_pg_types(),
-                                    column_definition.name(),
-                                    row_index,
-                                );
-                            }
-                            ConstraintError::ValueTooLong(len) => {
-                                builder.string_length_mismatch(
-                                    column_definition.sql_type().to_pg_types(),
-                                    *len,
-                                    column_definition.name(),
-                                    row_index,
-                                );
-                            }
-                        };
-
-                    constraint_errors.iter().for_each(|(err, column_definition)| {
-                        constraint_error_mapper(err, column_definition, row_index)
-                    });
-                    Ok(Err(builder.build()))
-                }
-                Err(OperationOnTableError::InsertTooManyExpressions) => {
-                    Ok(Err(QueryErrorBuilder::new().too_many_insert_expressions().build()))
-                }
-            }
-        } else {
-            Ok(Err(QueryErrorBuilder::new()
-                .feature_not_supported(self.raw_sql_query.to_owned())
-                .build()))
-        }
+        todo!()
     }
 }

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -26,10 +26,19 @@ use crate::{
 use kernel::SystemResult;
 use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
 
+use crate::query::{
+    plan::{Plan, PlanError},
+    QueryProcessor, TransformError,
+};
+use sqlparser::{
+    ast::{ObjectType, Statement},
+    dialect::PostgreSqlDialect,
+    parser::Parser,
+};
 use crate::query::{Plan, PlanError, QueryProcessor, TransformError};
 use sqlparser::{ast::Statement, dialect::PostgreSqlDialect, parser::Parser};
 use std::sync::{Arc, Mutex};
-use storage::{backend::BackendStorage, frontend::FrontendStorage};
+use storage::{backend::BackendStorage, frontend::FrontendStorage, ColumnDefinition, TableDescription};
 
 mod ddl;
 mod dml;

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -26,17 +26,12 @@ use crate::{
 use kernel::SystemResult;
 use protocol::results::{QueryErrorBuilder, QueryEvent, QueryResult};
 
-use crate::query::{
-    plan::{Plan, PlanError},
-    QueryProcessor, TransformError,
-};
+use crate::query::{Plan, PlanError, QueryProcessor, TransformError};
 use sqlparser::{
     ast::{ObjectType, Statement},
     dialect::PostgreSqlDialect,
     parser::Parser,
 };
-use crate::query::{Plan, PlanError, QueryProcessor, TransformError};
-use sqlparser::{ast::Statement, dialect::PostgreSqlDialect, parser::Parser};
 use std::sync::{Arc, Mutex};
 use storage::{backend::BackendStorage, frontend::FrontendStorage, ColumnDefinition, TableDescription};
 

--- a/src/sql_engine/src/query/expr.rs
+++ b/src/sql_engine/src/query/expr.rs
@@ -87,10 +87,10 @@ pub fn resolve_static_expr<'a>(expr: &'a Expr) -> Result<Datum<'a>, EvalError> {
 }
 
 // precondition: lhs and rhs must reduced to Expr::Value otherwise, the original expression will be returned.
-pub fn resolve_binary_expr<'a>(_op: BinaryOperator, _lhs: Datum<'a>, rhs: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    Err(EvalError::UnsupportedOperation)
-}
+// pub fn resolve_binary_expr(_op: BinaryOperator, _lhs: Datum, _rhs: Datum) -> Result<Datum, EvalError> {
+//     Err(EvalError::UnsupportedOperation)
+// }
 
-pub fn resolve_unary_expr<'a>(_op: UnaryOperator, _operand: Datum<'a>) -> Result<Datum<'a>, EvalError> {
-    Err(EvalError::UnsupportedOperation)
-}
+// pub fn resolve_unary_expr(_op: UnaryOperator, _operand: Datum) -> Result<Datum, EvalError> {
+//     Err(EvalError::UnsupportedOperation)
+// }

--- a/src/sql_engine/src/query/expr.rs
+++ b/src/sql_engine/src/query/expr.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::query::repr::Datum;
-use sqlparser::ast::{Value, Expr, BinaryOperator, UnaryOperator};
+use sqlparser::ast::{BinaryOperator, Expr, UnaryOperator, Value};
 use std::convert::TryFrom;
 
 #[derive(Debug, Clone)]

--- a/src/sql_engine/src/query/mod.rs
+++ b/src/sql_engine/src/query/mod.rs
@@ -14,10 +14,22 @@
 
 ///! Module for representing how a query will be executed and values represented
 ///! during runtime.
+mod expr;
 mod plan;
+mod relation;
+mod repr;
+mod scalar;
 mod transform;
 
 pub use plan::{Plan, PlanError, SchemaCreationInfo, TableCreationInfo};
+pub use transform::QueryProcessor;
+
+use sql_types::SqlType;
+use expr::{resolve_static_expr, EvalError};
+pub use plan::{Plan, PlanError};
+pub use relation::{RelationError, RelationOp};
+pub use repr::{Datum, Row};
+pub use scalar::ScalarOp;
 pub use transform::QueryProcessor;
 
 use sql_types::SqlType;
@@ -32,6 +44,41 @@ pub struct ColumnType {
     sql_type: SqlType,
 }
 
+impl ColumnType {
+    pub fn new(sql_type: SqlType) -> Self {
+        Self {
+            nullable: false,
+            sql_type,
+        }
+    }
+
+    pub fn typ(&self) -> SqlType {
+        self.sql_type
+    }
+}
+
+/// relation (table) type
+/// A relation type is just the types of the columns.
+/// Materialize uses this same concept.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelationType {
+    /// the types of the columns in the specified order.
+    column_types: Vec<ColumnType>,
+    // Materialized also has a Vec<Vec<usize>> to represent the indices
+    // available for this table but I do not know how that is going to work
+    // in this database so I am leaving it out.
+}
+
+impl RelationType {
+    pub fn new(column_types: Vec<ColumnType>) -> Self {
+        Self { column_types }
+    }
+
+    pub fn columns(&self) -> &[ColumnType] {
+        self.column_types.as_slice()
+    }
+}
+
 // this works for now, but ideally this should be usize's instead of strings.
 
 /// represents a table uniquly
@@ -42,6 +89,10 @@ pub struct ColumnType {
 pub struct TableId(SchemaId, String);
 
 impl TableId {
+    pub fn new(schema: SchemaId, table_name: String) -> Self {
+        Self(schema, table_name)
+    }
+
     pub fn schema_name(&self) -> &str {
         self.0.name()
     }
@@ -58,6 +109,10 @@ impl TableId {
 pub struct SchemaId(String);
 
 impl SchemaId {
+    pub fn new(schema_name: String) -> Self {
+        Self(schema_name)
+    }
+
     pub fn name(&self) -> &str {
         self.0.as_str()
     }
@@ -68,6 +123,8 @@ pub enum TransformError {
     UnimplementedFeature(String),
     SyntaxError(String),
     PlanError(PlanError),
+    RelationError(RelationError),
+    EvalError(EvalError),
     NotProcessed(Statement),
 }
 
@@ -76,3 +133,18 @@ impl From<PlanError> for TransformError {
         TransformError::PlanError(other)
     }
 }
+
+impl From<RelationError> for TransformError {
+    fn from(other: RelationError) -> TransformError {
+        TransformError::RelationError(other)
+    }
+}
+
+impl From<EvalError> for TransformError {
+    fn from(other: EvalError) -> TransformError {
+        TransformError::EvalError(other)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/sql_engine/src/query/mod.rs
+++ b/src/sql_engine/src/query/mod.rs
@@ -21,16 +21,14 @@ mod repr;
 mod scalar;
 mod transform;
 
-pub use plan::{Plan, PlanError, SchemaCreationInfo, TableCreationInfo};
+use expr::resolve_static_expr;
+use expr::EvalError;
+pub use plan::{Plan, PlanError, SchemaCreationInfo, TableCreationInfo, TableInserts};
 pub use transform::QueryProcessor;
 
-use sql_types::SqlType;
-use expr::{resolve_static_expr, EvalError};
-pub use plan::{Plan, PlanError};
 pub use relation::{RelationError, RelationOp};
 pub use repr::{Datum, Row};
 pub use scalar::ScalarOp;
-pub use transform::QueryProcessor;
 
 use sql_types::SqlType;
 use sqlparser::ast::Statement;

--- a/src/sql_engine/src/query/plan.rs
+++ b/src/sql_engine/src/query/plan.rs
@@ -1,3 +1,5 @@
+// Copyright 2020 Alex Dukhno
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -10,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{SchemaId, TableId};
+use super::{relation::RelationOp, ScalarOp, SchemaId, TableId};
 ///! represents a plan to be executed by the engine.
 use storage::ColumnDefinition;
 
@@ -35,9 +37,18 @@ pub struct SchemaCreationInfo {
 }
 
 #[derive(Debug, Clone)]
+pub struct TableInserts {
+    pub table_id: TableId,
+    pub column_indices: Vec<ScalarOp>,
+    pub input: Box<RelationOp>,
+}
+
+#[derive(Debug, Clone)]
 pub enum Plan {
     CreateTable(TableCreationInfo),
     CreateSchema(SchemaCreationInfo),
     DropTables(Vec<TableId>),
     DropSchemas(Vec<SchemaId>),
+    InsertRows(TableInserts),
+    // Query(Box<RelationOp>),
 }

--- a/src/sql_engine/src/query/transform.rs
+++ b/src/sql_engine/src/query/transform.rs
@@ -1,3 +1,5 @@
+// Copyright 2020 Alex Dukhno
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,13 +16,19 @@ use super::{
     plan::{Plan, PlanError, SchemaCreationInfo, TableCreationInfo},
     SchemaId, TableId, TransformError,
 };
+use super::{
+    plan::{SchemaCreationInfo, TableCreationInfo, TableInserts},
+    resolve_static_expr, Datum, Plan, PlanError, RelationError, RelationOp, RelationType, Row, ScalarOp, SchemaId,
+    TableId, TransformError,
+};
 ///! Module for transforming the input Query AST into representation the engine can proecess.
 use sql_types::SqlType;
 use sqlparser::ast::*;
 use std::sync::{Arc, Mutex, MutexGuard};
-use storage::{backend::BackendStorage, frontend::FrontendStorage, ColumnDefinition};
+use storage::{
+    backend::BackendStorage, frontend::FrontendStorage, ColumnDefinition, OperationOnTableError, TableDescription,
+};
 
-// I do not know what the error type is yet.
 type Result<T> = ::std::result::Result<T, TransformError>;
 
 // this could probably just be a function.
@@ -118,7 +126,17 @@ impl<B: BackendStorage> QueryProcessor<B> {
                 }
             }
             Statement::Drop { object_type, names, .. } => self.handle_drop(object_type, names),
-            _ => Err(TransformError::NotProcessed(stmt.clone())),
+            Statement::Insert {
+                table_name,
+                columns,
+                source,
+                ..
+            } => self.handle_insert(table_name, columns, source),
+            Statement::Query(query) => {
+                let op = self.handle_query(query.as_ref())?;
+                Ok(Plan::Query(Box::new(op)))
+            }
+            other _ => Err(TransformError::NotProcessed(other)),
         }
     }
 
@@ -140,10 +158,9 @@ impl<B: BackendStorage> QueryProcessor<B> {
         if !self.storage().schema_exists(schema_name) {
             Err(TransformError::from(PlanError::InvalidSchema(schema_name.to_string())))
         } else if self.storage().table_exists(schema_name, table_name) {
-            Err(TransformError::from(PlanError::TableAlreadyExists(format!(
-                "{}.{}",
-                schema_name, table_name
-            ))))
+            Err(TransformError::from(PlanError::TableAlreadyExists(
+                table_name.to_string(),
+            )))
         } else {
             let columns = self.resolve_column_definitions(columns)?;
             let table_info = TableCreationInfo {
@@ -168,10 +185,7 @@ impl<B: BackendStorage> QueryProcessor<B> {
                     if !self.storage().schema_exists(schema_name) {
                         return Err(TransformError::from(PlanError::InvalidSchema(schema_name.to_string())));
                     } else if !self.storage().table_exists(schema_name, table_name) {
-                        return Err(TransformError::from(PlanError::InvalidTable(format!(
-                            "{}.{}",
-                            schema_name, table_name
-                        ))));
+                        return Err(TransformError::from(PlanError::InvalidTable(table_name.to_string())));
                     } else {
                         table_names.push(table_id);
                     }
@@ -194,5 +208,151 @@ impl<B: BackendStorage> QueryProcessor<B> {
             }
             _ => unimplemented!(),
         }
+    }
+
+    fn handle_insert(&mut self, name: &ObjectName, columns: &[Ident], source: &Query) -> Result<Plan> {
+        let table_name = table_from_object(name)?;
+        let query_op = self.handle_query(source)?;
+
+        let table_descriptor = self
+            .storage()
+            .table_descriptor(table_name.schema_name(), table_name.name())
+            .unwrap()
+            .map_err(|e| match e {
+                OperationOnTableError::SchemaDoesNotExist => {
+                    TransformError::from(PlanError::InvalidSchema(table_name.schema_name().to_string()))
+                }
+                OperationOnTableError::TableDoesNotExist => {
+                    TransformError::from(PlanError::InvalidTable(table_name.name().to_string()))
+                }
+                _ => unreachable!(),
+            })?;
+
+        let column_info = table_descriptor.column_data();
+
+        let column_indices = if !columns.is_empty() {
+            let mut column_indices = Vec::with_capacity(columns.len());
+            for column in columns {
+                if let Some((idx, _)) = column_info
+                    .iter()
+                    .enumerate()
+                    .find(|(_, column_def)| column_def.name() == column.value)
+                {
+                    column_indices.push(ScalarOp::Column(idx));
+                } else {
+                    return Err(TransformError::from(RelationError::InvalidColumnName {
+                        column: column.value.clone(),
+                        table: table_descriptor.full_name(),
+                    }));
+                }
+            }
+            column_indices
+        } else {
+            (0..table_descriptor.column_len())
+                .into_iter()
+                .map(|i| ScalarOp::Column(i))
+                .collect::<Vec<ScalarOp>>()
+        };
+
+        // @TODO: check type compatability between the resulting relation type and the actual type of the columns
+        // the relation type are different then SqlType because the relation might be the result
+        // of a join or some other operation.
+        //
+        //let relation_type = query_op.typ(); // maybe this returns an Option
+        //relation_type.compatable(table_descriptor) or something like this?
+        // - Andrew Bregger
+
+        let table_insert = TableInserts {
+            table_id: table_name,
+            column_indices,
+            input: Box::new(query_op),
+        };
+
+        Ok(Plan::InsertRows(table_insert))
+    }
+
+    fn handle_query(&mut self, query: &Query) -> Result<RelationOp> {
+        let Query {
+            body,
+            ..
+            // order_by,
+            // limit,
+            // ctes,
+            // offset,
+            // fetch
+        } = query;
+        let relation_op = self.handle_set_expr(&body)?;
+
+        Ok(relation_op)
+    }
+
+    fn handle_set_expr(&mut self, expr: &SetExpr) -> Result<RelationOp> {
+        match expr {
+            SetExpr::Select(select) => self.handle_select(select),
+            SetExpr::Query(query) => self.handle_query(query),
+            SetExpr::Values(values) => self.handle_values(values),
+            e => Err(TransformError::UnimplementedFeature(format!("{:?}", e))),
+        }
+    }
+    fn handle_select(&mut self, select: &Select) -> Result<RelationOp> {
+        let Select {
+            distinct: _,
+            top: _,
+            projection: _,
+            from,
+            selection: _,
+            group_by: _,
+            having: _,
+        } = select;
+        // this implementation is naive.
+
+        // 1. resolve the from clause to know the resulting relation of the selection (from clause) push down predicates when possible.
+        let _from_clause = self.handle_from_clause(from.as_slice())?;
+        // 2. resolve remaining predicates.
+        // 3. resolve any groupby clauses
+        // 4. resolve having
+        // 5. resolve projection
+
+        Err(TransformError::UnimplementedFeature(
+            "select clauses are not implemented".to_string(),
+        ))
+    }
+
+    fn handle_values(&self, values: &Values) -> Result<RelationOp> {
+        let mut rows = Vec::new();
+        for expr_row in values.0.iter() {
+            let mut row = Vec::new();
+            for expr in expr_row {
+                let datum = resolve_static_expr(&expr).map_err(|e| TransformError::from(e))?;
+                row.push(datum);
+            }
+            rows.push(Row::pack(&row));
+        }
+        Ok(RelationOp::Constants(rows))
+    }
+
+    fn handle_from_clause(&mut self, from: &[TableWithJoins]) -> Result<RelationOp> {
+        // for now only handle when there is one table
+        if from.len() == 1 {
+            let TableWithJoins { relation, joins: _ } = from.first().unwrap();
+            let _table_info = self.resolve_table_factor(relation)?;
+            unimplemented!()
+        } else {
+            // cartician product.
+            Err(TransformError::UnimplementedFeature(
+                "multiple table in the from clause are not implemented".to_string(),
+            ))
+        }
+    }
+
+    fn resolve_table_factor(&self, relation: &TableFactor) -> Result<RelationType> {
+        match relation {
+            TableFactor::Table { name: _, .. } => {
+                // let table_info = self.frontend_storage.table_descriptor();
+            }
+            TableFactor::Derived { .. } => {}
+            TableFactor::NestedJoin(_table) => {}
+        }
+        unimplemented!()
     }
 }

--- a/src/sql_engine/src/query/transform.rs
+++ b/src/sql_engine/src/query/transform.rs
@@ -13,13 +13,8 @@
 // limitations under the License.
 
 use super::{
-    plan::{Plan, PlanError, SchemaCreationInfo, TableCreationInfo},
-    SchemaId, TableId, TransformError,
-};
-use super::{
-    plan::{SchemaCreationInfo, TableCreationInfo, TableInserts},
-    resolve_static_expr, Datum, Plan, PlanError, RelationError, RelationOp, RelationType, Row, ScalarOp, SchemaId,
-    TableId, TransformError,
+    resolve_static_expr, Datum, Plan, PlanError, RelationError, RelationOp, RelationType, Row, ScalarOp,
+    SchemaCreationInfo, SchemaId, TableCreationInfo, TableId, TableInserts, TransformError,
 };
 ///! Module for transforming the input Query AST into representation the engine can proecess.
 use sql_types::SqlType;
@@ -132,11 +127,11 @@ impl<B: BackendStorage> QueryProcessor<B> {
                 source,
                 ..
             } => self.handle_insert(table_name, columns, source),
-            Statement::Query(query) => {
-                let op = self.handle_query(query.as_ref())?;
-                Ok(Plan::Query(Box::new(op)))
-            }
-            other _ => Err(TransformError::NotProcessed(other)),
+            // Statement::Query(query) => {
+            //     let op = self.handle_query(query.as_ref())?;
+            //     Ok(Plan::Query(Box::new(op)))
+            // }
+            other => Err(TransformError::NotProcessed(other.clone())),
         }
     }
 


### PR DESCRIPTION
Closes #188 

#### Description
Migrates Insert commands to use `QueryProcessor`.

Introduced types:
1. EvalError, an error that can occur during evaluation (i.e. numeric overflow)
2. RelationError, error within relation operations (i.e. invalid column name)
3. Datum, A single value of a database, can be used borrowed memory for strings
4. Row, a packed list for Datums, each value is tagged by the type.
5 TableInserts, the information needed to inserted values into a table.

I am creating a draft for feedback. This PR defines the initial ideas for how table data will be processed by other operators. Any initial thoughts or concerns could be addressed now with further discussion when full select (select *) is implemented.

#### Client output
will add output once it works.

