### PR TITLE
almost working updates is left, I hope

### DIFF
--- a/src/sql_engine/src/query/mod.rs
+++ b/src/sql_engine/src/query/mod.rs
@@ -14,7 +14,7 @@
 
 ///! Module for representing how a query will be executed and values represented
 ///! during runtime.
-mod expr;
+pub mod expr;
 mod plan;
 mod relation;
 mod repr;

--- a/src/sql_engine/src/query/repr.rs
+++ b/src/sql_engine/src/query/repr.rs
@@ -302,7 +302,7 @@ impl Row {
         Self { data }
     }
 
-    pub fn unpack<'a>(&'a self) -> Vec<Datum<'a>> {
+    pub fn unpack(&self) -> Vec<Datum> {
         let mut index = 0;
         let mut res = Vec::new();
         let data = self.data.as_slice();

--- a/src/sql_engine/src/query/tests.rs
+++ b/src/sql_engine/src/query/tests.rs
@@ -24,7 +24,6 @@ mod scalar {
     // }
 
     #[test]
-    #[ignore]
     fn row_packing_single() {
         let datums = vec![Datum::from_bool(true)];
         let row = Row::pack(&datums);
@@ -32,7 +31,6 @@ mod scalar {
     }
 
     #[test]
-    #[ignore]
     fn row_packing_multiple() {
         let datums = vec![Datum::from_bool(true), Datum::from_i32(100000)];
         let row = Row::pack(&datums);
@@ -40,12 +38,11 @@ mod scalar {
     }
 
     #[test]
-    #[ignore]
     fn row_packing_with_floats() {
         let datums = vec![
             Datum::from_bool(false),
             Datum::from_i32(100000),
-            Datum::from_f64(100.134_212_309_847),
+            Datum::from_f32(100.134_21),
         ];
         let row = Row::pack(&datums);
         assert_eq!(
@@ -55,7 +52,6 @@ mod scalar {
     }
 
     #[test]
-    #[ignore]
     fn row_packing_with_null() {
         let datums = vec![Datum::from_bool(true), Datum::from_null(), Datum::from_i32(100000)];
         let row = Row::pack(&datums);
@@ -63,7 +59,6 @@ mod scalar {
     }
 
     #[test]
-    #[ignore]
     fn row_packing_string() {
         let datums = vec![Datum::from_bool(true), Datum::from_str("hello")];
         let row = Row::pack(&datums);
@@ -76,7 +71,6 @@ mod scalar {
     }
 
     #[test]
-    #[ignore]
     fn row_unpacking_single() {
         let datums = vec![Datum::from_bool(true)];
         let row = Row::pack(&datums);
@@ -84,7 +78,6 @@ mod scalar {
     }
 
     #[test]
-    #[ignore]
     fn row_unpacking_multiple() {
         let datums = vec![Datum::from_bool(true), Datum::from_i32(100000)];
         let row = Row::pack(&datums);
@@ -92,7 +85,6 @@ mod scalar {
     }
 
     #[test]
-    #[ignore]
     fn row_unpacking_with_floats() {
         let datums = vec![
             Datum::from_bool(false),
@@ -104,7 +96,6 @@ mod scalar {
     }
 
     #[test]
-    #[ignore]
     fn row_unpacking_with_null() {
         let datums = vec![Datum::from_bool(true), Datum::from_null(), Datum::from_i32(100000)];
         let row = Row::pack(&datums);
@@ -112,7 +103,6 @@ mod scalar {
     }
 
     #[test]
-    #[ignore]
     fn row_unpacking_string() {
         let datums = vec![Datum::from_bool(true), Datum::from_str("hello")];
         let row = Row::pack(&datums);

--- a/src/sql_engine/src/query/transform.rs
+++ b/src/sql_engine/src/query/transform.rs
@@ -266,7 +266,7 @@ impl<'qp, B: BackendStorage> QueryProcessor<B> {
             Err(OperationOnTableError::SchemaDoesNotExist) => {
                 self.session
                     .send(Err(QueryErrorBuilder::new()
-                        .table_already_exists(table_name.schema_name().to_string())
+                        .schema_does_not_exist(table_name.schema_name().to_string())
                         .build()))
                     .expect("To Send Result to Client");
                 return Err(());
@@ -309,7 +309,7 @@ impl<'qp, B: BackendStorage> QueryProcessor<B> {
                 .collect::<Vec<ScalarOp>>()
         };
 
-        // @TODO: check type compatability between the resulting relation type and the actual type of the columns
+        // @TODO: check type compatibility between the resulting relation type and the actual type of the columns
         // the relation type are different then SqlType because the relation might be the result
         // of a join or some other operation.
         //

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -192,10 +192,7 @@ fn insert_and_select_different_integer_types(sql_engine_with_schema: (QueryExecu
     collector.assert_content(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
-        Err(QueryErrorBuilder::new()
-            .feature_not_supported("UnsupportedOperation".to_owned())
-            .build()),
-        // Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::RecordsInserted(1)),
         Ok(QueryEvent::RecordsInserted(1)),
         Ok(QueryEvent::RecordsSelected((
             vec![
@@ -205,12 +202,12 @@ fn insert_and_select_different_integer_types(sql_engine_with_schema: (QueryExecu
                 ("column_serial".to_owned(), PostgreSqlType::Integer),
             ],
             vec![
-                // vec![
-                //     "-32768".to_owned(),
-                //     "-2147483648".to_owned(),
-                //     "-9223372036854775808".to_owned(),
-                //     "1".to_owned(),
-                // ],
+                vec![
+                    "-32768".to_owned(),
+                    "-2147483648".to_owned(),
+                    "-9223372036854775808".to_owned(),
+                    "1".to_owned(),
+                ],
                 vec![
                     "32767".to_owned(),
                     "2147483647".to_owned(),

--- a/src/sql_engine/src/tests/schema.rs
+++ b/src/sql_engine/src/tests/schema.rs
@@ -82,7 +82,6 @@ fn select_named_columns_from_nonexistent_schema(sql_engine: (QueryExecutor<InMem
 }
 
 #[rstest::rstest]
-#[ignore]
 fn insert_into_table_in_nonexistent_schema(sql_engine: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
     let (mut engine, collector) = sql_engine;
     engine

--- a/src/sql_engine/src/tests/select.rs
+++ b/src/sql_engine/src/tests/select.rs
@@ -78,7 +78,6 @@ fn select_all_from_table_with_multiple_columns(
 }
 
 #[rstest::rstest]
-#[ignore]
 fn select_not_all_columns(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
     let (mut engine, collector) = sql_engine_with_schema;
     engine

--- a/src/sql_engine/src/tests/table.rs
+++ b/src/sql_engine/src/tests/table.rs
@@ -14,164 +14,164 @@
 
 use super::*;
 
-// #[cfg(test)]
-// mod schemaless {
-//     use super::*;
-//
-//     #[rstest::rstest]
-//     fn create_table_in_non_existent_schema(sql_engine: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//         let (mut engine, collector) = sql_engine;
-//
-//         engine
-//             .execute("create table schema_name.table_name (column_name smallint);")
-//             .expect("no system errors");
-//
-//         collector.assert_content(vec![Err(QueryErrorBuilder::new()
-//             .schema_does_not_exist("schema_name".to_owned())
-//             .build())]);
-//     }
-//
-//     #[rstest::rstest]
-//     fn drop_table_from_non_existent_schema(sql_engine: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//         let (mut engine, collector) = sql_engine;
-//         engine
-//             .execute("drop table schema_name.table_name;")
-//             .expect("no system errors");
-//
-//         collector.assert_content(vec![Err(QueryErrorBuilder::new()
-//             .schema_does_not_exist("schema_name".to_owned())
-//             .build())]);
-//     }
-// }
-//
-// #[rstest::rstest]
-// fn create_table(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//     let (mut engine, collector) = sql_engine_with_schema;
-//
-//     engine
-//         .execute("create table schema_name.table_name (column_name smallint);")
-//         .expect("no system errors");
-//
-//     collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
-// }
-//
-// #[rstest::rstest]
-// fn create_same_table(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//     let (mut engine, collector) = sql_engine_with_schema;
-//     engine
-//         .execute("create table schema_name.table_name (column_name smallint);")
-//         .expect("no system errors");
-//     engine
-//         .execute("create table schema_name.table_name (column_name smallint);")
-//         .expect("no system errors");
-//
-//     collector.assert_content(vec![
-//         Ok(QueryEvent::SchemaCreated),
-//         Ok(QueryEvent::TableCreated),
-//         Err(QueryErrorBuilder::new()
-//             .table_already_exists("schema_name.table_name".to_owned())
-//             .build()),
-//     ]);
-// }
-//
-// #[rstest::rstest]
-// fn drop_table(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//     let (mut engine, collector) = sql_engine_with_schema;
-//     engine
-//         .execute("create table schema_name.table_name (column_name smallint);")
-//         .expect("no system errors");
-//     engine
-//         .execute("drop table schema_name.table_name;")
-//         .expect("no system errors");
-//     engine
-//         .execute("create table schema_name.table_name (column_name smallint);")
-//         .expect("no system errors");
-//
-//     collector.assert_content(vec![
-//         Ok(QueryEvent::SchemaCreated),
-//         Ok(QueryEvent::TableCreated),
-//         Ok(QueryEvent::TableDropped),
-//         Ok(QueryEvent::TableCreated),
-//     ]);
-// }
-//
-// #[rstest::rstest]
-// fn drop_non_existent_table(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//     let (mut engine, collector) = sql_engine_with_schema;
-//     engine
-//         .execute("drop table schema_name.table_name;")
-//         .expect("no system errors");
-//
-//     collector.assert_content(vec![
-//         Ok(QueryEvent::SchemaCreated),
-//         Err(QueryErrorBuilder::new()
-//             .table_does_not_exist("schema_name.table_name".to_owned())
-//             .build()),
-//     ]);
-// }
-//
-// #[cfg(test)]
-// mod different_types {
-//     use super::*;
-//
-//     #[rstest::rstest]
-//     fn ints(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//         let (mut engine, collector) = sql_engine_with_schema;
-//         engine
-//             .execute(
-//                 "create table schema_name.table_name (\
-//             column_si smallint,\
-//             column_i integer,\
-//             column_bi bigint
-//             );",
-//             )
-//             .expect("no system errors");
-//
-//         collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
-//     }
-//
-//     #[rstest::rstest]
-//     fn strings(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//         let (mut engine, collector) = sql_engine_with_schema;
-//         engine
-//             .execute(
-//                 "create table schema_name.table_name (\
-//             column_c char(10),\
-//             column_vc varchar(10)\
-//             );",
-//             )
-//             .expect("no system errors");
-//
-//         collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
-//     }
-//
-//     #[rstest::rstest]
-//     fn boolean(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//         let (mut engine, collector) = sql_engine_with_schema;
-//         engine
-//             .execute(
-//                 "create table schema_name.table_name (\
-//             column_b boolean\
-//             );",
-//             )
-//             .expect("no system errors");
-//
-//         collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
-//     }
-//
-//     #[rstest::rstest]
-//     fn serials(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//         let (mut engine, collector) = sql_engine_with_schema;
-//         engine
-//             .execute(
-//                 "create table schema_name.table_name (\
-//             column_smalls smallserial,\
-//             column_s serial,\
-//             column_bigs bigserial\
-//             );",
-//             )
-//             .expect("no system errors");
-//
-//         collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
-//     }
-// }
+#[cfg(test)]
+mod schemaless {
+    use super::*;
+
+    #[rstest::rstest]
+    fn create_table_in_non_existent_schema(sql_engine: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+        let (mut engine, collector) = sql_engine;
+
+        engine
+            .execute("create table schema_name.table_name (column_name smallint);")
+            .expect("no system errors");
+
+        collector.assert_content(vec![Err(QueryErrorBuilder::new()
+            .schema_does_not_exist("schema_name".to_owned())
+            .build())]);
+    }
+
+    #[rstest::rstest]
+    fn drop_table_from_non_existent_schema(sql_engine: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+        let (mut engine, collector) = sql_engine;
+        engine
+            .execute("drop table schema_name.table_name;")
+            .expect("no system errors");
+
+        collector.assert_content(vec![Err(QueryErrorBuilder::new()
+            .schema_does_not_exist("schema_name".to_owned())
+            .build())]);
+    }
+}
+
+#[rstest::rstest]
+fn create_table(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+
+    engine
+        .execute("create table schema_name.table_name (column_name smallint);")
+        .expect("no system errors");
+
+    collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+}
+
+#[rstest::rstest]
+fn create_same_table(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .execute("create table schema_name.table_name (column_name smallint);")
+        .expect("no system errors");
+    engine
+        .execute("create table schema_name.table_name (column_name smallint);")
+        .expect("no system errors");
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::TableCreated),
+        Err(QueryErrorBuilder::new()
+            .table_already_exists("schema_name.table_name".to_owned())
+            .build()),
+    ]);
+}
+
+#[rstest::rstest]
+fn drop_table(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .execute("create table schema_name.table_name (column_name smallint);")
+        .expect("no system errors");
+    engine
+        .execute("drop table schema_name.table_name;")
+        .expect("no system errors");
+    engine
+        .execute("create table schema_name.table_name (column_name smallint);")
+        .expect("no system errors");
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::TableDropped),
+        Ok(QueryEvent::TableCreated),
+    ]);
+}
+
+#[rstest::rstest]
+fn drop_non_existent_table(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .execute("drop table schema_name.table_name;")
+        .expect("no system errors");
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Err(QueryErrorBuilder::new()
+            .table_does_not_exist("schema_name.table_name".to_owned())
+            .build()),
+    ]);
+}
+
+#[cfg(test)]
+mod different_types {
+    use super::*;
+
+    #[rstest::rstest]
+    fn ints(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+        let (mut engine, collector) = sql_engine_with_schema;
+        engine
+            .execute(
+                "create table schema_name.table_name (\
+            column_si smallint,\
+            column_i integer,\
+            column_bi bigint
+            );",
+            )
+            .expect("no system errors");
+
+        collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+    }
+
+    #[rstest::rstest]
+    fn strings(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+        let (mut engine, collector) = sql_engine_with_schema;
+        engine
+            .execute(
+                "create table schema_name.table_name (\
+            column_c char(10),\
+            column_vc varchar(10)\
+            );",
+            )
+            .expect("no system errors");
+
+        collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+    }
+
+    #[rstest::rstest]
+    fn boolean(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+        let (mut engine, collector) = sql_engine_with_schema;
+        engine
+            .execute(
+                "create table schema_name.table_name (\
+            column_b boolean\
+            );",
+            )
+            .expect("no system errors");
+
+        collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+    }
+
+    #[rstest::rstest]
+    fn serials(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+        let (mut engine, collector) = sql_engine_with_schema;
+        engine
+            .execute(
+                "create table schema_name.table_name (\
+            column_smalls smallserial,\
+            column_s serial,\
+            column_bigs bigserial\
+            );",
+            )
+            .expect("no system errors");
+
+        collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+    }
+}

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -39,6 +39,7 @@ fn str_table(
     (engine, collector)
 }
 
+// TODO should be fixed by https://github.com/alex-dukhno/database/issues/202
 #[cfg(test)]
 mod insert {
     use super::*;

--- a/src/sql_engine/src/tests/update.rs
+++ b/src/sql_engine/src/tests/update.rs
@@ -15,46 +15,45 @@
 use super::*;
 use protocol::sql_types::PostgreSqlType;
 
-// #[rstest::rstest]
-// #[ignore]
-// fn update_all_records(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
-//     let (mut engine, collector) = sql_engine_with_schema;
-//     engine
-//         .execute("create table schema_name.table_name (column_test smallint);")
-//         .expect("no system errors");
-//     engine
-//         .execute("insert into schema_name.table_name values (123);")
-//         .expect("no system errors");
-//     engine
-//         .execute("insert into schema_name.table_name values (456);")
-//         .expect("no system errors");
-//     engine
-//         .execute("select * from schema_name.table_name;")
-//         .expect("no system errors");
-//     engine
-//         .execute("update schema_name.table_name set column_test=789;")
-//         .expect("no system errors");
-//     engine
-//         .execute("select * from schema_name.table_name;")
-//         .expect("no system errors");
-//
-//     collector.assert_content(vec![
-//         Ok(QueryEvent::SchemaCreated),
-//         Ok(QueryEvent::TableCreated),
-//         Ok(QueryEvent::RecordsInserted(1)),
-//         Ok(QueryEvent::RecordsInserted(1)),
-//         Ok(QueryEvent::RecordsSelected((
-//             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
-//             vec![vec!["123".to_owned()], vec!["456".to_owned()]],
-//         ))),
-//         Ok(QueryEvent::RecordsUpdated(2)),
-//         Ok(QueryEvent::RecordsSelected((
-//             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
-//             vec![vec!["789".to_owned()], vec!["789".to_owned()]],
-//         ))),
-//     ]);
-// }
-//
+#[rstest::rstest]
+fn update_all_records(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .execute("create table schema_name.table_name (column_test smallint);")
+        .expect("no system errors");
+    engine
+        .execute("insert into schema_name.table_name values (123);")
+        .expect("no system errors");
+    engine
+        .execute("insert into schema_name.table_name values (456);")
+        .expect("no system errors");
+    engine
+        .execute("select * from schema_name.table_name;")
+        .expect("no system errors");
+    engine
+        .execute("update schema_name.table_name set column_test=789;")
+        .expect("no system errors");
+    engine
+        .execute("select * from schema_name.table_name;")
+        .expect("no system errors");
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::RecordsSelected((
+            vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
+            vec![vec!["123".to_owned()], vec!["456".to_owned()]],
+        ))),
+        Ok(QueryEvent::RecordsUpdated(2)),
+        Ok(QueryEvent::RecordsSelected((
+            vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
+            vec![vec!["789".to_owned()], vec!["789".to_owned()]],
+        ))),
+    ]);
+}
+
 // #[rstest::rstest]
 // #[ignore]
 // fn update_single_column_of_all_records(sql_engine_with_schema: (QueryExecutor<InMemoryStorage>, Arc<Collector>)) {

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -122,7 +122,7 @@ impl ColumnDefinition {
         self.sql_type
     }
 
-    fn has_name(&self, other_name: &str) -> bool {
+    pub fn has_name(&self, other_name: &str) -> bool {
         self.name == other_name
     }
 


### PR DESCRIPTION
I as I wrote in https://github.com/alex-dukhno/database/pull/199#issuecomment-663103117
this PR is targeting `migrate-insert` branch not master.

As I can see I was able to resurrect most of cases the following is left:
 * [ ] updates corrupt data in the storage. All of them, except single one, are commented out (I think if this one passes then most of them should too)
 * [ ] type constraint validations. I think what we can do is to split #202 in multiple tasks and move constraints per operation (insert and update)
 * [ ] evaluating expression in insert and updates. I don't know what to do with that, for now I think it could be implemented in scope of merging `migrate-insert` into `master` branch 