### PR TITLE
simplistic insert migration to query processor

### DIFF
--- a/src/representation/src/lib.rs
+++ b/src/representation/src/lib.rs
@@ -274,7 +274,7 @@ fn read_tag(data: &[u8], idx: &mut usize) -> TypeTag {
 /// in-memory representation of a table row. It is unable to deserialize
 /// the row without knowing the types of each column, which makes this unsafe
 /// however it is more memory efficient.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, PartialOrd, Ord)]
 pub struct Binary(Vec<u8>);
 
 impl Binary {
@@ -283,8 +283,8 @@ impl Binary {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_bytes(self) -> Vec<u8> {
-        self.0
+    pub fn to_bytes(&self) -> &[u8] {
+        self.0.as_slice()
     }
 
     pub fn with_data(data: Vec<u8>) -> Self {

--- a/src/sql_engine/src/dml/select.rs
+++ b/src/sql_engine/src/dml/select.rs
@@ -94,7 +94,7 @@ impl<'sc, P: BackendStorage> SelectCommand<'sc, P> {
                 }
                 columns
             };
-            let data = (self.storage.lock().unwrap()).select_all_from(&schema_name, &table_name)?;
+            let data = (self.storage.lock().unwrap()).table_scan(&schema_name, &table_name)?;
             match data {
                 Ok(records) => {
                     let all_columns = (self.storage.lock().unwrap()).table_columns(&schema_name, &table_name)?;
@@ -144,21 +144,6 @@ impl<'sc, P: BackendStorage> SelectCommand<'sc, P> {
                             values.into_iter().map(|(_, value)| value).collect()
                         })
                         .collect();
-
-                    // let values = records
-                    //     .into_iter()
-                    //     .map(|bytes| {
-                    //         let mut values = vec![];
-                    //         for (i, (origin, ord)) in column_indexes.iter().enumerate() {
-                    //             for (index, value) in bytes.split(|b| *b == b'|').enumerate() {
-                    //                 if index == *origin {
-                    //                     values.push((ord, description[i].sql_type().serializer().des(value)))
-                    //                 }
-                    //             }
-                    //         }
-                    //         values.into_iter().map(|(_, value)| value).collect()
-                    //     })
-                    //     .collect();
 
                     let projection = (
                         description

--- a/src/sql_engine/src/dml/update.rs
+++ b/src/sql_engine/src/dml/update.rs
@@ -197,11 +197,11 @@ impl<'uc, P: BackendStorage> UpdateCommand<'uc, P> {
             .expect("no system errors")
             .map(backend::Result::unwrap)
             .map(|(key, values)| {
-                let mut datums = unpack_raw(values.as_slice());
+                let mut datums = unpack_raw(values.to_bytes());
                 for (idx, data) in index_value_pairs.as_slice() {
                     datums[*idx] = data.clone();
                 }
-                (key, Binary::pack(&datums).to_bytes())
+                (key, Binary::pack(&datums))
             })
             .collect();
 

--- a/src/sql_engine/src/query/mod.rs
+++ b/src/sql_engine/src/query/mod.rs
@@ -15,20 +15,19 @@
 ///! Module for representing how a query will be executed and values represented
 ///! during runtime.
 pub mod plan;
-pub mod transform;
+pub mod process;
 
 use sql_types::SqlType;
+use sqlparser::ast::ObjectName;
+use std::convert::TryFrom;
 
 /// A type of a column
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnType {
     #[allow(dead_code)]
     nullable: bool,
-    /// the sql type
     sql_type: SqlType,
 }
-
-// this works for now, but ideally this should be usize's instead of strings.
 
 /// represents a table uniquely
 ///
@@ -47,6 +46,30 @@ impl TableId {
     }
 }
 
+impl TryFrom<ObjectName> for TableId {
+    type Error = TableNamingError;
+
+    fn try_from(object: ObjectName) -> Result<Self, Self::Error> {
+        if object.0.len() == 1 {
+            Err(TableNamingError(format!(
+                "unsupported table name '{}'. All table names must be qualified",
+                object.to_string()
+            )))
+        } else if object.0.len() != 2 {
+            Err(TableNamingError(format!(
+                "unable to process table name '{}'",
+                object.to_string()
+            )))
+        } else {
+            let table_name = object.0.last().unwrap().value.clone();
+            let schema_name = object.0.first().unwrap().value.clone();
+            Ok(TableId(SchemaId(schema_name), table_name))
+        }
+    }
+}
+
+pub struct TableNamingError(String);
+
 /// represents a schema uniquely
 ///
 /// this would be a u32
@@ -58,3 +81,20 @@ impl SchemaId {
         self.0.as_str()
     }
 }
+
+impl TryFrom<ObjectName> for SchemaId {
+    type Error = SchemaNamingError;
+
+    fn try_from(object: ObjectName) -> Result<Self, Self::Error> {
+        if object.0.len() != 1 {
+            Err(SchemaNamingError(format!(
+                "only unqualified schema names are supported, '{}'",
+                object
+            )))
+        } else {
+            Ok(SchemaId(object.to_string()))
+        }
+    }
+}
+
+pub struct SchemaNamingError(String);

--- a/src/sql_engine/src/query/plan.rs
+++ b/src/sql_engine/src/query/plan.rs
@@ -14,7 +14,7 @@
 
 ///! represents a plan to be executed by the engine.
 use crate::query::{SchemaId, TableId};
-use sqlparser::ast::Statement;
+use sqlparser::ast::{Ident, Query, Statement};
 use storage::ColumnDefinition;
 
 #[derive(Debug, Clone)]
@@ -30,10 +30,18 @@ pub struct SchemaCreationInfo {
 }
 
 #[derive(Debug, Clone)]
+pub struct TableInserts {
+    pub table_id: TableId,
+    pub column_indices: Vec<Ident>,
+    pub input: Box<Query>,
+}
+
+#[derive(Debug, Clone)]
 pub enum Plan {
     CreateTable(TableCreationInfo),
     CreateSchema(SchemaCreationInfo),
     DropTables(Vec<TableId>),
     DropSchemas(Vec<SchemaId>),
+    Insert(TableInserts),
     NotProcessed(Statement),
 }

--- a/src/sql_engine/src/tests/in_memory_backend_storage.rs
+++ b/src/sql_engine/src/tests/in_memory_backend_storage.rs
@@ -191,6 +191,7 @@ impl BackendStorage for InMemoryStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use representation::Binary;
 
     type Storage = InMemoryStorage;
 
@@ -624,13 +625,16 @@ mod tests {
                     .map(|s| s.as_bytes().to_vec())
                     .collect::<Vec<_>>()
                     .join(&b'|');
-                (k, v)
+                (Binary::with_data(k), Binary::with_data(v))
             })
             .collect()
     }
 
     fn as_keys(items: Vec<u8>) -> Vec<Key> {
-        items.into_iter().map(|key| key.to_be_bytes().to_vec()).collect()
+        items
+            .into_iter()
+            .map(|key| Binary::with_data(key.to_be_bytes().to_vec()))
+            .collect()
     }
 
     fn as_read_cursor(items: Vec<(u8, Vec<&'static str>)>) -> ReadCursor {
@@ -641,7 +645,7 @@ mod tests {
                 .map(|s| s.as_bytes().to_vec())
                 .collect::<Vec<_>>()
                 .join(&b'|');
-            Ok((k, v))
+            Ok((Binary::with_data(k), Binary::with_data(v)))
         }))
     }
 }

--- a/src/storage/src/frontend/tests/mod.rs
+++ b/src/storage/src/frontend/tests/mod.rs
@@ -81,7 +81,7 @@ fn insert_into<P: backend::BackendStorage>(
                 .map(|(k, v)| {
                     let key = k.to_be_bytes().to_vec();
                     let values = v.into_iter().map(|s| s.as_bytes()).collect::<Vec<_>>().join(&b'|');
-                    (key, values)
+                    (Binary::with_data(key), Binary::with_data(values))
                 })
                 .collect(),
         )

--- a/src/storage/src/frontend/tests/queries/delete.rs
+++ b/src/storage/src/frontend/tests/queries/delete.rs
@@ -75,7 +75,7 @@ fn delete_all_from_table(default_schema_name: &str, mut storage_with_schema: Per
 
     assert_eq!(
         storage_with_schema
-            .select_all_from("schema_name", "table_name")
+            .table_scan("schema_name", "table_name")
             .expect("no system errors"),
         Ok(vec![])
     );

--- a/src/storage/src/frontend/tests/queries/insert.rs
+++ b/src/storage/src/frontend/tests/queries/insert.rs
@@ -21,7 +21,10 @@ fn insert_into_non_existent_schema(mut storage: PersistentStorage) {
             .insert_into(
                 "non_existent",
                 "not_existed",
-                vec![(1usize.to_be_bytes().to_vec(), b"123".to_vec())]
+                vec![(
+                    Binary::with_data(1usize.to_be_bytes().to_vec()),
+                    Binary::with_data(b"123".to_vec())
+                )]
             )
             .expect("no system errors"),
         Err(OperationOnTableError::SchemaDoesNotExist)
@@ -35,7 +38,10 @@ fn insert_into_non_existent_table(default_schema_name: &str, mut storage_with_sc
             .insert_into(
                 default_schema_name,
                 "not_existed",
-                vec![(1usize.to_be_bytes().to_vec(), b"123".to_vec())]
+                vec![(
+                    Binary::with_data(1usize.to_be_bytes().to_vec()),
+                    Binary::with_data(b"123".to_vec())
+                )]
             )
             .expect("no system errors"),
         Err(OperationOnTableError::TableDoesNotExist)

--- a/src/storage/src/frontend/tests/queries/select.rs
+++ b/src/storage/src/frontend/tests/queries/select.rs
@@ -34,7 +34,7 @@ fn with_small_ints_table(default_schema_name: &str, mut storage_with_schema: Per
 fn select_from_table_from_non_existent_schema(mut storage: PersistentStorage) {
     assert_eq!(
         storage
-            .select_all_from("non_existent", "table_name")
+            .table_scan("non_existent", "table_name")
             .expect("no system errors"),
         Err(OperationOnTableError::SchemaDoesNotExist)
     );
@@ -44,7 +44,7 @@ fn select_from_table_from_non_existent_schema(mut storage: PersistentStorage) {
 fn select_from_table_that_does_not_exist(default_schema_name: &str, mut storage_with_schema: PersistentStorage) {
     assert_eq!(
         storage_with_schema
-            .select_all_from(default_schema_name, "not_existed")
+            .table_scan(default_schema_name, "not_existed")
             .expect("no system errors"),
         Err(OperationOnTableError::TableDoesNotExist)
     );
@@ -61,7 +61,7 @@ fn select_all_from_table_with_many_columns(default_schema_name: &str, mut with_s
 
     assert_eq!(
         with_small_ints_table
-            .select_all_from(default_schema_name, "table_name")
+            .table_scan(default_schema_name, "table_name")
             .expect("no system errors"),
         Ok(vec![Binary::with_data(b"1|2|3".to_vec())])
     );


### PR DESCRIPTION
No issue to close. Work done under #188 

#### Description
Simplistic representation of `TableInserts` for `InsertCommand` just to reduce number of parameters to `new()` constructor.
Removes methods from `QueryProcessor` and adds `TryFrom<ObjectName>` implementations for `SchemaId` and `TableId`
change `Row` type alias to `(Binary, Binary)` instead of `(Vec<u8>, Vec<u8>)`

#### Client output
No notable changes

