### PR TITLE
Implement Parse process of Postgres Extended Query protocol

### DIFF
--- a/src/kernel/src/lib.rs
+++ b/src/kernel/src/lib.rs
@@ -113,6 +113,7 @@ impl PartialEq for SystemErrorKind {
         match (self, other) {
             (SystemErrorKind::Io(_), SystemErrorKind::Io(_)) => true,
             (SystemErrorKind::Unrecoverable, SystemErrorKind::Unrecoverable) => true,
+            (SystemErrorKind::RuntimeCheckFailure, SystemErrorKind::RuntimeCheckFailure) => true,
             _ => false,
         }
     }

--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -72,14 +72,31 @@ pub fn start() {
                                     return;
                                 }
                                 Ok(Ok(Command::Continue)) => {}
-                                Ok(Ok(Command::Terminate)) => {
-                                    log::debug!("Closing connection with client");
-                                    break;
+                                Ok(Ok(Command::DescribeStatement(name))) => {
+                                    match query_executor.describe_prepared_statement(name.as_str()) {
+                                        Ok(()) => {}
+                                        Err(error) => log::error!("{:?}", error),
+                                    }
+                                }
+                                Ok(Ok(Command::Flush)) => query_executor.flush(),
+                                Ok(Ok(Command::Parse(statement_name, sql_query, param_types))) => {
+                                    match query_executor.parse(
+                                        statement_name.as_str(),
+                                        sql_query.as_str(),
+                                        param_types.as_ref(),
+                                    ) {
+                                        Ok(()) => {}
+                                        Err(error) => log::error!("{:?}", error),
+                                    }
                                 }
                                 Ok(Ok(Command::Query(sql_query))) => match query_executor.execute(sql_query.as_str()) {
                                     Ok(()) => {}
                                     Err(error) => log::error!("{:?}", error),
                                 },
+                                Ok(Ok(Command::Terminate)) => {
+                                    log::debug!("Closing connection with client");
+                                    break;
+                                }
                             }
                         }
                     })

--- a/src/protocol/src/sql_types.rs
+++ b/src/protocol/src/sql_types.rs
@@ -36,6 +36,28 @@ pub enum PostgreSqlType {
 }
 
 impl PostgreSqlType {
+    /// Returns the type corresponding to the provided OID, if the OID is known.
+    pub fn from_oid(oid: u32) -> Option<Self> {
+        match oid {
+            16 => Some(Self::Bool),
+            18 => Some(Self::Char),
+            20 => Some(Self::BigInt),
+            21 => Some(Self::SmallInt),
+            23 => Some(Self::Integer),
+            700 => Some(Self::Real),
+            701 => Some(Self::DoublePrecision),
+            1043 => Some(Self::VarChar),
+            1082 => Some(Self::Date),
+            1083 => Some(Self::Time),
+            1114 => Some(Self::Timestamp),
+            1184 => Some(Self::TimestampWithTimeZone),
+            1186 => Some(Self::Interval),
+            1266 => Some(Self::TimeWithTimeZone),
+            1700 => Some(Self::Decimal),
+            _ => None,
+        }
+    }
+
     /// PostgreSQL type OID
     pub fn pg_oid(&self) -> i32 {
         match self {

--- a/src/protocol/src/tests/connection.rs
+++ b/src/protocol/src/tests/connection.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    messages::BackendMessage, tests::async_io::TestCase, Channel, Command, Receiver, RequestReceiver, VERSION_3,
-};
+use crate::{tests::async_io::TestCase, Channel, Command, Receiver, RequestReceiver, VERSION_3};
 use async_mutex::Mutex as AsyncMutex;
 use futures_lite::future::block_on;
 use std::sync::Arc;
@@ -44,11 +42,6 @@ mod read_query {
 
             let query = receiver.receive().await.expect("no io errors");
             assert_eq!(query, Ok(Command::Query("select 1;".to_owned())));
-
-            let actual_content = test_case.read_result().await;
-            let mut expected_content = Vec::new();
-            expected_content.extend_from_slice(BackendMessage::ReadyForQuery.as_vec().as_slice());
-            assert_eq!(actual_content, expected_content);
         });
     }
 

--- a/src/protocol/src/tests/hand_shake.rs
+++ b/src/protocol/src/tests/hand_shake.rs
@@ -166,6 +166,7 @@ fn successful_connection_handshake_for_none_secure() {
                 .as_vec()
                 .as_slice(),
         );
+        expected_content.extend_from_slice(BackendMessage::ReadyForQuery.as_vec().as_slice());
         assert_eq!(actual_content, expected_content);
     });
 }

--- a/src/sql_engine/src/dml/select.rs
+++ b/src/sql_engine/src/dml/select.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use crate::catalog_manager::CatalogManager;
-use kernel::SystemResult;
+use kernel::{SystemError, SystemResult};
 use protocol::{
-    results::{QueryErrorBuilder, QueryEvent},
+    results::{Description, QueryErrorBuilder, QueryEvent},
     Sender,
 };
 use sqlparser::ast::{Expr, Ident, Query, Select, SelectItem, SetExpr, TableFactor, TableWithJoins};
@@ -43,6 +43,116 @@ impl<'sc> SelectCommand<'sc> {
             query,
             storage,
             session,
+        }
+    }
+
+    pub(crate) fn describe(&mut self) -> SystemResult<Description> {
+        let Query { body, .. } = &*self.query;
+        if let SetExpr::Select(select) = body {
+            let Select { projection, from, .. } = select.deref();
+            let TableWithJoins { relation, .. } = &from[0];
+            let (schema_name, table_name) = match relation {
+                TableFactor::Table { name, .. } => {
+                    let table_name = name.0[1].to_string();
+                    let schema_name = name.0[0].to_string();
+                    (schema_name, table_name)
+                }
+                _ => {
+                    self.session
+                        .send(Err(QueryErrorBuilder::new()
+                            .feature_not_supported(self.raw_sql_query.to_owned())
+                            .build()))
+                        .expect("To Send Query Result to Client");
+                    return Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()));
+                }
+            };
+
+            if !(self.storage.lock().unwrap()).schema_exists(&schema_name) {
+                self.session
+                    .send(Err(QueryErrorBuilder::new().schema_does_not_exist(schema_name).build()))
+                    .expect("To Send Result to Client");
+                return Err(SystemError::runtime_check_failure("Schema Does Not Exist".to_owned()));
+            }
+
+            if !(self.storage.lock().unwrap()).table_exists(&schema_name, &table_name) {
+                self.session
+                    .send(Err(QueryErrorBuilder::new()
+                        .table_does_not_exist(schema_name + "." + table_name.as_str())
+                        .build()))
+                    .expect("To Send Result to Client");
+                return Err(SystemError::runtime_check_failure("Table Does Not Exist".to_owned()));
+            }
+
+            let table_columns = {
+                let projection = projection.clone();
+                let mut columns: Vec<String> = vec![];
+                for item in projection {
+                    match item {
+                        SelectItem::Wildcard => {
+                            let all_columns =
+                                (self.storage.lock().unwrap()).table_columns(&schema_name, &table_name)?;
+                            columns.extend(
+                                all_columns
+                                    .into_iter()
+                                    .map(|column_definition| column_definition.name())
+                                    .collect::<Vec<String>>(),
+                            )
+                        }
+                        SelectItem::UnnamedExpr(Expr::Identifier(Ident { value, .. })) => columns.push(value.clone()),
+                        _ => {
+                            self.session
+                                .send(Err(QueryErrorBuilder::new()
+                                    .feature_not_supported(self.raw_sql_query.to_owned())
+                                    .build()))
+                                .expect("To Send Query Result to Client");
+                            return Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()));
+                        }
+                    }
+                }
+                columns
+            };
+
+            let all_columns = (self.storage.lock().unwrap()).table_columns(&schema_name, &table_name)?;
+            let mut column_definitions = vec![];
+            let mut non_existing_columns = vec![];
+            for column_name in table_columns {
+                let mut found = None;
+                for column_definition in &all_columns {
+                    if column_definition.has_name(&column_name) {
+                        found = Some(column_definition);
+                        break;
+                    }
+                }
+
+                if let Some(column_definition) = found {
+                    column_definitions.push(column_definition);
+                } else {
+                    non_existing_columns.push(column_name.clone());
+                }
+            }
+
+            if !non_existing_columns.is_empty() {
+                self.session
+                    .send(Err(QueryErrorBuilder::new()
+                        .column_does_not_exist(non_existing_columns)
+                        .build()))
+                    .expect("To Send Result to Client");
+                return Err(SystemError::runtime_check_failure("Column Does Not Exist".to_owned()));
+            }
+
+            let description = column_definitions
+                .into_iter()
+                .map(|column_definition| (column_definition.name(), (&column_definition.sql_type()).into()))
+                .collect();
+
+            Ok(description)
+        } else {
+            self.session
+                .send(Err(QueryErrorBuilder::new()
+                    .feature_not_supported(self.raw_sql_query.to_owned())
+                    .build()))
+                .expect("To Send Query Result to Client");
+            Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()))
         }
     }
 

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -23,21 +23,28 @@ use crate::{
     },
     dml::{delete::DeleteCommand, insert::InsertCommand, select::SelectCommand, update::UpdateCommand},
     query::{plan::Plan, process::QueryProcessor},
+    session::{statement::PreparedStatement, Session},
 };
 use kernel::SystemResult;
 use protocol::{
     results::{QueryErrorBuilder, QueryEvent},
+    sql_types::PostgreSqlType,
     Sender,
 };
 use serde::{Deserialize, Serialize};
 use sql_types::SqlType;
-use sqlparser::{ast::Statement, dialect::PostgreSqlDialect, parser::Parser};
+use sqlparser::{
+    ast::Statement,
+    dialect::{Dialect, PostgreSqlDialect},
+    parser::Parser,
+};
 use std::sync::{Arc, Mutex};
 
 pub mod catalog_manager;
 mod ddl;
 mod dml;
 mod query;
+mod session;
 
 pub type Projection = (Vec<ColumnDefinition>, Vec<Vec<String>>);
 
@@ -121,17 +128,19 @@ impl ColumnDefinition {
 }
 
 pub struct QueryExecutor {
-    storage: Arc<Mutex<CatalogManager>>,
     processor: QueryProcessor,
-    session: Arc<dyn Sender>,
+    storage: Arc<Mutex<CatalogManager>>,
+    sender: Arc<dyn Sender>,
+    session: Session,
 }
 
 impl QueryExecutor {
-    pub fn new(storage: Arc<Mutex<CatalogManager>>, session: Arc<dyn Sender>) -> Self {
+    pub fn new(storage: Arc<Mutex<CatalogManager>>, sender: Arc<dyn Sender>) -> Self {
         Self {
             storage: storage.clone(),
-            processor: QueryProcessor::new(storage, session.clone()),
-            session,
+            sender: sender.clone(),
+            session: Session::new(),
+            processor: QueryProcessor::new(storage, sender),
         }
     }
 
@@ -147,7 +156,7 @@ impl QueryExecutor {
                 let query_error = QueryErrorBuilder::new()
                     .syntax_error(format!("{:?} can't be parsed", raw_sql_query))
                     .build();
-                self.session
+                self.sender
                     .send(Err(query_error))
                     .expect("To Send Query Result to Client");
                 return Ok(());
@@ -157,69 +166,156 @@ impl QueryExecutor {
         log::debug!("STATEMENT = {:?}", statement);
         match self.processor.process(statement) {
             Ok(Plan::CreateSchema(creation_info)) => {
-                CreateSchemaCommand::new(creation_info, self.storage.clone(), self.session.clone()).execute()
+                CreateSchemaCommand::new(creation_info, self.storage.clone(), self.sender.clone()).execute()?
             }
             Ok(Plan::CreateTable(creation_info)) => {
-                CreateTableCommand::new(creation_info, self.storage.clone(), self.session.clone()).execute()
+                CreateTableCommand::new(creation_info, self.storage.clone(), self.sender.clone()).execute()?
             }
             Ok(Plan::DropSchemas(schemas)) => {
                 for schema in schemas {
-                    DropSchemaCommand::new(schema, self.storage.clone(), self.session.clone()).execute()?;
+                    DropSchemaCommand::new(schema, self.storage.clone(), self.sender.clone()).execute()?;
                 }
-                Ok(())
             }
             Ok(Plan::DropTables(tables)) => {
                 for table in tables {
-                    DropTableCommand::new(table, self.storage.clone(), self.session.clone()).execute()?;
+                    DropTableCommand::new(table, self.storage.clone(), self.sender.clone()).execute()?;
                 }
-                Ok(())
             }
             Ok(Plan::Insert(table_insert)) => {
-                InsertCommand::new(raw_sql_query, table_insert, self.storage.clone(), self.session.clone()).execute()
+                InsertCommand::new(raw_sql_query, table_insert, self.storage.clone(), self.sender.clone()).execute()?
             }
             Ok(Plan::NotProcessed(statement)) => match *statement {
                 Statement::StartTransaction { .. } => {
-                    self.session
+                    self.sender
                         .send(Ok(QueryEvent::TransactionStarted))
                         .expect("To Send Query Result to Client");
-                    Ok(())
                 }
                 Statement::SetVariable { .. } => {
-                    self.session
+                    self.sender
                         .send(Ok(QueryEvent::VariableSet))
                         .expect("To Send Query Result to Client");
-                    Ok(())
                 }
                 Statement::Drop { .. } => {
-                    self.session
+                    self.sender
                         .send(Err(QueryErrorBuilder::new()
                             .feature_not_supported(raw_sql_query.to_owned())
                             .build()))
                         .expect("To Send Query Result to Client");
-                    Ok(())
                 }
                 Statement::Query(query) => {
-                    SelectCommand::new(raw_sql_query, query, self.storage.clone(), self.session.clone()).execute()
+                    SelectCommand::new(raw_sql_query, query, self.storage.clone(), self.sender.clone()).execute()?
                 }
                 Statement::Update {
                     table_name,
                     assignments,
                     ..
-                } => UpdateCommand::new(table_name, assignments, self.storage.clone(), self.session.clone()).execute(),
+                } => {
+                    UpdateCommand::new(table_name, assignments, self.storage.clone(), self.sender.clone()).execute()?
+                }
                 Statement::Delete { table_name, .. } => {
-                    DeleteCommand::new(table_name, self.storage.clone(), self.session.clone()).execute()
+                    DeleteCommand::new(table_name, self.storage.clone(), self.sender.clone()).execute()?
                 }
                 _ => {
-                    self.session
+                    self.sender
                         .send(Err(QueryErrorBuilder::new()
                             .feature_not_supported(raw_sql_query.to_owned())
                             .build()))
                         .expect("To Send Query Result to Client");
-                    Ok(())
                 }
             },
-            Err(()) => Ok(()),
-        }
+            Err(()) => {}
+        };
+
+        self.sender
+            .send(Ok(QueryEvent::QueryComplete))
+            .expect("To Send Query Complete Event to Client");
+
+        Ok(())
+    }
+
+    pub fn parse(
+        &mut self,
+        statement_name: &str,
+        raw_sql_query: &str,
+        param_types: &[PostgreSqlType],
+    ) -> SystemResult<()> {
+        let statement = match Parser::parse_sql(&PreparedStatementDialect {}, raw_sql_query) {
+            Ok(mut statements) => {
+                log::info!("stmts: {:#?}", statements);
+                statements.pop().unwrap()
+            }
+            Err(e) => {
+                log::error!("{:?} can't be parsed. Error: {:?}", raw_sql_query, e);
+                let query_error = QueryErrorBuilder::new()
+                    .syntax_error(format!("{:?} can't be parsed", raw_sql_query))
+                    .build();
+                self.sender
+                    .send(Err(query_error))
+                    .expect("To Send Query Result to Client");
+                return Ok(());
+            }
+        };
+
+        let description = match &statement {
+            Statement::Query(query) => {
+                SelectCommand::new(raw_sql_query, query.clone(), self.storage.clone(), self.sender.clone())
+                    .describe()?
+            }
+            _ => vec![],
+        };
+
+        let prepared_statement = PreparedStatement::new(statement, param_types.to_vec(), description);
+        self.session
+            .set_prepared_statement(statement_name.to_owned(), prepared_statement);
+
+        self.sender
+            .send(Ok(QueryEvent::ParseComplete))
+            .expect("To Send ParseComplete Event");
+
+        Ok(())
+    }
+
+    pub fn describe_prepared_statement(&mut self, name: &str) -> SystemResult<()> {
+        match self.session.get_prepared_statement(name) {
+            Some(stmt) => {
+                self.sender
+                    .send(Ok(QueryEvent::PreparedStatementDescribed(
+                        stmt.param_types().to_vec(),
+                        stmt.description().to_vec(),
+                    )))
+                    .expect("To Send ParametersDescribed Event");
+            }
+            None => {
+                let query_error = QueryErrorBuilder::new()
+                    .prepared_statement_does_not_exist(name.to_owned())
+                    .build();
+                self.sender.send(Err(query_error)).expect("To Send Error to Client");
+            }
+        };
+
+        Ok(())
+    }
+
+    pub fn flush(&self) {
+        match self.sender.flush() {
+            Ok(_) => {}
+            Err(e) => {
+                log::error!("Flush error: {:?}", e);
+            }
+        };
+    }
+}
+
+#[derive(Debug)]
+struct PreparedStatementDialect {}
+
+impl Dialect for PreparedStatementDialect {
+    fn is_identifier_start(&self, ch: char) -> bool {
+        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || ch == '$'
+    }
+
+    fn is_identifier_part(&self, ch: char) -> bool {
+        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '$' || ch == '_'
     }
 }
 

--- a/src/sql_engine/src/session/mod.rs
+++ b/src/sql_engine/src/session/mod.rs
@@ -1,0 +1,44 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) mod statement;
+
+use statement::{Portal, PreparedStatement};
+use std::collections::HashMap;
+
+/// A `Session` holds SQL state that is attached to a session.
+#[derive(Clone, Debug)]
+pub struct Session {
+    /// A map from statement names to parameterized statements
+    prepared_statements: HashMap<String, PreparedStatement>,
+    /// A map from statement names to bound statements
+    portals: HashMap<String, Portal>,
+}
+
+impl Session {
+    pub fn new() -> Self {
+        Self {
+            prepared_statements: HashMap::new(),
+            portals: HashMap::new(),
+        }
+    }
+
+    pub fn get_prepared_statement(&self, name: &str) -> Option<&PreparedStatement> {
+        self.prepared_statements.get(name)
+    }
+
+    pub fn set_prepared_statement(&mut self, name: String, statement: PreparedStatement) {
+        self.prepared_statements.insert(name, statement);
+    }
+}

--- a/src/sql_engine/src/session/statement.rs
+++ b/src/sql_engine/src/session/statement.rs
@@ -1,0 +1,77 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Prepared statements maintain in-progress state during a session.
+//!
+//! In PostgreSQL there are two ways to construct prepared statements:
+//!
+//! * Via an explicit, user-provided `PREPARE <name> AS <sql>` sql statement.
+//! * As part of the PostgreSQL Frontend/Backend protocol, where prepared
+//!   statements are created implicitly by client libraries on behalf of users.
+//!
+//! For Frontend/Backend protocol, there are multiple steps to use prepared
+//! statements:
+//!
+//! 1. Receive a `Parse` message. `Parse` messages included a name for the
+//!    prepared statement, in addition to some other possible metadata.
+//! 2. After validation, we stash the statement in the `Session` associated with
+//!    the current user's session.
+//! 3. The client issues a `Bind` message, which provides a name for a portal,
+//!    and associates that name with a previously-named prepared statement. This
+//!    is the point at which all possible parameters are associated with the
+//!    statement, there are no longer any free variables permited.
+//! 4. The client issues an `Execute` message with the name of a portal, causing
+//!    that portal to actually start scanning and returning results.
+
+use protocol::{results::Description, sql_types::PostgreSqlType};
+use sqlparser::ast::Statement;
+
+/// A prepared statement.
+#[derive(Clone, Debug)]
+pub struct PreparedStatement {
+    sql: Statement,
+    param_types: Vec<PostgreSqlType>,
+    description: Description,
+}
+
+impl PreparedStatement {
+    /// Constructs a new `PreparedStatement`.
+    pub fn new(sql: Statement, param_types: Vec<PostgreSqlType>, description: Description) -> PreparedStatement {
+        PreparedStatement {
+            sql,
+            param_types,
+            description,
+        }
+    }
+
+    /// Returns the types of any parameters in this prepared statement.
+    pub fn param_types(&self) -> &[PostgreSqlType] {
+        &self.param_types
+    }
+
+    /// Returns the type of the rows that will be returned by this prepared
+    /// statement.
+    pub fn description(&self) -> &[(String, PostgreSqlType)] {
+        self.description.as_ref()
+    }
+}
+
+/// A portal represents the execution state of a running or runnable query.
+#[derive(Clone, Debug)]
+pub struct Portal {
+    /// The name of the prepared statement that is bound to this portal.
+    statement_name: String,
+}
+
+impl Portal {}

--- a/src/sql_engine/src/tests/delete.rs
+++ b/src/sql_engine/src/tests/delete.rs
@@ -27,7 +27,7 @@ fn delete_from_nonexistent_table(sql_engine_with_schema: (QueryExecutor, Arc<Col
         .execute("delete from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Err(QueryErrorBuilder::new()
             .table_does_not_exist("schema_name.table_name".to_owned())
@@ -57,7 +57,7 @@ fn delete_all_records(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),

--- a/src/sql_engine/src/tests/describe_prepared_statement.rs
+++ b/src/sql_engine/src/tests/describe_prepared_statement.rs
@@ -1,0 +1,94 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use protocol::sql_types::PostgreSqlType;
+
+#[rstest::rstest]
+fn describe_select_statement(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint);")
+        .expect("no system errors");
+    engine
+        .parse(
+            "statement_name",
+            "select * from schema_name.table_name where column = $1 and column_2 = $2;",
+            &vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
+        )
+        .expect("no system errors");
+    engine
+        .describe_prepared_statement("statement_name")
+        .expect("no system errors");
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::ParseComplete),
+        Ok(QueryEvent::PreparedStatementDescribed(
+            vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
+            vec![
+                ("column_1".to_owned(), PostgreSqlType::SmallInt),
+                ("column_2".to_owned(), PostgreSqlType::SmallInt),
+            ],
+        )),
+    ]);
+}
+
+#[rstest::rstest]
+fn describe_update_statement(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint);")
+        .expect("no system errors");
+    engine
+        .parse(
+            "statement_name",
+            "update schema_name.table_name set column_1 = $1 where column_2 = $2;",
+            &vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
+        )
+        .expect("no system errors");
+    engine
+        .describe_prepared_statement("statement_name")
+        .expect("no system errors");
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::ParseComplete),
+        Ok(QueryEvent::PreparedStatementDescribed(
+            vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
+            vec![],
+        )),
+    ]);
+}
+
+#[rstest::rstest]
+fn describe_not_existed_statement(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .describe_prepared_statement("non_existent")
+        .expect("no system errors");
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryErrorBuilder::new()
+            .prepared_statement_does_not_exist("non_existent".to_owned())
+            .build()),
+    ]);
+}

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -22,7 +22,7 @@ fn insert_into_nonexistent_table(sql_engine_with_schema: (QueryExecutor, Arc<Col
         .execute("insert into schema_name.table_name values (123);")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Err(QueryErrorBuilder::new()
             .table_does_not_exist("schema_name.table_name".to_owned())
@@ -40,7 +40,7 @@ fn insert_value_in_non_existent_column(sql_engine_with_schema: (QueryExecutor, A
         .execute("insert into schema_name.table_name (non_existent) values (123);")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Err(QueryErrorBuilder::new()
@@ -63,7 +63,7 @@ fn insert_and_select_single_row(sql_engine_with_schema: (QueryExecutor, Arc<Coll
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -94,7 +94,7 @@ fn insert_and_select_multiple_rows(sql_engine_with_schema: (QueryExecutor, Arc<C
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -123,7 +123,7 @@ fn insert_and_select_named_columns(sql_engine_with_schema: (QueryExecutor, Arc<C
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(2)),
@@ -154,7 +154,7 @@ fn insert_multiple_rows(sql_engine_with_schema: (QueryExecutor, Arc<Collector>))
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(3)),
@@ -189,7 +189,7 @@ fn insert_and_select_different_integer_types(sql_engine_with_schema: (QueryExecu
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -235,7 +235,7 @@ fn insert_and_select_different_character_types(sql_engine_with_schema: (QueryExe
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -269,7 +269,7 @@ fn insert_booleans(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
         .execute("insert into schema_name.table_name values('true'::boolean);")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -310,7 +310,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -331,7 +331,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -352,7 +352,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -373,7 +373,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -394,7 +394,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -418,7 +418,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -441,7 +441,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -464,7 +464,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -487,7 +487,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -510,7 +510,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -533,7 +533,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -554,7 +554,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -575,7 +575,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -598,7 +598,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -621,7 +621,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -644,7 +644,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -665,7 +665,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -702,7 +702,7 @@ mod operators {
                 .execute("select * from schema_name.table_name;")
                 .expect("no system errors");
 
-            collector.assert_content(vec![
+            collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
                 Ok(QueryEvent::TableCreated),
                 Ok(QueryEvent::RecordsInserted(1)),
@@ -726,7 +726,7 @@ mod operators {
                 .execute("select * from schema_name.table_name;")
                 .expect("no system errors");
 
-            collector.assert_content(vec![
+            collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
                 Ok(QueryEvent::TableCreated),
                 Ok(QueryEvent::RecordsInserted(1)),
@@ -746,7 +746,7 @@ mod operators {
                 .execute("insert into schema_name.table_name values (1 || 2);")
                 .expect("no system errors");
 
-            collector.assert_content(vec![
+            collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
                 Ok(QueryEvent::TableCreated),
                 Err(QueryErrorBuilder::new()

--- a/src/sql_engine/src/tests/parse.rs
+++ b/src/sql_engine/src/tests/parse.rs
@@ -1,0 +1,116 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use kernel::SystemError;
+use protocol::sql_types::PostgreSqlType;
+
+#[rstest::rstest]
+fn parse_select_statement(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint);")
+        .expect("no system errors");
+    engine
+        .parse(
+            "statement_name",
+            "select * from schema_name.table_name where column = $1 and column_2 = $2;",
+            &vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
+        )
+        .expect("no system errors");
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::ParseComplete),
+    ]);
+}
+
+#[rstest::rstest]
+fn parse_select_statement_with_not_existed_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    let error = engine
+        .parse(
+            "statement_name",
+            "select * from schema_name.non_existent where column_1 = $1;",
+            &vec![],
+        )
+        .unwrap_err();
+    assert_eq!(
+        error,
+        SystemError::runtime_check_failure("Table Does Not Exist".to_owned())
+    );
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryErrorBuilder::new()
+            .table_does_not_exist("schema_name.non_existent".to_owned())
+            .build()),
+    ]);
+}
+
+#[rstest::rstest]
+fn parse_select_statement_with_not_existed_column(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint);")
+        .expect("no system errors");
+    let error = engine
+        .parse(
+            "statement_name",
+            "select column_not_in_table from schema_name.table_name where column_1 = $1;",
+            &vec![],
+        )
+        .unwrap_err();
+    assert_eq!(
+        error,
+        SystemError::runtime_check_failure("Column Does Not Exist".to_owned())
+    );
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryErrorBuilder::new()
+            .column_does_not_exist(vec!["column_not_in_table".to_owned()])
+            .build()),
+    ]);
+}
+
+#[rstest::rstest]
+fn parse_update_statement(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
+    let (mut engine, collector) = sql_engine_with_schema;
+    engine
+        .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint);")
+        .expect("no system errors");
+    engine
+        .parse(
+            "statement_name",
+            "update schema_name.table_name set column_1 = $1 where column_2 = $2;",
+            &vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
+        )
+        .expect("no system errors");
+
+    collector.assert_content(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::ParseComplete),
+    ]);
+}

--- a/src/sql_engine/src/tests/schema.rs
+++ b/src/sql_engine/src/tests/schema.rs
@@ -19,7 +19,7 @@ fn create_schema(sql_engine: (QueryExecutor, Arc<Collector>)) {
     let (mut engine, collector) = sql_engine;
     engine.execute("create schema schema_name;").expect("no system errors");
 
-    collector.assert_content(vec![Ok(QueryEvent::SchemaCreated)]);
+    collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated)]);
 }
 
 #[rstest::rstest]
@@ -28,7 +28,7 @@ fn create_same_schema(sql_engine: (QueryExecutor, Arc<Collector>)) {
     engine.execute("create schema schema_name;").expect("no system errors");
     engine.execute("create schema schema_name;").expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Err(QueryErrorBuilder::new()
             .schema_already_exists("schema_name".to_owned())
@@ -42,7 +42,7 @@ fn drop_schema(sql_engine: (QueryExecutor, Arc<Collector>)) {
     engine.execute("create schema schema_name;").expect("no system errors");
     engine.execute("drop schema schema_name;").expect("no system errors");
 
-    collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::SchemaDropped)]);
+    collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::SchemaDropped)]);
 }
 
 #[rstest::rstest]
@@ -51,7 +51,7 @@ fn drop_non_existent_schema(sql_engine: (QueryExecutor, Arc<Collector>)) {
 
     engine.execute("drop schema non_existent;").expect("no system errors");
 
-    collector.assert_content(vec![Err(QueryErrorBuilder::new()
+    collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
         .schema_does_not_exist("non_existent".to_owned())
         .build())]);
 }
@@ -64,7 +64,7 @@ fn select_from_nonexistent_schema(sql_engine: (QueryExecutor, Arc<Collector>)) {
         .execute("select * from non_existent.some_table;")
         .expect("no system errors");
 
-    collector.assert_content(vec![Err(QueryErrorBuilder::new()
+    collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
         .schema_does_not_exist("non_existent".to_owned())
         .build())]);
 }
@@ -76,7 +76,7 @@ fn select_named_columns_from_nonexistent_schema(sql_engine: (QueryExecutor, Arc<
         .execute("select column_1 from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![Err(QueryErrorBuilder::new()
+    collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
         .schema_does_not_exist("schema_name".to_owned())
         .build())]);
 }
@@ -88,7 +88,7 @@ fn insert_into_table_in_nonexistent_schema(sql_engine: (QueryExecutor, Arc<Colle
         .execute("insert into schema_name.table_name values (123);")
         .expect("no system errors");
 
-    collector.assert_content(vec![Err(QueryErrorBuilder::new()
+    collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
         .schema_does_not_exist("schema_name".to_owned())
         .build())]);
 }
@@ -100,7 +100,7 @@ fn update_records_in_table_from_non_existent_schema(sql_engine: (QueryExecutor, 
         .execute("update schema_name.table_name set column_test=789;")
         .expect("no system errors");
 
-    collector.assert_content(vec![Err(QueryErrorBuilder::new()
+    collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
         .schema_does_not_exist("schema_name".to_owned())
         .build())]);
 }
@@ -112,7 +112,7 @@ fn delete_from_table_in_nonexistent_schema(sql_engine: (QueryExecutor, Arc<Colle
         .execute("delete from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![Err(QueryErrorBuilder::new()
+    collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
         .schema_does_not_exist("schema_name".to_owned())
         .build())]);
 }

--- a/src/sql_engine/src/tests/select.rs
+++ b/src/sql_engine/src/tests/select.rs
@@ -22,7 +22,7 @@ fn select_from_not_existed_table(sql_engine_with_schema: (QueryExecutor, Arc<Col
         .execute("select * from schema_name.non_existent;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Err(QueryErrorBuilder::new()
             .table_does_not_exist("schema_name.non_existent".to_owned())
@@ -37,7 +37,7 @@ fn select_named_columns_from_non_existent_table(sql_engine_with_schema: (QueryEx
         .execute("select column_1 from schema_name.non_existent;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Err(QueryErrorBuilder::new()
             .table_does_not_exist("schema_name.non_existent".to_owned())
@@ -58,7 +58,7 @@ fn select_all_from_table_with_multiple_columns(sql_engine_with_schema: (QueryExe
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -86,7 +86,7 @@ fn select_not_all_columns(sql_engine_with_schema: (QueryExecutor, Arc<Collector>
         .execute("select column_3, column_2 from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(3)),
@@ -114,7 +114,7 @@ fn select_non_existing_columns_from_table(sql_engine_with_schema: (QueryExecutor
         .execute("select column_not_in_table1, column_not_in_table2 from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Err(QueryErrorBuilder::new()
@@ -148,7 +148,7 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(
         .execute("select column_3, column_1 from schema_name.table_name")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -191,7 +191,7 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(
         .execute("select column_3, column_1, column_2 from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -232,7 +232,7 @@ fn select_with_column_name_duplication(sql_engine_with_schema: (QueryExecutor, A
         .execute("select column_3, column_2, column_1, column_3, column_2 from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -295,7 +295,7 @@ fn select_different_integer_types(sql_engine_with_schema: (QueryExecutor, Arc<Co
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -338,7 +338,7 @@ fn select_different_character_strings_types(sql_engine_with_schema: (QueryExecut
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),

--- a/src/sql_engine/src/tests/table.rs
+++ b/src/sql_engine/src/tests/table.rs
@@ -26,7 +26,7 @@ mod schemaless {
             .execute("create table schema_name.table_name (column_name smallint);")
             .expect("no system errors");
 
-        collector.assert_content(vec![Err(QueryErrorBuilder::new()
+        collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
             .schema_does_not_exist("schema_name".to_owned())
             .build())]);
     }
@@ -38,7 +38,7 @@ mod schemaless {
             .execute("drop table schema_name.table_name;")
             .expect("no system errors");
 
-        collector.assert_content(vec![Err(QueryErrorBuilder::new()
+        collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
             .schema_does_not_exist("schema_name".to_owned())
             .build())]);
     }
@@ -52,7 +52,7 @@ fn create_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
         .execute("create table schema_name.table_name (column_name smallint);")
         .expect("no system errors");
 
-    collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+    collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
 }
 
 #[rstest::rstest]
@@ -65,7 +65,7 @@ fn create_same_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
         .execute("create table schema_name.table_name (column_name smallint);")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Err(QueryErrorBuilder::new()
@@ -87,7 +87,7 @@ fn drop_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
         .execute("create table schema_name.table_name (column_name smallint);")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::TableDropped),
@@ -102,7 +102,7 @@ fn drop_non_existent_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector
         .execute("drop table schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Err(QueryErrorBuilder::new()
             .table_does_not_exist("schema_name.table_name".to_owned())
@@ -127,7 +127,7 @@ mod different_types {
             )
             .expect("no system errors");
 
-        collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+        collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
     }
 
     #[rstest::rstest]
@@ -142,7 +142,7 @@ mod different_types {
             )
             .expect("no system errors");
 
-        collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+        collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
     }
 
     #[rstest::rstest]
@@ -156,7 +156,7 @@ mod different_types {
             )
             .expect("no system errors");
 
-        collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+        collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
     }
 
     #[rstest::rstest]
@@ -172,6 +172,6 @@ mod different_types {
             )
             .expect("no system errors");
 
-        collector.assert_content(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+        collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
     }
 }

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -59,7 +59,7 @@ mod insert {
             .execute("insert into schema_name.table_name values (32768);")
             .expect("no system errors");
 
-        collector.assert_content(vec![
+        collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
             Ok(QueryEvent::TableCreated),
             Err(builder.build()),
@@ -76,7 +76,7 @@ mod insert {
             .execute("insert into schema_name.table_name values ('str');")
             .expect("no system errors");
 
-        collector.assert_content(vec![
+        collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
             Ok(QueryEvent::TableCreated),
             Err(builder.build()),
@@ -94,7 +94,7 @@ mod insert {
         builder.out_of_range(PostgreSqlType::SmallInt, "column_si".to_owned(), 1);
         builder.out_of_range(PostgreSqlType::Integer, "column_i".to_owned(), 1);
 
-        collector.assert_content(vec![
+        collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
             Ok(QueryEvent::TableCreated),
             Err(builder.build()),
@@ -110,7 +110,7 @@ mod insert {
             .execute("insert into schema_name.table_name values ('123457890');")
             .expect("no system errors");
 
-        collector.assert_content(vec![
+        collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
             Ok(QueryEvent::TableCreated),
             Err(builder.build()),
@@ -135,7 +135,7 @@ mod update {
             .execute("update schema_name.table_name set col = 32768;")
             .expect("no system errors");
 
-        collector.assert_content(vec![
+        collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
             Ok(QueryEvent::TableCreated),
             Ok(QueryEvent::RecordsInserted(1)),
@@ -155,7 +155,7 @@ mod update {
             .execute("update schema_name.table_name set col = 'str';")
             .expect("no system errors");
 
-        collector.assert_content(vec![
+        collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
             Ok(QueryEvent::TableCreated),
             Ok(QueryEvent::RecordsInserted(1)),
@@ -176,7 +176,7 @@ mod update {
             .execute("update schema_name.table_name set col = '123457890';")
             .expect("no system errors");
 
-        collector.assert_content(vec![
+        collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
             Ok(QueryEvent::TableCreated),
             Ok(QueryEvent::RecordsInserted(1)),
@@ -200,7 +200,7 @@ mod update {
         builder.out_of_range(PostgreSqlType::SmallInt, "column_si".to_owned(), 1);
         builder.out_of_range(PostgreSqlType::Integer, "column_i".to_owned(), 1);
 
-        collector.assert_content(vec![
+        collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
             Ok(QueryEvent::TableCreated),
             Ok(QueryEvent::RecordsInserted(2)),

--- a/src/sql_engine/src/tests/update.rs
+++ b/src/sql_engine/src/tests/update.rs
@@ -37,7 +37,7 @@ fn update_all_records(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -76,7 +76,7 @@ fn update_single_column_of_all_records(sql_engine_with_schema: (QueryExecutor, A
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -127,7 +127,7 @@ fn update_multiple_columns_of_all_records(sql_engine_with_schema: (QueryExecutor
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -177,7 +177,7 @@ fn update_all_records_in_multiple_columns(sql_engine_with_schema: (QueryExecutor
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(3)),
@@ -216,7 +216,7 @@ fn update_records_in_nonexistent_table(sql_engine_with_schema: (QueryExecutor, A
         .execute("update schema_name.table_name set column_test=789;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Err(QueryErrorBuilder::new()
             .table_does_not_exist("schema_name.table_name".to_owned())
@@ -240,7 +240,7 @@ fn update_non_existent_columns_of_records(sql_engine_with_schema: (QueryExecutor
         .execute("update schema_name.table_name set col1=456, col2=789;")
         .expect("no system errors");
 
-    collector.assert_content(vec![
+    collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::RecordsInserted(1)),
@@ -290,7 +290,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -312,7 +312,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -334,7 +334,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -356,7 +356,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -378,7 +378,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -403,7 +403,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -427,7 +427,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -451,7 +451,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -475,7 +475,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -499,7 +499,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -523,7 +523,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -545,7 +545,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -567,7 +567,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -591,7 +591,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -615,7 +615,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -639,7 +639,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -661,7 +661,7 @@ mod operators {
                     .execute("select * from schema_name.table_name;")
                     .expect("no system errors");
 
-                collector.assert_content(vec![
+                collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
                     Ok(QueryEvent::TableCreated),
                     Ok(QueryEvent::RecordsInserted(1)),
@@ -703,7 +703,7 @@ mod operators {
                 .execute("select * from schema_name.table_name;")
                 .expect("no system errors");
 
-            collector.assert_content(vec![
+            collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
                 Ok(QueryEvent::TableCreated),
                 Ok(QueryEvent::RecordsInserted(1)),
@@ -731,7 +731,7 @@ mod operators {
                 .execute("select * from schema_name.table_name;")
                 .expect("no system errors");
 
-            collector.assert_content(vec![
+            collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
                 Ok(QueryEvent::TableCreated),
                 Ok(QueryEvent::RecordsInserted(1)),
@@ -755,7 +755,7 @@ mod operators {
                 .execute("update schema_name.table_name set column_si = 1 || 2;")
                 .expect("no system errors");
 
-            collector.assert_content(vec![
+            collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
                 Ok(QueryEvent::TableCreated),
                 Ok(QueryEvent::RecordsInserted(1)),


### PR DESCRIPTION
This PR is part of Issue #177 (should not close).

#### Description

The [Postgres Extended Query](https://www.postgresql.org/docs/12/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY) includes three steps - `Parse`, `Bind` and `Execute`.
This PR implements the `Parse` step.

The main process of `Parse` is:

```
--> Client sends Parse message to Server
<-- Server responds ParseComplete
--> Client sends DescribeStatement to Server
<-- Service responds ParameterDescription
<-- Service responds RowDescription or NoData
--> Client sends Flush to Server
```

I adds a new Query Event `QueryComplete` to notify `protocol` module to send the `ReadyForQuery` message. Since the all Simple Query messages need send `ReadyForQuery` to client, but not necessary for the Extended Query messages except `Sync`.

#### Client output

For testing this `Parse` process of Extended Query, download `epgsql` and run the commands as below.

```
git clone git@github.com:epgsql/epgsql.git
cd epgsql
make

./rebar3 shell

1> {ok, C} = epgsql:connect("localhost", "user", "password", #{codecs => []}).
2> epgsql:squery(C, "create schema schema_name").
3> epgsql:squery(C, "create table schema_name.table_name (column_1 smallint, column_2 smallint)").

4> epgsql:parse(C, "select_columns", "select * from schema_name.table_name where column_1 = $1 and column_2 = $2", [int4, int4]).
5> epgsql:parse(C, "update_column", "update schema_name.table_name set column_1 = $1 where column_2 = $2", [int4, int4]).
```