### PR TITLE
Fix crash for upgrading crate smol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,14 +1036,15 @@ checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "smol"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5845838db1ab989f5ea8390faf8a5607de76b6fa70e4d5faf84780192b723a62"
+checksum = "67583f4ccc13bbb105a0752058d8ad66c47753d85445952809bcaca891954f83"
 dependencies = [
  "async-channel",
  "async-executor",
  "async-io",
  "blocking",
+ "cfg-if",
  "easy-parallel",
  "futures-lite",
  "num_cpus",

--- a/src/node/Cargo.toml
+++ b/src/node/Cargo.toml
@@ -18,7 +18,7 @@ sql_engine = { path = "../sql_engine" }
 sql_types = { path = "../sql_types" }
 storage = { path = "../storage" }
 futures-lite = "0.1.6"
-smol = "0.3.2"
+smol = "0.3.3"
 async-io = "0.1.6"
 protocol = { path = "../protocol" }
 log = "0.4.8"

--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -14,9 +14,8 @@
 
 use async_dup::Arc as AsyncArc;
 use async_io::Async;
-use futures_lite::future::block_on;
 use protocol::{Command, ProtocolConfiguration, Receiver};
-use smol::{self, Task};
+use smol::{self, block_on, Task};
 use sql_engine::QueryExecutor;
 use std::{
     env,


### PR DESCRIPTION
#### Description

The latest code is crashed when running with command `psql -h localhost -W` (after inputting the password).

The cash log is outputted as below.

```
...
     Running `target/debug/database`
thread 'main' panicked at '`Task::spawn()` must be called from an `Executor` or `LocalExecutor`', /rustc/c367798cfd3817ca6ae908ce675d1d99242af148/src/libstd/macros.rs:13:23
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

This crash is caused by upgrading crate `smol` in PR #224 . It works when downgrading to `smol-0.2.0`.
It seems that `smol::Task` must be called in smol `Executor` or `LocalExecutor` from `0.3`.

#### Test

The command `psql -h localhost -W` could work when fixing to use `smol::block_on`.
