### PR TITLE
implement drop schema cascade

### DIFF
--- a/src/protocol/src/results.rs
+++ b/src/protocol/src/results.rs
@@ -140,6 +140,7 @@ pub(crate) enum QueryErrorKind {
     SchemaAlreadyExists(String),
     TableAlreadyExists(String),
     SchemaDoesNotExist(String),
+    SchemaHasDependentObjects(String),
     TableDoesNotExist(String),
     ColumnDoesNotExist(Vec<String>),
     PreparedStatementDoesNotExist(String),
@@ -176,6 +177,7 @@ impl QueryErrorKind {
             Self::SchemaAlreadyExists(_) => "42P06",
             Self::TableAlreadyExists(_) => "42P07",
             Self::SchemaDoesNotExist(_) => "3F000",
+            Self::SchemaHasDependentObjects(_) => "2BP01",
             Self::TableDoesNotExist(_) => "42P01",
             Self::ColumnDoesNotExist(_) => "42703",
             Self::PreparedStatementDoesNotExist(_) => "26000",
@@ -196,6 +198,9 @@ impl Display for QueryErrorKind {
             Self::SchemaAlreadyExists(schema_name) => write!(f, "schema \"{}\" already exists", schema_name),
             Self::TableAlreadyExists(table_name) => write!(f, "table \"{}\" already exists", table_name),
             Self::SchemaDoesNotExist(schema_name) => write!(f, "schema \"{}\" does not exist", schema_name),
+            Self::SchemaHasDependentObjects(schema_name) => {
+                write!(f, "schema \"{}\" has dependent objects", schema_name)
+            }
             Self::TableDoesNotExist(table_name) => write!(f, "table \"{}\" does not exist", table_name),
             Self::ColumnDoesNotExist(columns) => {
                 if columns.len() > 1 {
@@ -331,6 +336,15 @@ impl QueryErrorBuilder {
         self.errors.push(QueryErrorInner {
             severity: Severity::Error,
             kind: QueryErrorKind::SchemaDoesNotExist(schema_name),
+        });
+        self
+    }
+
+    /// schema has dependent objects error constructor
+    pub fn schema_has_dependent_objects(mut self, schema_name: String) -> Self {
+        self.errors.push(QueryErrorInner {
+            severity: Severity::Error,
+            kind: QueryErrorKind::SchemaHasDependentObjects(schema_name),
         });
         self
     }

--- a/src/sql_engine/src/catalog_manager/data_definition.rs
+++ b/src/sql_engine/src/catalog_manager/data_definition.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::catalog_manager::DropStrategy;
 use crate::ColumnDefinition;
 use kernel::{SystemError, SystemResult};
 use representation::{Binary, Datum};
@@ -24,7 +25,7 @@ use std::{
         Arc, RwLock,
     },
 };
-use storage::{InitStatus, PersistentDatabaseCatalog, Storage, StorageError};
+use storage::{Database, InitStatus, PersistentDatabase, StorageError};
 
 const SYSTEM_CATALOG: &'_ str = "system";
 // CREATE SCHEMA DEFINITION_SCHEMA
@@ -386,6 +387,10 @@ impl Catalog {
             .cloned()
             .collect()
     }
+
+    fn empty(&self) -> bool {
+        self.schemas.read().expect("to acquire read lock").is_empty()
+    }
 }
 
 struct Schema {
@@ -462,6 +467,10 @@ impl Schema {
             .cloned()
             .collect()
     }
+
+    fn empty(&self) -> bool {
+        self.tables.read().expect("to acquire read lock").is_empty()
+    }
 }
 
 struct Table {
@@ -513,16 +522,23 @@ impl Table {
     }
 }
 
-#[allow(dead_code)]
-pub(crate) enum DropStrategy {
-    Restrict,
-    Cascade,
+#[derive(Debug, PartialEq)]
+pub(crate) enum DropCatalogError {
+    DoesNotExist,
+    HasDependentObjects,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum DropSchemaError {
+    CatalogDoesNotExist,
+    DoesNotExist,
+    HasDependentObjects,
 }
 
 pub(crate) struct DataDefinition {
     catalog_ids: AtomicU64,
     catalogs: RwLock<HashMap<Name, Arc<Catalog>>>,
-    system_catalog: Option<Box<dyn Storage>>,
+    system_catalog: Option<Box<dyn Database>>,
 }
 
 impl DataDefinition {
@@ -535,7 +551,7 @@ impl DataDefinition {
     }
 
     pub(crate) fn persistent(path: &PathBuf) -> SystemResult<DataDefinition> {
-        let system_catalog = PersistentDatabaseCatalog::new(path.join(SYSTEM_CATALOG));
+        let system_catalog = PersistentDatabase::new(path.join(SYSTEM_CATALOG));
         let (catalogs, catalog_ids) = match system_catalog.init(DEFINITION_SCHEMA) {
             Ok(InitStatus::Loaded) => {
                 let mut max_id = 0;
@@ -554,16 +570,16 @@ impl DataDefinition {
             }
             Ok(InitStatus::Created) => {
                 system_catalog
-                    .create_tree(DEFINITION_SCHEMA, CATALOG_NAMES_TABLE)
+                    .create_object(DEFINITION_SCHEMA, CATALOG_NAMES_TABLE)
                     .expect("table CATALOG_NAMES is created");
                 system_catalog
-                    .create_tree(DEFINITION_SCHEMA, SCHEMATA_TABLE)
+                    .create_object(DEFINITION_SCHEMA, SCHEMATA_TABLE)
                     .expect("table SCHEMATA is created");
                 system_catalog
-                    .create_tree(DEFINITION_SCHEMA, TABLES_TABLE)
+                    .create_object(DEFINITION_SCHEMA, TABLES_TABLE)
                     .expect("table TABLES is created");
                 system_catalog
-                    .create_tree(DEFINITION_SCHEMA, COLUMNS_TABLE)
+                    .create_object(DEFINITION_SCHEMA, COLUMNS_TABLE)
                     .expect("table COLUMNS is created");
                 (HashMap::new(), 0)
             }
@@ -607,26 +623,101 @@ impl DataDefinition {
             .read()
             .expect("to acquire read lock")
             .get(catalog_name)
-            .map(|database| database.id())
+            .map(|catalog| catalog.id())
     }
 
     #[allow(dead_code)]
-    pub(crate) fn drop_catalog(&self, catalog_name: &str, _strategy: DropStrategy) {
-        if let Some(catalog) = self
-            .catalogs
-            .write()
-            .expect("to acquire write lock")
-            .remove(catalog_name)
-        {
-            if let Some(system_catalog) = self.system_catalog.as_ref() {
-                system_catalog
-                    .delete(
-                        DEFINITION_SCHEMA,
-                        CATALOG_NAMES_TABLE,
-                        vec![Binary::pack(&[Datum::from_u64(catalog.id())])],
-                    )
-                    .expect("to remove catalog");
+    pub(crate) fn drop_catalog(&self, catalog_name: &str, strategy: DropStrategy) -> Result<(), DropCatalogError> {
+        if let Some(catalog) = self.catalog(catalog_name) {
+            match strategy {
+                DropStrategy::Restrict => {
+                    if catalog.empty() {
+                        if let Some(catalog) = self
+                            .catalogs
+                            .write()
+                            .expect("to acquire write lock")
+                            .remove(catalog_name)
+                        {
+                            if let Some(system_catalog) = self.system_catalog.as_ref() {
+                                system_catalog
+                                    .delete(
+                                        DEFINITION_SCHEMA,
+                                        CATALOG_NAMES_TABLE,
+                                        vec![Binary::pack(&[Datum::from_u64(catalog.id())])],
+                                    )
+                                    .expect("to remove catalog");
+                            }
+                        }
+                        Ok(())
+                    } else {
+                        Err(DropCatalogError::HasDependentObjects)
+                    }
+                }
+                DropStrategy::Cascade => {
+                    if let Some(catalog) = self
+                        .catalogs
+                        .write()
+                        .expect("to acquire write lock")
+                        .remove(catalog_name)
+                    {
+                        if let Some(system_catalog) = self.system_catalog.as_ref() {
+                            system_catalog
+                                .delete(
+                                    DEFINITION_SCHEMA,
+                                    CATALOG_NAMES_TABLE,
+                                    vec![Binary::pack(&[Datum::from_u64(catalog.id())])],
+                                )
+                                .expect("to remove catalog");
+                            let schema_record_ids = system_catalog
+                                .read(DEFINITION_SCHEMA, SCHEMATA_TABLE)
+                                .expect("to have SCHEMATA table")
+                                .map(Result::unwrap)
+                                .map(|(record_id, _columns)| {
+                                    let catalog_id = record_id.unpack()[0].as_u64();
+                                    (catalog_id, record_id)
+                                })
+                                .filter(|(catalog_id, _record_id)| *catalog_id == catalog.id())
+                                .map(|(_catalog_id, record_id)| record_id)
+                                .collect();
+                            system_catalog
+                                .delete(DEFINITION_SCHEMA, SCHEMATA_TABLE, schema_record_ids)
+                                .expect("to remove schemas under catalog");
+                            let table_record_ids = system_catalog
+                                .read(DEFINITION_SCHEMA, TABLES_TABLE)
+                                .expect("to have TABLES table")
+                                .map(Result::unwrap)
+                                .map(|(record_id, _columns)| {
+                                    let catalog_id = record_id.unpack()[0].as_u64();
+                                    (catalog_id, record_id)
+                                })
+                                .filter(|(catalog_id, _record_id)| *catalog_id == catalog.id())
+                                .map(|(_catalog_id, record_id)| record_id)
+                                .collect();
+                            system_catalog
+                                .delete(DEFINITION_SCHEMA, TABLES_TABLE, table_record_ids)
+                                .expect("to remove tables under catalog");
+                            let table_column_record_ids = system_catalog
+                                .read(DEFINITION_SCHEMA, COLUMNS_TABLE)
+                                .expect("to have COLUMNS table")
+                                .map(Result::unwrap)
+                                .map(|(record_id, _data)| {
+                                    let record = record_id.unpack();
+                                    let catalog = record[0].as_u64();
+                                    (record_id, catalog)
+                                })
+                                .filter(|(_record_id, catalog_id)| *catalog_id == catalog.id())
+                                .map(|(record_id, _catalog)| record_id)
+                                .collect();
+                            system_catalog
+                                .delete(DEFINITION_SCHEMA, COLUMNS_TABLE, table_column_record_ids)
+                                .expect("to have remove tables columns under catalog");
+                        }
+                    }
+                    Ok(())
+                }
             }
+        } else {
+            Err(DropCatalogError::DoesNotExist)
         }
     }
 
@@ -692,24 +783,102 @@ impl DataDefinition {
         result
     }
 
-    pub(crate) fn drop_schema(&self, catalog_name: &str, schema_name: &str) {
+    pub(crate) fn drop_schema(
+        &self,
+        catalog_name: &str,
+        schema_name: &str,
+        strategy: DropStrategy,
+    ) -> Result<(), DropSchemaError> {
         let catalog = match self.catalog(catalog_name) {
             Some(catalog) => catalog,
-            None => return,
+            None => return Err(DropSchemaError::CatalogDoesNotExist),
         };
-        let schema_id = catalog.remove_schema(schema_name);
-        if let Some(system_catalog) = self.system_catalog.as_ref() {
-            if let Some(schema_id) = schema_id {
-                system_catalog
-                    .delete(
-                        DEFINITION_SCHEMA,
-                        SCHEMATA_TABLE,
-                        vec![Binary::pack(&[
-                            Datum::from_u64(catalog.id()),
-                            Datum::from_u64(schema_id),
-                        ])],
-                    )
-                    .expect("to remove schema");
+        let schema = match catalog.schema(schema_name) {
+            Some(schema) => schema,
+            None => return Err(DropSchemaError::DoesNotExist),
+        };
+        match strategy {
+            DropStrategy::Restrict => {
+                if schema.empty() {
+                    let schema_id = catalog.remove_schema(schema_name);
+                    match schema_id {
+                        None => Err(DropSchemaError::DoesNotExist),
+                        Some(schema_id) => {
+                            if let Some(system_catalog) = self.system_catalog.as_ref() {
+                                system_catalog
+                                    .delete(
+                                        DEFINITION_SCHEMA,
+                                        SCHEMATA_TABLE,
+                                        vec![Binary::pack(&[
+                                            Datum::from_u64(catalog.id()),
+                                            Datum::from_u64(schema_id),
+                                        ])],
+                                    )
+                                    .expect("to remove schema");
+                            }
+                            Ok(())
+                        }
+                    }
+                } else {
+                    Err(DropSchemaError::HasDependentObjects)
+                }
+            }
+            DropStrategy::Cascade => {
+                let schema_id = catalog.remove_schema(schema_name);
+                match schema_id {
+                    None => Err(DropSchemaError::DoesNotExist),
+                    Some(schema_id) => {
+                        if let Some(system_catalog) = self.system_catalog.as_ref() {
+                            system_catalog
+                                .delete(
+                                    DEFINITION_SCHEMA,
+                                    SCHEMATA_TABLE,
+                                    vec![Binary::pack(&[
+                                        Datum::from_u64(catalog.id()),
+                                        Datum::from_u64(schema_id),
+                                    ])],
+                                )
+                                .expect("to remove schema");
+                            let table_record_ids = system_catalog
+                                .read(DEFINITION_SCHEMA, TABLES_TABLE)
+                                .expect("to have TABLES table")
+                                .map(Result::unwrap)
+                                .map(|(record_id, _columns)| {
+                                    let ids = record_id.unpack();
+                                    let catalog_id = ids[0].as_u64();
+                                    let schema_id = ids[1].as_u64();
+                                    (catalog_id, schema_id, record_id)
+                                })
+                                .filter(|(catalog_id, schema, _record_id)| {
+                                    *catalog_id == catalog.id() && *schema == schema_id
+                                })
+                                .map(|(_catalog_id, _schema, record_id)| record_id)
+                                .collect();
+                            system_catalog
+                                .delete(DEFINITION_SCHEMA, TABLES_TABLE, table_record_ids)
+                                .expect("to remove tables under catalog");
+                            let table_column_record_ids = system_catalog
+                                .read(DEFINITION_SCHEMA, COLUMNS_TABLE)
+                                .expect("to have COLUMNS table")
+                                .map(Result::unwrap)
+                                .map(|(record_id, _data)| {
+                                    let record = record_id.unpack();
+                                    let catalog = record[0].as_u64();
+                                    let schema = record[1].as_u64();
+                                    (record_id, catalog, schema)
+                                })
+                                .filter(|(_record_id, catalog_id, schema)| {
+                                    *catalog_id == catalog.id() && *schema == schema_id
+                                })
+                                .map(|(record_id, _catalog, _schema)| record_id)
+                                .collect();
+                            system_catalog
+                                .delete(DEFINITION_SCHEMA, COLUMNS_TABLE, table_column_record_ids)
+                                .expect("to have remove tables columns under catalog");
+                        }
+                        Ok(())
+                    }
+                }
             }
         }
     }
@@ -741,12 +910,6 @@ impl DataDefinition {
     }
 
     pub(crate) fn table_exists(&self, catalog_name: &str, schema_name: &str, table_name: &str) -> TableId {
-        log::debug!(
-            "checking table existence {:?}.{:?}.{:?}",
-            catalog_name,
-            schema_name,
-            table_name
-        );
         let catalog = match self.catalog(catalog_name) {
             Some(catalog) => catalog,
             None => return None,
@@ -1015,7 +1178,21 @@ mod tests {
     fn not_created_catalog_does_not_exist() {
         let data_definition = DataDefinition::in_memory();
 
-        assert!(data_definition.catalog_exists("catalog_name").is_none());
+        assert!(matches!(data_definition.catalog_exists("catalog_name"), None));
+    }
+
+    #[test]
+    fn cant_drop_non_existent_catalog() {
+        let data_definition = DataDefinition::in_memory();
+
+        assert_eq!(
+            data_definition.drop_catalog("catalog_name", DropStrategy::Restrict),
+            Err(DropCatalogError::DoesNotExist)
+        );
+        assert_eq!(
+            data_definition.drop_catalog("catalog_name", DropStrategy::Cascade),
+            Err(DropCatalogError::DoesNotExist)
+        );
     }
 
     #[test]
@@ -1024,7 +1201,7 @@ mod tests {
 
         data_definition.create_catalog("catalog_name");
 
-        assert!(data_definition.catalog_exists("catalog_name").is_some());
+        assert!(matches!(data_definition.catalog_exists("catalog_name"), Some(_)));
     }
 
     #[test]
@@ -1033,11 +1210,48 @@ mod tests {
 
         data_definition.create_catalog("catalog_name");
 
-        assert!(data_definition.catalog_exists("catalog_name").is_some());
+        assert!(matches!(data_definition.catalog_exists("catalog_name"), Some(_)));
 
-        data_definition.drop_catalog("catalog_name", DropStrategy::Restrict);
+        assert_eq!(
+            data_definition.drop_catalog("catalog_name", DropStrategy::Restrict),
+            Ok(())
+        );
 
-        assert!(data_definition.catalog_exists("catalog_name").is_none());
+        assert!(matches!(data_definition.catalog_exists("catalog_name"), None));
+    }
+
+    #[test]
+    fn restrict_drop_strategy_cant_drop_non_empty_catalog() {
+        let data_definition = DataDefinition::in_memory();
+
+        data_definition.create_catalog("catalog_name");
+        data_definition.create_schema("catalog_name", "schema_name");
+
+        assert_eq!(
+            data_definition.drop_catalog("catalog_name", DropStrategy::Restrict),
+            Err(DropCatalogError::HasDependentObjects)
+        );
+
+        assert!(matches!(data_definition.catalog_exists("catalog_name"), Some(_)));
+    }
+
+    #[test]
+    fn cascade_drop_of_non_empty_catalog() {
+        let data_definition = DataDefinition::in_memory();
+
+        data_definition.create_catalog("catalog_name");
+        data_definition.create_schema("catalog_name", "schema_name");
+
+        assert_eq!(
+            data_definition.drop_catalog("catalog_name", DropStrategy::Cascade),
+            Ok(())
+        );
+
+        assert!(matches!(data_definition.catalog_exists("catalog_name"), None));
+        assert!(matches!(
+            data_definition.schema_exists("catalog_name", "schema_name"),
+            None
+        ));
     }
 
     #[test]
@@ -1045,11 +1259,39 @@ mod tests {
         let data_definition = DataDefinition::in_memory();
 
         data_definition.create_catalog("catalog_name");
-        assert!(data_definition
-            .schema_exists("catalog_name", "schema_name")
-            .expect("to have catalog")
-            .1
-            .is_none());
+        assert!(matches!(
+            data_definition.schema_exists("catalog_name", "schema_name"),
+            Some((_, None))
+        ));
+    }
+
+    #[test]
+    fn cant_drop_schema_from_nonexistent_catalog() {
+        let data_definition = DataDefinition::in_memory();
+
+        assert_eq!(
+            data_definition.drop_schema("catalog_name", "schema_name", DropStrategy::Restrict),
+            Err(DropSchemaError::CatalogDoesNotExist)
+        );
+        assert_eq!(
+            data_definition.drop_schema("catalog_name", "schema_name", DropStrategy::Cascade),
+            Err(DropSchemaError::CatalogDoesNotExist)
+        );
+    }
+
+    #[test]
+    fn cant_drop_non_existent_schema() {
+        let data_definition = DataDefinition::in_memory();
+
+        data_definition.create_catalog("catalog_name");
+        assert_eq!(
+            data_definition.drop_schema("catalog_name", "schema_name", DropStrategy::Restrict),
+            Err(DropSchemaError::DoesNotExist)
+        );
+        assert_eq!(
+            data_definition.drop_schema("catalog_name", "schema_name", DropStrategy::Cascade),
+            Err(DropSchemaError::DoesNotExist)
+        );
     }
 
     #[test]
@@ -1071,13 +1313,61 @@ mod tests {
 
         assert!(data_definition.schema_exists("catalog_name", "schema_name").is_some());
 
-        data_definition.drop_schema("catalog_name", "schema_name");
+        assert_eq!(
+            data_definition.drop_schema("catalog_name", "schema_name", DropStrategy::Restrict),
+            Ok(())
+        );
 
-        assert!(data_definition
-            .schema_exists("catalog_name", "schema_name")
-            .expect("to have catalog")
-            .1
-            .is_none());
+        assert!(matches!(
+            data_definition.schema_exists("catalog_name", "schema_name"),
+            Some((_, None))
+        ));
+    }
+
+    #[test]
+    fn restrict_drop_strategy_cant_drop_non_empty_schema() {
+        let data_definition = DataDefinition::in_memory();
+
+        data_definition.create_catalog("catalog_name");
+        data_definition.create_schema("catalog_name", "schema_name");
+        data_definition.create_table("catalog_name", "schema_name", "table_name", &[]);
+
+        assert_eq!(
+            data_definition.drop_schema("catalog_name", "schema_name", DropStrategy::Restrict),
+            Err(DropSchemaError::HasDependentObjects)
+        );
+
+        assert!(matches!(
+            data_definition.schema_exists("catalog_name", "schema_name"),
+            Some((_, Some(_)))
+        ));
+        assert!(matches!(
+            data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+            Some((_, Some((_, Some(_)))))
+        ))
+    }
+
+    #[test]
+    fn cascade_drop_of_non_empty_schema() {
+        let data_definition = DataDefinition::in_memory();
+
+        data_definition.create_catalog("catalog_name");
+        data_definition.create_schema("catalog_name", "schema_name");
+        data_definition.create_table("catalog_name", "schema_name", "table_name", &[]);
+
+        assert_eq!(
+            data_definition.drop_schema("catalog_name", "schema_name", DropStrategy::Cascade),
+            Ok(())
+        );
+
+        assert!(matches!(
+            data_definition.schema_exists("catalog_name", "schema_name"),
+            Some((_, None))
+        ));
+        assert!(matches!(
+            data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+            Some((_, None))
+        ));
     }
 
     #[test]
@@ -1086,13 +1376,10 @@ mod tests {
 
         data_definition.create_catalog("catalog_name");
         data_definition.create_schema("catalog_name", "schema_name");
-        assert!(data_definition
-            .table_exists("catalog_name", "schema_name", "table_name")
-            .expect("to have catalog")
-            .1
-            .expect("to have schema")
-            .1
-            .is_none());
+        assert!(matches!(
+            data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+            Some((_, Some((_, None))))
+        ));
     }
 
     #[test]
@@ -1103,13 +1390,10 @@ mod tests {
         data_definition.create_schema("catalog_name", "schema_name");
         data_definition.create_table("catalog_name", "schema_name", "table_name", &[]);
 
-        assert!(data_definition
-            .table_exists("catalog_name", "schema_name", "table_name")
-            .expect("to have catalog")
-            .1
-            .expect("to have schema")
-            .1
-            .is_some());
+        assert!(matches!(
+            data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+            Some((_, Some((_, Some(_)))))
+        ));
     }
 
     #[test]
@@ -1120,23 +1404,17 @@ mod tests {
         data_definition.create_schema("catalog_name", "schema_name");
         data_definition.create_table("catalog_name", "schema_name", "table_name", &[]);
 
-        assert!(data_definition
-            .table_exists("catalog_name", "schema_name", "table_name")
-            .expect("to have catalog")
-            .1
-            .expect("to have schema")
-            .1
-            .is_some());
+        assert!(matches!(
+            data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+            Some((_, Some((_, Some(_)))))
+        ));
 
         data_definition.drop_table("catalog_name", "schema_name", "table_name");
 
-        assert!(data_definition
-            .table_exists("catalog_name", "schema_name", "table_name")
-            .expect("to have catalog")
-            .1
-            .expect("to have schema")
-            .1
-            .is_none());
+        assert!(matches!(
+            data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+            Some((_, Some((_, None))))
+        ));
     }
 
     #[cfg(test)]
@@ -1158,20 +1436,22 @@ mod tests {
             drop(data_definition);
 
             let data_definition = DataDefinition::persistent(&path).expect("create persistent data definition");
-            assert!(data_definition.catalog_exists("catalog_name").is_some());
+            assert!(matches!(data_definition.catalog_exists("catalog_name"), Some(_)));
         }
 
         #[rstest::rstest]
         fn dropped_catalog_is_not_preserved_after_restart(storage_path: (DataDefinition, PathBuf)) {
             let (data_definition, path) = storage_path;
             data_definition.create_catalog("catalog_name");
-            assert!(data_definition.catalog_exists("catalog_name").is_some());
-            data_definition.drop_catalog("catalog_name", DropStrategy::Restrict);
-            assert!(data_definition.catalog_exists("catalog_name").is_none());
+            assert!(matches!(data_definition.catalog_exists("catalog_name"), Some(_)));
+            data_definition
+                .drop_catalog("catalog_name", DropStrategy::Restrict)
+                .expect("to catalog dropped");
+            assert!(matches!(data_definition.catalog_exists("catalog_name"), None));
             drop(data_definition);
 
             let data_definition = DataDefinition::persistent(&path).expect("create persistent data definition");
-            assert!(data_definition.catalog_exists("catalog_name").is_none());
+            assert!(matches!(data_definition.catalog_exists("catalog_name"), None));
         }
 
         #[rstest::rstest]
@@ -1182,11 +1462,10 @@ mod tests {
             drop(data_definition);
 
             let data_definition = DataDefinition::persistent(&path).expect("create persistent data definition");
-            assert!(data_definition
-                .schema_exists("catalog_name", "schema_name")
-                .expect("to have catalog")
-                .1
-                .is_some());
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name", "schema_name"),
+                Some(_)
+            ));
         }
 
         #[rstest::rstest]
@@ -1200,49 +1479,41 @@ mod tests {
             data_definition.create_catalog("catalog_name_2");
             data_definition.create_schema("catalog_name_2", "schema_name_3");
             data_definition.create_schema("catalog_name_2", "schema_name_4");
-            assert!(data_definition
-                .schema_exists("catalog_name_1", "schema_name_1")
-                .expect("to have catalog")
-                .1
-                .is_some());
-            assert!(data_definition
-                .schema_exists("catalog_name_1", "schema_name_2")
-                .expect("to have catalog")
-                .1
-                .is_some());
-            assert!(data_definition
-                .schema_exists("catalog_name_2", "schema_name_3")
-                .expect("to have catalog")
-                .1
-                .is_some());
-            assert!(data_definition
-                .schema_exists("catalog_name_2", "schema_name_4")
-                .expect("to have catalog")
-                .1
-                .is_some());
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name_1", "schema_name_1"),
+                Some((_, Some(_)))
+            ));
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name_1", "schema_name_2"),
+                Some((_, Some(_)))
+            ));
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name_2", "schema_name_3"),
+                Some((_, Some(_)))
+            ));
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name_2", "schema_name_4"),
+                Some((_, Some(_)))
+            ));
             drop(data_definition);
 
             let data_definition = DataDefinition::persistent(&path).expect("create persistent data definition");
-            assert!(data_definition
-                .schema_exists("catalog_name_1", "schema_name_1")
-                .expect("to have catalog")
-                .1
-                .is_some());
-            assert!(data_definition
-                .schema_exists("catalog_name_1", "schema_name_2")
-                .expect("to have catalog")
-                .1
-                .is_some());
-            assert!(data_definition
-                .schema_exists("catalog_name_2", "schema_name_3")
-                .expect("to have catalog")
-                .1
-                .is_some());
-            assert!(data_definition
-                .schema_exists("catalog_name_2", "schema_name_4")
-                .expect("to have catalog")
-                .1
-                .is_some());
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name_1", "schema_name_1"),
+                Some((_, Some(_)))
+            ));
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name_1", "schema_name_2"),
+                Some((_, Some(_)))
+            ));
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name_2", "schema_name_3"),
+                Some((_, Some(_)))
+            ));
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name_2", "schema_name_4"),
+                Some((_, Some(_)))
+            ));
         }
 
         #[rstest::rstest]
@@ -1250,25 +1521,25 @@ mod tests {
             let (data_definition, path) = storage_path;
             data_definition.create_catalog("catalog_name");
             data_definition.create_schema("catalog_name", "schema_name");
-            assert!(data_definition
-                .schema_exists("catalog_name", "schema_name")
-                .expect("to have catalog")
-                .1
-                .is_some());
-            data_definition.drop_schema("catalog_name", "schema_name");
-            assert!(data_definition
-                .schema_exists("catalog_name", "schema_name")
-                .expect("to have catalog")
-                .1
-                .is_none());
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name", "schema_name"),
+                Some((_, Some(_)))
+            ));
+            assert_eq!(
+                data_definition.drop_schema("catalog_name", "schema_name", DropStrategy::Restrict),
+                Ok(())
+            );
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name", "schema_name"),
+                Some((_, None))
+            ));
             drop(data_definition);
 
             let data_definition = DataDefinition::persistent(&path).expect("create persistent data definition");
-            assert!(data_definition
-                .schema_exists("catalog_name", "schema_name")
-                .expect("to have catalog")
-                .1
-                .is_none());
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name", "schema_name"),
+                Some((_, None))
+            ));
         }
 
         #[rstest::rstest]
@@ -1398,62 +1669,38 @@ mod tests {
             drop(data_definition);
 
             let data_definition = DataDefinition::persistent(&path).expect("create persistent data definition");
-            assert!(data_definition
-                .table_exists("catalog_name_1", "schema_name_1", "table_name_1")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_some());
-            assert!(data_definition
-                .table_exists("catalog_name_1", "schema_name_1", "table_name_2")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_some());
-            assert!(data_definition
-                .table_exists("catalog_name_1", "schema_name_2", "table_name_3")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_some());
-            assert!(data_definition
-                .table_exists("catalog_name_1", "schema_name_2", "table_name_4")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_some());
-            assert!(data_definition
-                .table_exists("catalog_name_2", "schema_name_3", "table_name_5")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_some());
-            assert!(data_definition
-                .table_exists("catalog_name_2", "schema_name_3", "table_name_6")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_some());
-            assert!(data_definition
-                .table_exists("catalog_name_2", "schema_name_4", "table_name_7")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_some());
-            assert!(data_definition
-                .table_exists("catalog_name_2", "schema_name_4", "table_name_8")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_some());
+            assert!(matches!(
+                data_definition.table_exists("catalog_name_1", "schema_name_1", "table_name_1"),
+                Some((_, Some((_, Some(_)))))
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name_1", "schema_name_1", "table_name_2"),
+                Some((_, Some((_, Some(_)))))
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name_1", "schema_name_2", "table_name_3"),
+                Some((_, Some((_, Some(_)))))
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name_1", "schema_name_2", "table_name_4"),
+                Some((_, Some((_, Some(_)))))
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name_2", "schema_name_3", "table_name_5"),
+                Some((_, Some((_, Some(_)))))
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name_2", "schema_name_3", "table_name_6"),
+                Some((_, Some((_, Some(_)))))
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name_2", "schema_name_4", "table_name_7"),
+                Some((_, Some((_, Some(_)))))
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name_2", "schema_name_4", "table_name_8"),
+                Some((_, Some((_, Some(_)))))
+            ));
         }
 
         #[rstest::rstest]
@@ -1467,31 +1714,22 @@ mod tests {
                 "table_name",
                 &[ColumnDefinition::new("col_1", SqlType::Integer(0))],
             );
-            assert!(data_definition
-                .table_exists("catalog_name", "schema_name", "table_name")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_some());
+            assert!(matches!(
+                data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+                Some((_, Some((_, Some(_)))))
+            ));
             data_definition.drop_table("catalog_name", "schema_name", "table_name");
-            assert!(data_definition
-                .table_exists("catalog_name", "schema_name", "table_name")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_none());
+            assert!(matches!(
+                data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+                Some((_, Some((_, None))))
+            ));
             drop(data_definition);
 
             let data_definition = DataDefinition::persistent(&path).expect("create persistent data definition");
-            assert!(data_definition
-                .table_exists("catalog_name", "schema_name", "table_name")
-                .expect("to have catalog")
-                .1
-                .expect("to have schema")
-                .1
-                .is_none());
+            assert!(matches!(
+                data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+                Some((_, Some((_, None))))
+            ));
         }
 
         #[rstest::rstest]
@@ -1762,6 +2000,119 @@ mod tests {
                     ColumnDefinition::new("col_6", SqlType::BigInt(0))
                 ]
             );
+        }
+
+        #[rstest::rstest]
+        fn tables_schemas_are_not_preserved_after_cascade_catalog_drop(storage_path: (DataDefinition, PathBuf)) {
+            let (data_definition, path) = storage_path;
+            data_definition.create_catalog("catalog_name");
+            data_definition.create_schema("catalog_name", "schema_name");
+            data_definition.create_table(
+                "catalog_name",
+                "schema_name",
+                "table_name",
+                &[ColumnDefinition::new("col_1", SqlType::SmallInt(0))],
+            );
+
+            assert_eq!(
+                data_definition.drop_catalog("catalog_name", DropStrategy::Cascade),
+                Ok(())
+            );
+            assert!(matches!(data_definition.catalog_exists("catalog_name"), None));
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name", "schema_name"),
+                None
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+                None
+            ));
+            assert_eq!(
+                data_definition.table_columns("catalog_name", "schema_name", "table_name"),
+                vec![]
+            );
+
+            drop(data_definition);
+
+            let data_definition = DataDefinition::persistent(&path).expect("create persistent data definition");
+
+            assert!(matches!(data_definition.catalog_exists("catalog_name"), None));
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name", "schema_name"),
+                None
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+                None
+            ));
+            assert_eq!(
+                data_definition.table_columns("catalog_name", "schema_name", "table_name"),
+                vec![]
+            );
+
+            data_definition.create_catalog("catalog_name");
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name", "schema_name"),
+                Some((_, None))
+            ));
+            data_definition.create_schema("catalog_name", "schema_name");
+            assert!(matches!(
+                data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+                Some((_, Some((_, None))))
+            ));
+        }
+
+        #[rstest::rstest]
+        fn tables_are_not_preserved_after_cascade_schema_drop(storage_path: (DataDefinition, PathBuf)) {
+            let (data_definition, path) = storage_path;
+            data_definition.create_catalog("catalog_name");
+            data_definition.create_schema("catalog_name", "schema_name");
+            data_definition.create_table(
+                "catalog_name",
+                "schema_name",
+                "table_name",
+                &[ColumnDefinition::new("col_1", SqlType::SmallInt(0))],
+            );
+
+            assert_eq!(
+                data_definition.drop_schema("catalog_name", "schema_name", DropStrategy::Cascade),
+                Ok(())
+            );
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name", "schema_name"),
+                Some((_, None))
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+                Some((_, None))
+            ));
+            assert_eq!(
+                data_definition.table_columns("catalog_name", "schema_name", "table_name"),
+                vec![]
+            );
+
+            drop(data_definition);
+
+            let data_definition = DataDefinition::persistent(&path).expect("create persistent data definition");
+
+            assert!(matches!(
+                data_definition.schema_exists("catalog_name", "schema_name"),
+                Some((_, None))
+            ));
+            assert!(matches!(
+                data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+                Some((_, None))
+            ));
+            assert_eq!(
+                data_definition.table_columns("catalog_name", "schema_name", "table_name"),
+                vec![]
+            );
+
+            // data_definition.create_schema("catalog_name", "schema_name");
+            // assert!(matches!(
+            //     data_definition.table_exists("catalog_name", "schema_name", "table_name"),
+            //     Some((_, Some((_, None))))
+            // ));
         }
     }
 }

--- a/src/sql_engine/src/catalog_manager/data_definition.rs
+++ b/src/sql_engine/src/catalog_manager/data_definition.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::catalog_manager::DropStrategy;
-use crate::ColumnDefinition;
+use crate::{catalog_manager::DropStrategy, ColumnDefinition};
 use kernel::{SystemError, SystemResult};
 use representation::{Binary, Datum};
 use sql_types::SqlType;

--- a/src/sql_engine/src/catalog_manager/data_definition.rs
+++ b/src/sql_engine/src/catalog_manager/data_definition.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::catalog_manager::DropSchemaError;
-use crate::{catalog_manager::DropStrategy, ColumnDefinition};
+use crate::{
+    catalog_manager::{DropSchemaError, DropStrategy},
+    ColumnDefinition,
+};
 use kernel::{SystemError, SystemResult};
 use representation::{Binary, Datum};
 use sql_types::SqlType;

--- a/src/sql_engine/src/catalog_manager/data_definition.rs
+++ b/src/sql_engine/src/catalog_manager/data_definition.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::catalog_manager::DropSchemaError;
 use crate::{catalog_manager::DropStrategy, ColumnDefinition};
 use kernel::{SystemError, SystemResult};
 use representation::{Binary, Datum};
@@ -523,13 +524,6 @@ impl Table {
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum DropCatalogError {
-    DoesNotExist,
-    HasDependentObjects,
-}
-
-#[derive(Debug, PartialEq)]
-pub(crate) enum DropSchemaError {
-    CatalogDoesNotExist,
     DoesNotExist,
     HasDependentObjects,
 }

--- a/src/sql_engine/src/catalog_manager/tests/mod.rs
+++ b/src/sql_engine/src/catalog_manager/tests/mod.rs
@@ -23,20 +23,18 @@ mod schema;
 #[cfg(test)]
 mod table;
 
-type PersistentStorage = CatalogManager;
-
 #[rstest::fixture]
 fn default_schema_name() -> &'static str {
     "schema_name"
 }
 
 #[rstest::fixture]
-fn storage() -> PersistentStorage {
+fn storage() -> CatalogManager {
     CatalogManager::default()
 }
 
 #[rstest::fixture]
-fn storage_with_schema(storage: PersistentStorage, default_schema_name: &str) -> PersistentStorage {
+fn storage_with_schema(storage: CatalogManager, default_schema_name: &str) -> CatalogManager {
     create_schema(&storage, default_schema_name);
     storage
 }

--- a/src/sql_engine/src/catalog_manager/tests/queries/delete.rs
+++ b/src/sql_engine/src/catalog_manager/tests/queries/delete.rs
@@ -16,7 +16,7 @@ use super::*;
 use sql_types::SqlType;
 
 #[rstest::rstest]
-fn delete_all_from_table(default_schema_name: &str, storage_with_schema: PersistentStorage) {
+fn delete_all_from_table(default_schema_name: &str, storage_with_schema: CatalogManager) {
     create_table(
         &storage_with_schema,
         default_schema_name,

--- a/src/sql_engine/src/catalog_manager/tests/queries/select.rs
+++ b/src/sql_engine/src/catalog_manager/tests/queries/select.rs
@@ -17,7 +17,7 @@ use representation::Binary;
 use sql_types::SqlType;
 
 #[rstest::fixture]
-fn with_small_ints_table(default_schema_name: &str, storage_with_schema: PersistentStorage) -> PersistentStorage {
+fn with_small_ints_table(default_schema_name: &str, storage_with_schema: CatalogManager) -> CatalogManager {
     create_table(
         &storage_with_schema,
         default_schema_name,
@@ -32,7 +32,7 @@ fn with_small_ints_table(default_schema_name: &str, storage_with_schema: Persist
 }
 
 #[rstest::rstest]
-fn select_all_from_table_with_many_columns(default_schema_name: &str, with_small_ints_table: PersistentStorage) {
+fn select_all_from_table_with_many_columns(default_schema_name: &str, with_small_ints_table: CatalogManager) {
     insert_into(
         &with_small_ints_table,
         default_schema_name,

--- a/src/sql_engine/src/catalog_manager/tests/schema.rs
+++ b/src/sql_engine/src/catalog_manager/tests/schema.rs
@@ -58,10 +58,28 @@ fn same_table_names_with_different_columns_in_different_schemas(storage: Catalog
 #[rstest::rstest]
 fn drop_schema(default_schema_name: &str, storage_with_schema: CatalogManager) {
     assert_eq!(
-        storage_with_schema.drop_schema(default_schema_name, DropStrategy::Restrict),
+        storage_with_schema
+            .drop_schema(default_schema_name, DropStrategy::Restrict)
+            .expect("no system errors"),
         Ok(())
     );
     assert_eq!(storage_with_schema.create_schema(default_schema_name), Ok(()));
+}
+
+#[rstest::rstest]
+fn restrict_drop_schema_does_not_drop_schema_with_table(
+    default_schema_name: &str,
+    storage_with_schema: CatalogManager,
+) {
+    storage_with_schema
+        .create_table(default_schema_name, "table_name", &[])
+        .expect("no system errors");
+    assert_eq!(
+        storage_with_schema
+            .drop_schema(default_schema_name, DropStrategy::Restrict)
+            .expect("no system errors"),
+        Err(DropSchemaError::HasDependentObjects)
+    );
 }
 
 #[rstest::rstest]
@@ -80,7 +98,9 @@ fn cascade_drop_schema_drops_tables_in_it(default_schema_name: &str, storage_wit
     );
 
     assert_eq!(
-        storage_with_schema.drop_schema(default_schema_name, DropStrategy::Cascade),
+        storage_with_schema
+            .drop_schema(default_schema_name, DropStrategy::Cascade)
+            .expect("no system errors"),
         Ok(())
     );
     assert_eq!(storage_with_schema.create_schema(default_schema_name), Ok(()));

--- a/src/sql_engine/src/catalog_manager/tests/table.rs
+++ b/src/sql_engine/src/catalog_manager/tests/table.rs
@@ -16,7 +16,7 @@ use super::*;
 use sql_types::SqlType;
 
 #[rstest::rstest]
-fn create_tables_with_different_names(default_schema_name: &str, storage_with_schema: PersistentStorage) {
+fn create_tables_with_different_names(default_schema_name: &str, storage_with_schema: CatalogManager) {
     assert_eq!(
         storage_with_schema.create_table(
             default_schema_name,
@@ -42,7 +42,7 @@ fn create_tables_with_different_names(default_schema_name: &str, storage_with_sc
 }
 
 #[rstest::rstest]
-fn create_table_with_the_same_name_in_different_schemas(storage: PersistentStorage) {
+fn create_table_with_the_same_name_in_different_schemas(storage: CatalogManager) {
     create_schema(&storage, "schema_name_1");
     create_schema(&storage, "schema_name_2");
     assert_eq!(
@@ -70,7 +70,7 @@ fn create_table_with_the_same_name_in_different_schemas(storage: PersistentStora
 }
 
 #[rstest::rstest]
-fn drop_table(default_schema_name: &str, storage_with_schema: PersistentStorage) {
+fn drop_table(default_schema_name: &str, storage_with_schema: CatalogManager) {
     create_table(
         &storage_with_schema,
         default_schema_name,
@@ -98,7 +98,7 @@ fn drop_table(default_schema_name: &str, storage_with_schema: PersistentStorage)
 }
 
 #[rstest::rstest]
-fn table_columns_on_empty_table(default_schema_name: &str, storage_with_schema: PersistentStorage) {
+fn table_columns_on_empty_table(default_schema_name: &str, storage_with_schema: CatalogManager) {
     create_table(&storage_with_schema, default_schema_name, "table_name", vec![]);
 
     assert_eq!(

--- a/src/sql_engine/src/ddl/drop_schema.rs
+++ b/src/sql_engine/src/ddl/drop_schema.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::catalog_manager::DropSchemaError;
 use crate::{
-    catalog_manager::{CatalogManager, DropStrategy},
+    catalog_manager::{CatalogManager, DropSchemaError, DropStrategy},
     query::SchemaId,
 };
 use kernel::SystemResult;
-use protocol::results::QueryErrorBuilder;
-use protocol::{results::QueryEvent, Sender};
+use protocol::{
+    results::{QueryErrorBuilder, QueryEvent},
+    Sender,
+};
 use std::sync::Arc;
 
 pub(crate) struct DropSchemaCommand {

--- a/src/sql_engine/src/ddl/drop_schema.rs
+++ b/src/sql_engine/src/ddl/drop_schema.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::catalog_manager::DropStrategy;
-use crate::{catalog_manager::CatalogManager, query::SchemaId};
+use crate::{
+    catalog_manager::{CatalogManager, DropStrategy},
+    query::SchemaId,
+};
 use kernel::SystemResult;
 use protocol::{results::QueryEvent, Sender};
 use std::sync::Arc;

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -172,8 +172,8 @@ impl QueryExecutor {
                 CreateTableCommand::new(creation_info, self.storage.clone(), self.sender.clone()).execute()?
             }
             Ok(Plan::DropSchemas(schemas)) => {
-                for schema in schemas {
-                    DropSchemaCommand::new(schema, self.storage.clone(), self.sender.clone()).execute()?;
+                for (schema, cascade) in schemas {
+                    DropSchemaCommand::new(schema, cascade, self.storage.clone(), self.sender.clone()).execute()?;
                 }
             }
             Ok(Plan::DropTables(tables)) => {

--- a/src/sql_engine/src/query/plan.rs
+++ b/src/sql_engine/src/query/plan.rs
@@ -41,7 +41,7 @@ pub enum Plan {
     CreateTable(TableCreationInfo),
     CreateSchema(SchemaCreationInfo),
     DropTables(Vec<TableId>),
-    DropSchemas(Vec<SchemaId>),
+    DropSchemas(Vec<(SchemaId, bool)>),
     Insert(TableInserts),
     NotProcessed(Box<Statement>),
 }

--- a/src/sql_engine/src/query/process.rs
+++ b/src/sql_engine/src/query/process.rs
@@ -62,7 +62,12 @@ impl<'qp> QueryProcessor {
                     }))
                 }
             }
-            Statement::Drop { object_type, names, .. } => self.handle_drop(&object_type, &names),
+            Statement::Drop {
+                object_type,
+                names,
+                cascade,
+                ..
+            } => self.handle_drop(&object_type, &names, cascade),
             Statement::Insert {
                 table_name,
                 columns,
@@ -167,7 +172,7 @@ impl<'qp> QueryProcessor {
         }
     }
 
-    fn handle_drop(&mut self, object_type: &ObjectType, names: &[ObjectName]) -> Result<Plan> {
+    fn handle_drop(&mut self, object_type: &ObjectType, names: &[ObjectName], cascade: bool) -> Result<Plan> {
         match object_type {
             ObjectType::Table => {
                 let mut table_names = Vec::with_capacity(names.len());
@@ -226,7 +231,7 @@ impl<'qp> QueryProcessor {
                         return Err(());
                     }
 
-                    schema_names.push(schema_id);
+                    schema_names.push((schema_id, cascade));
                 }
                 Ok(Plan::DropSchemas(schema_names))
             }

--- a/src/storage/src/in_memory.rs
+++ b/src/storage/src/in_memory.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Key, ReadCursor, Row, Storage, StorageError, StorageResult, Values};
+use crate::{Database, Key, ReadCursor, Row, StorageError, StorageResult, Values};
 use kernel::SystemResult;
 use std::{
     collections::{BTreeMap, HashMap},
     sync::RwLock,
 };
+
+type Name = String;
 
 #[derive(Default, Debug)]
 struct StorageObject {
@@ -25,59 +27,52 @@ struct StorageObject {
 }
 
 #[derive(Default, Debug)]
-struct Namespace {
-    pub objects: HashMap<String, StorageObject>,
+struct Schema {
+    pub objects: HashMap<Name, StorageObject>,
 }
 
 #[derive(Default)]
-pub struct InMemoryDatabaseCatalog {
-    namespaces: RwLock<HashMap<String, Namespace>>,
+pub struct InMemoryDatabase {
+    schemas: RwLock<HashMap<Name, Schema>>,
 }
 
-impl Storage for InMemoryDatabaseCatalog {
-    fn create_namespace(&self, namespace: &str) -> StorageResult<()> {
+impl Database for InMemoryDatabase {
+    fn create_schema(&self, schema_name: &str) -> StorageResult<()> {
         if self
-            .namespaces
+            .schemas
             .read()
             .expect("to acquire read lock")
-            .contains_key(namespace)
+            .contains_key(schema_name)
         {
             Err(StorageError::RuntimeCheckError)
         } else {
-            self.namespaces
+            self.schemas
                 .write()
                 .expect("to acquire write lock")
-                .insert(namespace.to_owned(), Namespace::default());
+                .insert(schema_name.to_owned(), Schema::default());
             Ok(())
         }
     }
 
-    fn drop_namespace(&self, namespace: &str) -> StorageResult<()> {
-        match self
-            .namespaces
-            .write()
-            .expect("to acquire write lock")
-            .remove(namespace)
-        {
+    fn drop_schema(&self, schema_name: &str) -> StorageResult<()> {
+        match self.schemas.write().expect("to acquire write lock").remove(schema_name) {
             Some(_namespace) => Ok(()),
             None => Err(StorageError::RuntimeCheckError),
         }
     }
 
-    fn create_tree(&self, namespace: &str, object_name: &str) -> StorageResult<()> {
+    fn create_object(&self, schema_name: &str, object_name: &str) -> StorageResult<()> {
         match self
-            .namespaces
+            .schemas
             .write()
             .expect("to acquire write lock")
-            .get_mut(namespace)
+            .get_mut(schema_name)
         {
-            Some(namespace) => {
-                if namespace.objects.contains_key(object_name) {
+            Some(schema) => {
+                if schema.objects.contains_key(object_name) {
                     Err(StorageError::RuntimeCheckError)
                 } else {
-                    namespace
-                        .objects
-                        .insert(object_name.to_owned(), StorageObject::default());
+                    schema.objects.insert(object_name.to_owned(), StorageObject::default());
                     Ok(())
                 }
             }
@@ -85,14 +80,14 @@ impl Storage for InMemoryDatabaseCatalog {
         }
     }
 
-    fn drop_tree(&self, namespace: &str, object_name: &str) -> StorageResult<()> {
+    fn drop_object(&self, schema_name: &str, object_name: &str) -> StorageResult<()> {
         match self
-            .namespaces
+            .schemas
             .write()
             .expect("to acquire write lock")
-            .get_mut(namespace)
+            .get_mut(schema_name)
         {
-            Some(namespace) => match namespace.objects.remove(object_name) {
+            Some(schema) => match schema.objects.remove(object_name) {
                 Some(_) => Ok(()),
                 None => Err(StorageError::RuntimeCheckError),
             },
@@ -100,14 +95,14 @@ impl Storage for InMemoryDatabaseCatalog {
         }
     }
 
-    fn write(&self, namespace: &str, object_name: &str, rows: Vec<(Key, Values)>) -> StorageResult<usize> {
+    fn write(&self, schema_name: &str, object_name: &str, rows: Vec<(Key, Values)>) -> StorageResult<usize> {
         match self
-            .namespaces
+            .schemas
             .write()
             .expect("to acquire write lock")
-            .get_mut(namespace)
+            .get_mut(schema_name)
         {
-            Some(namespace) => match namespace.objects.get_mut(object_name) {
+            Some(schema) => match schema.objects.get_mut(object_name) {
                 Some(object) => {
                     let len = rows.len();
                     for (key, value) in rows {
@@ -121,9 +116,9 @@ impl Storage for InMemoryDatabaseCatalog {
         }
     }
 
-    fn read(&self, namespace: &str, object_name: &str) -> StorageResult<ReadCursor> {
-        match self.namespaces.read().expect("to acquire read lock").get(namespace) {
-            Some(namespace) => match namespace.objects.get(object_name) {
+    fn read(&self, schema_name: &str, object_name: &str) -> StorageResult<ReadCursor> {
+        match self.schemas.read().expect("to acquire read lock").get(schema_name) {
+            Some(schema) => match schema.objects.get(object_name) {
                 Some(object) => Ok(Box::new(
                     object
                         .records
@@ -139,14 +134,14 @@ impl Storage for InMemoryDatabaseCatalog {
         }
     }
 
-    fn delete(&self, namespace: &str, object_name: &str, keys: Vec<Key>) -> StorageResult<usize> {
+    fn delete(&self, schema_name: &str, object_name: &str, keys: Vec<Key>) -> StorageResult<usize> {
         match self
-            .namespaces
+            .schemas
             .write()
             .expect("to acquire write lock")
-            .get_mut(namespace)
+            .get_mut(schema_name)
         {
-            Some(namespace) => match namespace.objects.get_mut(object_name) {
+            Some(schema) => match schema.objects.get_mut(object_name) {
                 Some(object) => {
                     object.records = object
                         .records

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -27,7 +27,7 @@ pub type StorageResult<T> = std::result::Result<T, StorageError>;
 mod in_memory;
 mod persistent;
 
-pub use crate::{in_memory::InMemoryDatabaseCatalog, persistent::PersistentDatabaseCatalog};
+pub use crate::{in_memory::InMemoryDatabase, persistent::PersistentDatabase};
 
 pub enum InitStatus {
     Created,
@@ -40,20 +40,20 @@ pub enum StorageError {
     SystemError(SystemError),
 }
 
-pub trait Storage {
-    fn create_namespace(&self, namespace: &str) -> StorageResult<()>;
+pub trait Database {
+    fn create_schema(&self, schema_name: &str) -> StorageResult<()>;
 
-    fn drop_namespace(&self, namespace: &str) -> StorageResult<()>;
+    fn drop_schema(&self, schema_name: &str) -> StorageResult<()>;
 
-    fn create_tree(&self, namespace: &str, object_name: &str) -> StorageResult<()>;
+    fn create_object(&self, schema_name: &str, object_name: &str) -> StorageResult<()>;
 
-    fn drop_tree(&self, namespace: &str, object_name: &str) -> StorageResult<()>;
+    fn drop_object(&self, schema_name: &str, object_name: &str) -> StorageResult<()>;
 
-    fn write(&self, namespace: &str, object_name: &str, values: Vec<Row>) -> StorageResult<usize>;
+    fn write(&self, schema_name: &str, object_name: &str, values: Vec<Row>) -> StorageResult<usize>;
 
-    fn read(&self, namespace: &str, object_name: &str) -> StorageResult<ReadCursor>;
+    fn read(&self, schema_name: &str, object_name: &str) -> StorageResult<ReadCursor>;
 
-    fn delete(&self, namespace: &str, object_name: &str, keys: Vec<Key>) -> StorageResult<usize>;
+    fn delete(&self, schema_name: &str, object_name: &str, keys: Vec<Key>) -> StorageResult<usize>;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #252 

#### Description
added support for `drop schema schema_name [restrict|cascade]`

#### Client output

e.g. for `psql`

```
alex-dukhno=> create schema schema_name;
CREATE SCHEMA
alex-dukhno=> create table schema_name.table_name (col1 integer);
CREATE TABLE
alex-dukhno=> insert into schema_name.table_name values (1);
INSERT 0 1
alex-dukhno=> select * from schema_name.table_name;
 col1
------
    1
(1 row)

alex-dukhno=> drop schema schema_name cascade;
DROP SCHEMA
alex-dukhno=> select * from schema_name.table_name;
ERROR:  schema "schema_name" does not exist
```

