### PR TITLE
SQL API for system tables (#114)

### DIFF
--- a/src/sql_types/src/lib.rs
+++ b/src/sql_types/src/lib.rs
@@ -15,6 +15,7 @@
 use protocol::sql_types::PostgreSqlType;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
+use std::fmt;
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum SqlType {
@@ -33,6 +34,28 @@ pub enum SqlType {
     TimestampWithTimeZone,
     Date,
     Interval,
+}
+
+impl fmt::Display for SqlType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SqlType::Bool => write!(f, "BOOL"),
+            SqlType::Char(s) => write!(f, "CHAR ({})", s),
+            SqlType::VarChar(s) => write!(f, "VARCHAR ({})", s),
+            SqlType::Decimal => write!(f, "DECIMAL"),
+            SqlType::SmallInt(_) => write!(f, "SMALLINT"),
+            SqlType::Integer(_) => write!(f, "INT"),
+            SqlType::BigInt(_) => write!(f, "BIGINT"),
+            SqlType::Real => write!(f, "REAL"),
+            SqlType::DoublePrecision => write!(f, "DOUBLE"),
+            SqlType::Time => write!(f, "TIME"),
+            SqlType::TimeWithTimeZone => write!(f, "TIME_WITH_TIMEZONE"),
+            SqlType::Timestamp => write!(f, "TIMESTAMP"),
+            SqlType::TimestampWithTimeZone => write!(f, "TIMESTAMP_WITH_TIMEZONE"),
+            SqlType::Date => write!(f, "DATE"),
+            SqlType::Interval => write!(f, "INTERVAL"),
+        }
+    }
 }
 
 impl SqlType {

--- a/src/storage/src/frontend/mod.rs
+++ b/src/storage/src/frontend/mod.rs
@@ -159,9 +159,7 @@ impl<P: BackendStorage> FrontendStorage<P> {
 
                         (schema, table, column, sql_type)
                     })
-                    .filter(|(schema, table, _, _)| {
-                        *schema == schema_name.to_string() && *table == table_name.to_string()
-                    })
+                    .filter(|(schema, table, _, _)| schema.as_str() == schema_name && table.as_str() == table_name)
                     .map(|(_, _, column, sql_type)| ColumnDefinition::new(column.as_str(), sql_type))
                     .collect::<Vec<_>>()
             })


### PR DESCRIPTION
Closes #114 

#### Description
Implemented the ability to query the 'system.columns' table to get a list of columns.

#### Client output

```
vkulichenko=> create schema schema_name;
CREATE SCHEMA
vkulichenko=> create table schema_name.table_name (col_1 smallint, col_2 integer, col_3 bigint);
CREATE TABLE
vkulichenko=> create schema schema_name;
ERROR:  schema "schema_name" already exists
vkulichenko=> select * from system.columns;
 schema_name | table_name | column_name | column_type 
-------------+------------+-------------+-------------
 schema_name | table_name | col_1       | SMALLINT
 schema_name | table_name | col_2       | INT
 schema_name | table_name | col_3       | BIGINT
(3 rows)
```

