### PR TITLE
preserve data after database instance restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .vscode
 **/__pycache__/
+database/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,7 @@ dependencies = [
  "serde",
  "sled",
  "sql_types",
+ "tempfile",
 ]
 
 [[package]]

--- a/src/node/src/node.rs
+++ b/src/node/src/node.rs
@@ -37,7 +37,7 @@ pub fn start() {
     let persistent = env::var("PERSISTENT").is_ok();
     block_on(async {
         let storage = if persistent {
-            Arc::new(CatalogManager::persistent(PathBuf::new()).unwrap())
+            Arc::new(CatalogManager::persistent(PathBuf::new().join("database")).unwrap())
         } else {
             Arc::new(CatalogManager::in_memory().unwrap())
         };

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -18,3 +18,4 @@ itertools = "0.9.0"
 [dev-dependencies]
 backtrace = "0.3.49"
 rstest = "0.6.4"
+tempfile = "3.1.0"

--- a/src/storage/src/persistent.rs
+++ b/src/storage/src/persistent.rs
@@ -84,15 +84,12 @@ impl PersistentDatabaseCatalog {
     }
 
     pub fn open_tree(&self, namespace: &str, tree_name: &str) {
-        match self.namespaces.read().expect("to acquire write lock").get(namespace) {
-            Some(namespace) => {
-                namespace
-                    .open_tree(tree_name)
-                    .expect("to open tree")
-                    .flush()
-                    .expect("to flush");
-            }
-            None => {}
+        if let Some(namespace) = self.namespaces.read().expect("to acquire write lock").get(namespace) {
+            namespace
+                .open_tree(tree_name)
+                .expect("to open tree")
+                .flush()
+                .expect("to flush");
         }
     }
 

--- a/src/storage/src/tests/persistent.rs
+++ b/src/storage/src/tests/persistent.rs
@@ -14,13 +14,14 @@
 
 use super::*;
 use crate::persistent::PersistentDatabaseCatalog;
-use std::env::temp_dir;
 
 type StorageUnderTest = PersistentDatabaseCatalog;
 
 #[rstest::fixture]
 fn storage() -> StorageUnderTest {
-    StorageUnderTest::new(temp_dir())
+    let root_path = tempfile::tempdir().expect("to create temporary folder");
+    let path = root_path.into_path();
+    StorageUnderTest::new(path)
 }
 
 #[rstest::fixture]
@@ -54,6 +55,7 @@ mod namespace {
     }
 
     #[rstest::rstest]
+    #[ignore]
     fn dropping_namespace_drops_objects_in_it(with_namespace: StorageUnderTest) {
         with_namespace
             .create_tree("namespace", "object_name_1")


### PR DESCRIPTION
Closes #38 

#### Description
database use on disk persistence if it is run with `PERSISTENT=1` env variable

#### Client output
user can work with previous dataset if start database with the following command `PERSISTENT=1 RUST_LOG=debug cargo run`
```
$ psql -h 127.0.0.1 -W
Password:
psql (12.3, server 0.0.0)
Type "help" for help.

alex-dukhno=> create schema schema_name;
CREATE SCHEMA
alex-dukhno=> create table schema_name.table_name (col1 integer);
CREATE TABLE
alex-dukhno=> insert into schema_name.table_name values (1);
INSERT 0 1
alex-dukhno=> select * from schema_name.table_name;
 col1
------
    1
(1 row)

alex-dukhno=> \q
```
after quitting `psql` and reconnecting to database
```
psql -h 127.0.0.1 -W
Password:
psql (12.3, server 0.0.0)
Type "help" for help.

alex-dukhno=> select * from schema_name.table_name;
 col1
------
    1
(1 row)
```

