### PR TITLE
Decode Frontend Messages

### DIFF
--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -73,6 +73,7 @@ pub fn start() {
                                     state.store(STOPPED, Ordering::SeqCst);
                                     return;
                                 }
+                                Ok(Ok(Command::Continue)) => {}
                                 Ok(Ok(Command::Terminate)) => {
                                     log::debug!("Closing connection with client");
                                     break;

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -17,7 +17,7 @@
 extern crate log;
 
 use crate::{
-    messages::{Encryption, Message},
+    messages::{BackendMessage, Encryption, FrontendMessage},
     results::QueryResult,
 };
 use async_mutex::Mutex as AsyncMutex;
@@ -70,8 +70,12 @@ pub const VERSION_GSSENC: Version = (1234 << 16) + 5680;
 /// `Error` type in protocol `Result`. Indicates that something went not well
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    /// Indicates that incoming query can't be parsed as UTF-8 string
-    QueryIsNotValidUtfString,
+    /// Indicates that incoming data is invalid
+    InvalidInput(String),
+    /// Indicates that incoming data can't be parsed as UTF-8 string
+    InvalidUtfString,
+    /// Indicates that frontend message is not supported
+    UnsupportedFrontendMessage,
     /// Indicates that protocol version is not supported
     UnsupportedVersion,
     /// Indicates that client request is not supported
@@ -83,6 +87,8 @@ pub enum Error {
 /// Result of handling incoming bytes from a client
 #[derive(Debug, PartialEq)]
 pub enum Command {
+    /// Nothing needs to handle on client, just to receive next message
+    Continue,
     /// Client commands to execute a `Query`
     Query(String),
     /// Client commands to terminate current connection
@@ -120,7 +126,7 @@ where
         match decode_startup(message) {
             Ok(ClientHandshake::Startup(version, params)) => {
                 channel
-                    .write_all(Message::AuthenticationCleartextPassword.as_vec().as_slice())
+                    .write_all(BackendMessage::AuthenticationCleartextPassword.as_vec().as_slice())
                     .await?;
                 let mut buffer = [0u8; 1];
                 let tag = channel.read_exact(&mut buffer).await.map(|_| buffer[0]);
@@ -135,11 +141,13 @@ where
                 let mut buffer = Vec::with_capacity(len);
                 buffer.resize(len, b'0');
                 let _message = channel.read_exact(&mut buffer).await.map(|_| buffer)?;
-                channel.write_all(Message::AuthenticationOk.as_vec().as_slice()).await?;
+                channel
+                    .write_all(BackendMessage::AuthenticationOk.as_vec().as_slice())
+                    .await?;
 
                 channel
                     .write_all(
-                        Message::ParameterStatus("client_encoding".to_owned(), "UTF8".to_owned())
+                        BackendMessage::ParameterStatus("client_encoding".to_owned(), "UTF8".to_owned())
                             .as_vec()
                             .as_slice(),
                     )
@@ -147,7 +155,15 @@ where
 
                 channel
                     .write_all(
-                        Message::ParameterStatus("DateStyle".to_owned(), "ISO".to_owned())
+                        BackendMessage::ParameterStatus("DateStyle".to_owned(), "ISO".to_owned())
+                            .as_vec()
+                            .as_slice(),
+                    )
+                    .await?;
+
+                channel
+                    .write_all(
+                        BackendMessage::ParameterStatus("integer_datetimes".to_owned(), "off".to_owned())
                             .as_vec()
                             .as_slice(),
                     )
@@ -235,12 +251,14 @@ impl<RW: AsyncRead + AsyncWrite + Unpin> RequestReceiver<RW> {
 #[async_trait]
 impl<RW: AsyncRead + AsyncWrite + Unpin> Receiver for RequestReceiver<RW> {
     async fn receive(&mut self) -> io::Result<Result<Command>> {
-        log::debug!("send ready for query message");
+        log::debug!("Send ready_for_query message");
         self.channel
             .lock()
             .await
-            .write_all(Message::ReadyForQuery.as_vec().as_slice())
+            .write_all(BackendMessage::ReadyForQuery.as_vec().as_slice())
             .await?;
+
+        // Parses the one-byte tag.
         let mut buffer = [0u8; 1];
         let tag = self
             .channel
@@ -250,33 +268,31 @@ impl<RW: AsyncRead + AsyncWrite + Unpin> Receiver for RequestReceiver<RW> {
             .await
             .map(|_| buffer[0])?;
         log::debug!("tag {:?}", tag);
-        if b'X' == tag {
-            Ok(Ok(Command::Terminate))
-        } else {
-            let mut buffer = [0u8; 4];
-            let len = self
-                .channel
-                .lock()
-                .await
-                .read_exact(&mut buffer)
-                .await
-                .map(|_| NetworkEndian::read_u32(&buffer))?;
-            let mut buffer = Vec::with_capacity(len as usize - 4);
-            buffer.resize(len as usize - 4, b'0');
-            let sql_buff = self
-                .channel
-                .lock()
-                .await
-                .read_exact(&mut buffer)
-                .await
-                .map(|_| buffer)?;
-            log::debug!("FOR TEST sql = {:?}", sql_buff);
-            let sql = match String::from_utf8(sql_buff[..sql_buff.len() - 1].to_vec()) {
-                Ok(sql) => sql,
-                Err(_e) => return Ok(Err(Error::QueryIsNotValidUtfString)),
-            };
-            log::debug!("SQL = {}", sql);
-            Ok(Ok(Command::Query(sql)))
+
+        // Parses the frame length.
+        let mut buffer = [0u8; 4];
+        let len = self
+            .channel
+            .lock()
+            .await
+            .read_exact(&mut buffer)
+            .await
+            .map(|_| NetworkEndian::read_u32(&buffer))?;
+
+        // Parses the frame data.
+        let mut buffer = Vec::with_capacity(len as usize - 4);
+        buffer.resize(len as usize - 4, b'0');
+        self.channel.lock().await.read_exact(&mut buffer).await?;
+
+        let message = match FrontendMessage::decode(tag, &buffer) {
+            Ok(msg) => msg,
+            Err(err) => return Ok(Err(err)),
+        };
+
+        match message {
+            FrontendMessage::Query { sql } => Ok(Ok(Command::Query(sql))),
+            FrontendMessage::Terminate => Ok(Ok(Command::Terminate)),
+            _ => Ok(Ok(Command::Continue)),
         }
     }
 }
@@ -312,7 +328,7 @@ impl<RW: AsyncRead + AsyncWrite + Unpin> ResponseSender<RW> {
 impl<RW: AsyncRead + AsyncWrite + Unpin> Sender for ResponseSender<RW> {
     fn send(&self, query_result: QueryResult) -> io::Result<()> {
         block_on(async {
-            let messages: Vec<Message> = query_result.map_or_else(|event| event.into(), |err| err.into());
+            let messages: Vec<BackendMessage> = query_result.map_or_else(|event| event.into(), |err| err.into());
             for message in messages {
                 log::debug!("{:?}", message);
                 self.channel

--- a/src/protocol/src/messages.rs
+++ b/src/protocol/src/messages.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::{Error, Result};
+
 const COMMAND_COMPLETE: u8 = b'C';
 const DATA_ROW: u8 = b'D';
 const ERROR_RESPONSE: u8 = b'E';
@@ -39,11 +41,135 @@ impl Into<&'_ [u8]> for Encryption {
     }
 }
 
+/// Frontend PostgreSQL Wire Protocol messages
+/// see https://www.postgresql.org/docs/12/protocol-flow.html
+#[derive(Debug, PartialEq)]
+pub enum FrontendMessage {
+    /// Execute the specified SQL.
+    ///
+    /// This is issued as part of the simple query flow.
+    Query {
+        /// The SQL to execute.
+        sql: String,
+    },
+
+    /// Parse the specified SQL into a prepared statement.
+    ///
+    /// This starts the extended query flow.
+    Parse {
+        /// The name of the prepared statement to create. An empty string
+        /// specifies the unnamed prepared statement.
+        statement_name: String,
+        /// The SQL to parse.
+        sql: String,
+    },
+
+    /// Describe an existing prepared statement.
+    ///
+    /// This command is part of the extended query flow.
+    DescribeStatement {
+        /// The name of the prepared statement to describe.
+        name: String,
+    },
+
+    /// Describe an existing portal.
+    ///
+    /// This command is part of the extended query flow.
+    DescribePortal {
+        /// The name of the portal to describe.
+        name: String,
+    },
+
+    /// Bind an existing prepared statement to a portal.
+    ///
+    /// This command is part of the extended query flow.
+    Bind {
+        /// The destination portal. An empty string selects the unnamed
+        /// portal. The portal can later be executed with the `Execute` command.
+        portal_name: String,
+        /// The source prepared statement. An empty string selects the unnamed
+        /// prepared statement.
+        statement_name: String,
+    },
+
+    /// Execute a bound portal.
+    ///
+    /// This command is part of the extended query flow.
+    Execute {
+        /// The name of the portal to execute.
+        portal_name: String,
+    },
+
+    /// Flush any pending output.
+    ///
+    /// This command is part of the extended query flow.
+    Flush,
+
+    /// Finish an extended query.
+    ///
+    /// This command is part of the extended query flow.
+    Sync,
+
+    /// Close the named statement.
+    ///
+    /// This command is part of the extended query flow.
+    CloseStatement {
+        /// The name of the prepared statement to close.
+        name: String,
+    },
+
+    /// Close the named portal.
+    ///
+    /// This command is part of the extended query flow.
+    ClosePortal {
+        /// The name of the portal to close.
+        name: String,
+    },
+
+    /// Terminate a connection.
+    Terminate,
+}
+
+impl FrontendMessage {
+    /// decodes buffer data to a frontend message
+    pub fn decode(tag: u8, buffer: &[u8]) -> Result<Self> {
+        log::debug!(
+            "Receives frontend tag = {:?}, buffer = {:?}",
+            std::char::from_u32(tag as u32).unwrap(),
+            buffer
+        );
+
+        let cursor = Cursor::new(buffer);
+        match tag {
+            // Simple query flow.
+            b'Q' => decode_query(cursor),
+
+            // Extended query flow.
+            b'B' => decode_bind(cursor),
+            b'C' => decode_close(cursor),
+            b'D' => decode_describe(cursor),
+            b'E' => decode_execute(cursor),
+            b'H' => decode_flush(cursor),
+            b'P' => decode_parse(cursor),
+            b'S' => decode_sync(cursor),
+
+            // Termination.
+            b'X' => decode_terminate(cursor),
+
+            // Invalid.
+            _ => {
+                log::debug!("Unsupport frontend message tag {}", tag);
+                Err(Error::UnsupportedFrontendMessage)
+            }
+        }
+    }
+}
+
 /// Backend PostgreSQL Wire Protocol messages
 /// see https://www.postgresql.org/docs/12/protocol-flow.html
 #[allow(dead_code)]
 #[derive(Debug, PartialEq)]
-pub enum Message {
+pub enum BackendMessage {
     /// A warning message has been issued. The frontend should display the message
     /// but continue listening for ReadyForQuery or ErrorResponse.
     NoticeResponse,
@@ -88,16 +214,16 @@ pub enum Message {
     ParameterStatus(String, String),
 }
 
-impl Message {
+impl BackendMessage {
     /// returns binary representation of a backend message
     pub fn as_vec(&self) -> Vec<u8> {
         match self {
-            Message::NoticeResponse => vec![NOTICE_RESPONSE],
-            Message::AuthenticationCleartextPassword => vec![AUTHENTICATION, 0, 0, 0, 8, 0, 0, 0, 3],
-            Message::AuthenticationMD5Password => vec![AUTHENTICATION, 0, 0, 0, 12, 0, 0, 0, 5, 1, 1, 1, 1],
-            Message::AuthenticationOk => vec![AUTHENTICATION, 0, 0, 0, 8, 0, 0, 0, 0],
-            Message::ReadyForQuery => vec![READY_FOR_QUERY, 0, 0, 0, 5, EMPTY_QUERY_RESPONSE],
-            Message::DataRow(row) => {
+            BackendMessage::NoticeResponse => vec![NOTICE_RESPONSE],
+            BackendMessage::AuthenticationCleartextPassword => vec![AUTHENTICATION, 0, 0, 0, 8, 0, 0, 0, 3],
+            BackendMessage::AuthenticationMD5Password => vec![AUTHENTICATION, 0, 0, 0, 12, 0, 0, 0, 5, 1, 1, 1, 1],
+            BackendMessage::AuthenticationOk => vec![AUTHENTICATION, 0, 0, 0, 8, 0, 0, 0, 0],
+            BackendMessage::ReadyForQuery => vec![READY_FOR_QUERY, 0, 0, 0, 5, EMPTY_QUERY_RESPONSE],
+            BackendMessage::DataRow(row) => {
                 let mut row_buff = Vec::new();
                 for field in row.iter() {
                     row_buff.extend_from_slice(&(field.len() as i32).to_be_bytes());
@@ -110,7 +236,7 @@ impl Message {
                 len_buff.extend_from_slice(&row_buff);
                 len_buff
             }
-            Message::RowDescription(description) => {
+            BackendMessage::RowDescription(description) => {
                 let mut buff = Vec::new();
                 for field in description.iter() {
                     buff.extend_from_slice(field.name.as_str().as_bytes());
@@ -129,7 +255,7 @@ impl Message {
                 len_buff.extend_from_slice(&buff);
                 len_buff
             }
-            Message::CommandComplete(command) => {
+            BackendMessage::CommandComplete(command) => {
                 let mut command_buff = Vec::new();
                 command_buff.extend_from_slice(&[COMMAND_COMPLETE]);
                 command_buff.extend_from_slice(&(4 + command.len() as i32 + 1).to_be_bytes());
@@ -137,8 +263,8 @@ impl Message {
                 command_buff.extend_from_slice(&[0]);
                 command_buff
             }
-            Message::EmptyQueryResponse => vec![EMPTY_QUERY_RESPONSE, 0, 0, 0, 4],
-            Message::ErrorResponse(severity, code, message) => {
+            BackendMessage::EmptyQueryResponse => vec![EMPTY_QUERY_RESPONSE, 0, 0, 0, 4],
+            BackendMessage::ErrorResponse(severity, code, message) => {
                 let mut error_response_buff = Vec::new();
                 error_response_buff.extend_from_slice(&[ERROR_RESPONSE]);
                 let mut message_buff = Vec::new();
@@ -162,7 +288,7 @@ impl Message {
                 error_response_buff.extend_from_slice(&[0]);
                 error_response_buff.to_vec()
             }
-            Message::ParameterStatus(name, value) => {
+            BackendMessage::ParameterStatus(name, value) => {
                 let mut parameter_status_buff = Vec::new();
                 parameter_status_buff.extend_from_slice(&[PARAMETER_STATUS]);
                 let mut parameters = Vec::new();
@@ -201,19 +327,260 @@ impl ColumnMetadata {
     }
 }
 
+/// Decodes data within messages.
+#[derive(Debug)]
+struct Cursor<'a> {
+    buf: &'a [u8],
+}
+
+impl<'a> Cursor<'a> {
+    /// Constructs a new `Cursor` from a byte slice. The cursor will begin
+    /// decoding from the beginning of the slice.
+    fn new(buf: &'a [u8]) -> Cursor {
+        Cursor { buf }
+    }
+
+    /// Advances the cursor by `n` bytes.
+    fn advance(&mut self, n: usize) {
+        self.buf = &self.buf[n..]
+    }
+
+    /// Returns the next byte without advancing the cursor.
+    fn peek_byte(&self) -> Result<u8> {
+        self.buf
+            .get(0)
+            .copied()
+            .ok_or_else(|| Error::InvalidInput("No byte to read".to_owned()))
+    }
+
+    /// Returns the next byte, advancing the cursor by one byte.
+    fn read_byte(&mut self) -> Result<u8> {
+        let byte = self.peek_byte()?;
+        self.advance(1);
+        Ok(byte)
+    }
+
+    /// Returns the next null-terminated string. The null character is not
+    /// included the returned string. The cursor is advanced past the null-
+    /// terminated string.
+    fn read_cstr(&mut self) -> Result<&'a str> {
+        if let Some(pos) = self.buf.iter().position(|b| *b == 0) {
+            let val = std::str::from_utf8(&self.buf[..pos]).map_err(|_e| Error::InvalidUtfString)?;
+            self.advance(pos + 1);
+            Ok(val)
+        } else {
+            Err(Error::InvalidUtfString)
+        }
+    }
+}
+
+fn decode_bind(mut cursor: Cursor) -> Result<FrontendMessage> {
+    let portal_name = cursor.read_cstr()?.to_owned();
+    let statement_name = cursor.read_cstr()?.to_owned();
+    Ok(FrontendMessage::Bind {
+        portal_name,
+        statement_name,
+    })
+}
+
+fn decode_close(mut cursor: Cursor) -> Result<FrontendMessage> {
+    let first_char = cursor.read_byte()?;
+    let name = cursor.read_cstr()?.to_owned();
+    match first_char {
+        b'P' => Ok(FrontendMessage::ClosePortal { name }),
+        b'S' => Ok(FrontendMessage::CloseStatement { name }),
+        other => Err(Error::InvalidInput(format!(
+            "invalid type byte in Close frontend message: {:?}",
+            std::char::from_u32(other as u32).unwrap(),
+        ))),
+    }
+}
+
+fn decode_describe(mut cursor: Cursor) -> Result<FrontendMessage> {
+    let first_char = cursor.read_byte()?;
+    let name = cursor.read_cstr()?.to_owned();
+    match first_char {
+        b'P' => Ok(FrontendMessage::DescribePortal { name }),
+        b'S' => Ok(FrontendMessage::DescribeStatement { name }),
+        other => Err(Error::InvalidInput(format!(
+            "invalid type byte in Describe frontend message: {:?}",
+            std::char::from_u32(other as u32).unwrap(),
+        ))),
+    }
+}
+
+fn decode_execute(mut cursor: Cursor) -> Result<FrontendMessage> {
+    let portal_name = cursor.read_cstr()?.to_owned();
+    Ok(FrontendMessage::Execute { portal_name })
+}
+
+fn decode_flush(_cursor: Cursor) -> Result<FrontendMessage> {
+    Ok(FrontendMessage::Flush)
+}
+
+fn decode_parse(mut cursor: Cursor) -> Result<FrontendMessage> {
+    let statement_name = cursor.read_cstr()?.to_owned();
+    let sql = cursor.read_cstr()?.to_owned();
+
+    Ok(FrontendMessage::Parse { statement_name, sql })
+}
+
+fn decode_sync(_cursor: Cursor) -> Result<FrontendMessage> {
+    Ok(FrontendMessage::Sync)
+}
+
+fn decode_query(mut cursor: Cursor) -> Result<FrontendMessage> {
+    let sql = cursor.read_cstr()?.to_owned();
+    Ok(FrontendMessage::Query { sql })
+}
+
+fn decode_terminate(_cursor: Cursor) -> Result<FrontendMessage> {
+    Ok(FrontendMessage::Terminate)
+}
+
 #[cfg(test)]
-mod serialized_messages {
+mod decoding_frontend_messages {
+    use super::*;
+
+    #[test]
+    fn query() {
+        let buffer = [
+            99, 114, 101, 97, 116, 101, 32, 115, 99, 104, 101, 109, 97, 32, 115, 99, 104, 101, 109, 97, 95, 110, 97,
+            109, 101, 59, 0,
+        ];
+        let message = FrontendMessage::decode(b'Q', &buffer);
+        assert_eq!(
+            message,
+            Ok(FrontendMessage::Query {
+                sql: "create schema schema_name;".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn bind() {
+        let buffer = [
+            112, 111, 114, 116, 97, 108, 95, 110, 97, 109, 101, 0, 115, 116, 97, 116, 101, 109, 101, 110, 116, 95, 110,
+            97, 109, 101, 0,
+        ];
+        let message = FrontendMessage::decode(b'B', &buffer);
+        assert_eq!(
+            message,
+            Ok(FrontendMessage::Bind {
+                portal_name: "portal_name".to_owned(),
+                statement_name: "statement_name".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn close_protal() {
+        let buffer = [80, 112, 111, 114, 116, 97, 108, 95, 110, 97, 109, 101, 0];
+        let message = FrontendMessage::decode(b'C', &buffer);
+        assert_eq!(
+            message,
+            Ok(FrontendMessage::ClosePortal {
+                name: "portal_name".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn close_statement() {
+        let buffer = [83, 115, 116, 97, 116, 101, 109, 101, 110, 116, 95, 110, 97, 109, 101, 0];
+        let message = FrontendMessage::decode(b'C', &buffer);
+        assert_eq!(
+            message,
+            Ok(FrontendMessage::CloseStatement {
+                name: "statement_name".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn describe_portal() {
+        let buffer = [80, 112, 111, 114, 116, 97, 108, 95, 110, 97, 109, 101, 0];
+        let message = FrontendMessage::decode(b'D', &buffer);
+        assert_eq!(
+            message,
+            Ok(FrontendMessage::DescribePortal {
+                name: "portal_name".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn describe_statement() {
+        let buffer = [83, 115, 116, 97, 116, 101, 109, 101, 110, 116, 95, 110, 97, 109, 101, 0];
+        let message = FrontendMessage::decode(b'D', &buffer);
+        assert_eq!(
+            message,
+            Ok(FrontendMessage::DescribeStatement {
+                name: "statement_name".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn execute() {
+        let buffer = [112, 111, 114, 116, 97, 108, 95, 110, 97, 109, 101, 0];
+        let message = FrontendMessage::decode(b'E', &buffer);
+        assert_eq!(
+            message,
+            Ok(FrontendMessage::Execute {
+                portal_name: "portal_name".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn flush() {
+        let message = FrontendMessage::decode(b'H', &[]);
+        assert_eq!(message, Ok(FrontendMessage::Flush));
+    }
+
+    #[test]
+    fn parse() {
+        let buffer = [
+            0, 115, 101, 108, 101, 99, 116, 32, 42, 32, 102, 114, 111, 109, 32, 115, 99, 104, 101, 109, 97, 95, 110,
+            97, 109, 101, 46, 116, 97, 98, 108, 101, 95, 110, 97, 109, 101, 59, 0, 0, 0,
+        ];
+        let message = FrontendMessage::decode(b'P', &buffer);
+        assert_eq!(
+            message,
+            Ok(FrontendMessage::Parse {
+                statement_name: "".to_owned(),
+                sql: "select * from schema_name.table_name;".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn sync() {
+        let message = FrontendMessage::decode(b'S', &[]);
+        assert_eq!(message, Ok(FrontendMessage::Sync));
+    }
+
+    #[test]
+    fn terminate() {
+        let message = FrontendMessage::decode(b'X', &[]);
+        assert_eq!(message, Ok(FrontendMessage::Terminate));
+    }
+}
+
+#[cfg(test)]
+mod serializing_backend_messages {
     use super::*;
 
     #[test]
     fn notice() {
-        assert_eq!(Message::NoticeResponse.as_vec(), vec![NOTICE_RESPONSE]);
+        assert_eq!(BackendMessage::NoticeResponse.as_vec(), vec![NOTICE_RESPONSE]);
     }
 
     #[test]
     fn authentication_cleartext_password() {
         assert_eq!(
-            Message::AuthenticationCleartextPassword.as_vec(),
+            BackendMessage::AuthenticationCleartextPassword.as_vec(),
             vec![AUTHENTICATION, 0, 0, 0, 8, 0, 0, 0, 3]
         )
     }
@@ -221,7 +588,7 @@ mod serialized_messages {
     #[test]
     fn authentication_md5_password() {
         assert_eq!(
-            Message::AuthenticationMD5Password.as_vec(),
+            BackendMessage::AuthenticationMD5Password.as_vec(),
             vec![AUTHENTICATION, 0, 0, 0, 12, 0, 0, 0, 5, 1, 1, 1, 1]
         )
     }
@@ -229,7 +596,7 @@ mod serialized_messages {
     #[test]
     fn authentication_ok() {
         assert_eq!(
-            Message::AuthenticationOk.as_vec(),
+            BackendMessage::AuthenticationOk.as_vec(),
             vec![AUTHENTICATION, 0, 0, 0, 8, 0, 0, 0, 0]
         )
     }
@@ -237,7 +604,7 @@ mod serialized_messages {
     #[test]
     fn parameter_status() {
         assert_eq!(
-            Message::ParameterStatus("client_encoding".to_owned(), "UTF8".to_owned()).as_vec(),
+            BackendMessage::ParameterStatus("client_encoding".to_owned(), "UTF8".to_owned()).as_vec(),
             vec![
                 PARAMETER_STATUS,
                 0,
@@ -272,7 +639,7 @@ mod serialized_messages {
     #[test]
     fn ready_for_query() {
         assert_eq!(
-            Message::ReadyForQuery.as_vec(),
+            BackendMessage::ReadyForQuery.as_vec(),
             vec![READY_FOR_QUERY, 0, 0, 0, 5, EMPTY_QUERY_RESPONSE]
         )
     }
@@ -280,7 +647,7 @@ mod serialized_messages {
     #[test]
     fn data_row() {
         assert_eq!(
-            Message::DataRow(vec!["1".to_owned(), "2".to_owned(), "3".to_owned()]).as_vec(),
+            BackendMessage::DataRow(vec!["1".to_owned(), "2".to_owned(), "3".to_owned()]).as_vec(),
             vec![DATA_ROW, 0, 0, 0, 21, 0, 3, 0, 0, 0, 1, 49, 0, 0, 0, 1, 50, 0, 0, 0, 1, 51]
         )
     }
@@ -288,7 +655,7 @@ mod serialized_messages {
     #[test]
     fn row_description() {
         assert_eq!(
-            Message::RowDescription(vec![ColumnMetadata::new("c1".to_owned(), 23, 4)]).as_vec(),
+            BackendMessage::RowDescription(vec![ColumnMetadata::new("c1".to_owned(), 23, 4)]).as_vec(),
             vec![
                 ROW_DESCRIPTION,
                 0,
@@ -325,7 +692,7 @@ mod serialized_messages {
     #[test]
     fn command_complete() {
         assert_eq!(
-            Message::CommandComplete("SELECT".to_owned()).as_vec(),
+            BackendMessage::CommandComplete("SELECT".to_owned()).as_vec(),
             vec![COMMAND_COMPLETE, 0, 0, 0, 11, 83, 69, 76, 69, 67, 84, 0]
         )
     }
@@ -333,7 +700,7 @@ mod serialized_messages {
     #[test]
     fn empty_response() {
         assert_eq!(
-            Message::EmptyQueryResponse.as_vec(),
+            BackendMessage::EmptyQueryResponse.as_vec(),
             vec![EMPTY_QUERY_RESPONSE, 0, 0, 0, 4]
         )
     }
@@ -341,7 +708,7 @@ mod serialized_messages {
     #[test]
     fn error_response() {
         assert_eq!(
-            Message::ErrorResponse(None, None, None).as_vec(),
+            BackendMessage::ErrorResponse(None, None, None).as_vec(),
             vec![ERROR_RESPONSE, 0, 0, 0, 5, 0]
         )
     }

--- a/src/protocol/src/tests/connection.rs
+++ b/src/protocol/src/tests/connection.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{messages::Message, tests::async_io::TestCase, Channel, Command, Receiver, RequestReceiver, VERSION_3};
+use crate::{
+    messages::BackendMessage, tests::async_io::TestCase, Channel, Command, Receiver, RequestReceiver, VERSION_3,
+};
 use async_mutex::Mutex as AsyncMutex;
 use futures_lite::future::block_on;
 use std::sync::Arc;
@@ -45,7 +47,7 @@ mod read_query {
 
             let actual_content = test_case.read_result().await;
             let mut expected_content = Vec::new();
-            expected_content.extend_from_slice(Message::ReadyForQuery.as_vec().as_slice());
+            expected_content.extend_from_slice(BackendMessage::ReadyForQuery.as_vec().as_slice());
             assert_eq!(actual_content, expected_content);
         });
     }

--- a/src/protocol/src/tests/hand_shake.rs
+++ b/src/protocol/src/tests/hand_shake.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     hand_shake,
-    messages::{Encryption, Message},
+    messages::{BackendMessage, Encryption},
     tests::{
         async_io::{empty_file_named, TestCase},
         certificate_content, pg_frontend,
@@ -149,15 +149,20 @@ fn successful_connection_handshake_for_none_secure() {
         let actual_content = test_case.read_result().await;
         let mut expected_content = Vec::new();
         expected_content.extend_from_slice(Encryption::RejectSsl.into());
-        expected_content.extend_from_slice(Message::AuthenticationCleartextPassword.as_vec().as_slice());
-        expected_content.extend_from_slice(Message::AuthenticationOk.as_vec().as_slice());
+        expected_content.extend_from_slice(BackendMessage::AuthenticationCleartextPassword.as_vec().as_slice());
+        expected_content.extend_from_slice(BackendMessage::AuthenticationOk.as_vec().as_slice());
         expected_content.extend_from_slice(
-            Message::ParameterStatus("client_encoding".to_owned(), "UTF8".to_owned())
+            BackendMessage::ParameterStatus("client_encoding".to_owned(), "UTF8".to_owned())
                 .as_vec()
                 .as_slice(),
         );
         expected_content.extend_from_slice(
-            Message::ParameterStatus("DateStyle".to_owned(), "ISO".to_owned())
+            BackendMessage::ParameterStatus("DateStyle".to_owned(), "ISO".to_owned())
+                .as_vec()
+                .as_slice(),
+        );
+        expected_content.extend_from_slice(
+            BackendMessage::ParameterStatus("integer_datetimes".to_owned(), "off".to_owned())
                 .as_vec()
                 .as_slice(),
         );
@@ -196,15 +201,15 @@ fn successful_connection_handshake_for_ssl_only_secure() {
         let actual_content = test_case.read_result().await;
         let mut expected_content = Vec::new();
         expected_content.extend_from_slice(Encryption::AcceptSsl.into());
-        expected_content.extend_from_slice(Message::AuthenticationCleartextPassword.as_vec().as_slice());
-        expected_content.extend_from_slice(Message::AuthenticationOk.as_vec().as_slice());
+        expected_content.extend_from_slice(BackendMessage::AuthenticationCleartextPassword.as_vec().as_slice());
+        expected_content.extend_from_slice(BackendMessage::AuthenticationOk.as_vec().as_slice());
         expected_content.extend_from_slice(
-            Message::ParameterStatus("client_encoding".to_owned(), "UTF8".to_owned())
+            BackendMessage::ParameterStatus("client_encoding".to_owned(), "UTF8".to_owned())
                 .as_vec()
                 .as_slice(),
         );
         expected_content.extend_from_slice(
-            Message::ParameterStatus("DateStyle".to_owned(), "ISO".to_owned())
+            BackendMessage::ParameterStatus("DateStyle".to_owned(), "ISO".to_owned())
                 .as_vec()
                 .as_slice(),
         );


### PR DESCRIPTION
This PR is part of Issue #177  (should not close).

#### Description

Adds Frontend Messages to separate with Backend Messages, and decodes Frontend Messages from incoming data, including Extended Query.

In PostgreSQL there are two ways to construct prepared statements:

1. Via an explicit user-provided `PREPARE <statement name> AS <SQL>` SQL statement.

https://www.postgresql.org/docs/current/sql-prepare.html
https://www.postgresql.org/docs/current/sql-execute.html
https://www.postgresql.org/docs/current/sql-deallocate.html

2. Via Extended Query as part of the Frontend/Backend Messages.

https://www.postgresql.org/docs/12/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY

For SQL statements `PREPARE`, `EXECUTE` and `DEALLOCATE`, they could be easily tested (via `psql` or `psycopg2`). But I could not find a good method to test Extended Query. I am using an Erlang library https://github.com/epgsql/epgsql.

For testing Extended Query, download `epgsql` and run the commands as below.

```
git clone git@github.com:epgsql/epgsql.git
cd epgsql
make

./rebar3 shell

1> {ok, C} = epgsql:connect("localhost", "user", "password", #{codecs => []}).
2> epgsql:equery(C, "select * from schema_name.table_name;").
```

### TODO

- [ ] Add a struct `Session` to `sql_engine` to save `prepared_statements`, `portals` (and original `Sender`).
- [ ] Handle the whole process of Extended Query (and delete `Command::Continue`).
- [ ] Handle SQL statement `PREPARE`, `EXECUTE` and `DEALLOCATE`.