### PR TITLE
make QueryError represent single error

### DIFF
--- a/src/sql_engine/src/ddl/drop_schema.rs
+++ b/src/sql_engine/src/ddl/drop_schema.rs
@@ -17,10 +17,8 @@ use crate::{
     query::SchemaId,
 };
 use kernel::SystemResult;
-use protocol::{
-    results::{QueryErrorBuilder, QueryEvent},
-    Sender,
-};
+use protocol::results::QueryError;
+use protocol::{results::QueryEvent, Sender};
 use std::sync::Arc;
 
 pub(crate) struct DropSchemaCommand {
@@ -60,15 +58,13 @@ impl DropSchemaCommand {
             }
             Ok(Err(DropSchemaError::HasDependentObjects)) => {
                 self.session
-                    .send(Err(QueryErrorBuilder::new()
-                        .schema_has_dependent_objects(schema_name)
-                        .build()))
+                    .send(Err(QueryError::schema_has_dependent_objects(schema_name)))
                     .expect("To Send Query Result to Client");
                 Ok(())
             }
             Ok(Err(DropSchemaError::DoesNotExist)) => {
                 self.session
-                    .send(Err(QueryErrorBuilder::new().schema_does_not_exist(schema_name).build()))
+                    .send(Err(QueryError::schema_does_not_exist(schema_name)))
                     .expect("To Send Query Result to Client");
                 Ok(())
             }

--- a/src/sql_engine/src/dml/delete.rs
+++ b/src/sql_engine/src/dml/delete.rs
@@ -14,10 +14,8 @@
 
 use crate::catalog_manager::CatalogManager;
 use kernel::SystemResult;
-use protocol::{
-    results::{QueryErrorBuilder, QueryEvent},
-    Sender,
-};
+use protocol::results::QueryError;
+use protocol::{results::QueryEvent, Sender};
 use sqlparser::ast::ObjectName;
 use std::sync::Arc;
 
@@ -38,16 +36,16 @@ impl DeleteCommand {
 
         if !self.storage.schema_exists(&schema_name) {
             self.session
-                .send(Err(QueryErrorBuilder::new().schema_does_not_exist(schema_name).build()))
+                .send(Err(QueryError::schema_does_not_exist(schema_name)))
                 .expect("To Send Result to Client");
             return Ok(());
         }
 
         if !self.storage.table_exists(&schema_name, &table_name) {
             self.session
-                .send(Err(QueryErrorBuilder::new()
-                    .table_does_not_exist(schema_name + "." + table_name.as_str())
-                    .build()))
+                .send(Err(QueryError::table_does_not_exist(
+                    schema_name + "." + table_name.as_str(),
+                )))
                 .expect("To Send Result to Client");
             return Ok(());
         }

--- a/src/sql_engine/src/dml/mod.rs
+++ b/src/sql_engine/src/dml/mod.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use bigdecimal::BigDecimal;
-use protocol::{results::QueryErrorBuilder, Sender};
+use protocol::results::QueryError;
+use protocol::Sender;
 use sqlparser::ast::{BinaryOperator, Expr, Value};
 use std::{ops::Deref, sync::Arc};
 
@@ -61,9 +62,11 @@ impl ExpressionEvaluation {
                     }
                     operator => {
                         self.session
-                            .send(Err(QueryErrorBuilder::new()
-                                .undefined_function(operator.to_string(), "NUMBER".to_owned(), "NUMBER".to_owned())
-                                .build()))
+                            .send(Err(QueryError::undefined_function(
+                                operator.to_string(),
+                                "NUMBER".to_owned(),
+                                "NUMBER".to_owned(),
+                            )))
                             .expect("To Send Query Result to Client");
                         Err(())
                     }
@@ -72,9 +75,11 @@ impl ExpressionEvaluation {
                     BinaryOperator::StringConcat => Ok(ExprResult::String(left + right.as_str())),
                     operator => {
                         self.session
-                            .send(Err(QueryErrorBuilder::new()
-                                .undefined_function(operator.to_string(), "STRING".to_owned(), "STRING".to_owned())
-                                .build()))
+                            .send(Err(QueryError::undefined_function(
+                                operator.to_string(),
+                                "STRING".to_owned(),
+                                "STRING".to_owned(),
+                            )))
                             .expect("To Send Query Result to Client");
                         Err(())
                     }
@@ -83,9 +88,11 @@ impl ExpressionEvaluation {
                     BinaryOperator::StringConcat => Ok(ExprResult::String(left.to_string() + right.as_str())),
                     operator => {
                         self.session
-                            .send(Err(QueryErrorBuilder::new()
-                                .undefined_function(operator.to_string(), "NUMBER".to_owned(), "STRING".to_owned())
-                                .build()))
+                            .send(Err(QueryError::undefined_function(
+                                operator.to_string(),
+                                "NUMBER".to_owned(),
+                                "STRING".to_owned(),
+                            )))
                             .expect("To Send Query Result to Client");
                         Err(())
                     }
@@ -94,9 +101,11 @@ impl ExpressionEvaluation {
                     BinaryOperator::StringConcat => Ok(ExprResult::String(left + right.to_string().as_str())),
                     operator => {
                         self.session
-                            .send(Err(QueryErrorBuilder::new()
-                                .undefined_function(operator.to_string(), "STRING".to_owned(), "NUMBER".to_owned())
-                                .build()))
+                            .send(Err(QueryError::undefined_function(
+                                operator.to_string(),
+                                "STRING".to_owned(),
+                                "NUMBER".to_owned(),
+                            )))
                             .expect("To Send Query Result to Client");
                         Err(())
                     }
@@ -108,7 +117,7 @@ impl ExpressionEvaluation {
                 Expr::Value(Value::SingleQuotedString(v)) => Ok(ExprResult::String(v.clone())),
                 e => {
                     self.session
-                        .send(Err(QueryErrorBuilder::new().syntax_error(e.to_string()).build()))
+                        .send(Err(QueryError::syntax_error(e.to_string())))
                         .expect("To Send Query Result to Client");
                     Err(())
                 }

--- a/src/sql_engine/src/dml/select.rs
+++ b/src/sql_engine/src/dml/select.rs
@@ -14,8 +14,9 @@
 
 use crate::catalog_manager::CatalogManager;
 use kernel::{SystemError, SystemResult};
+use protocol::results::QueryError;
 use protocol::{
-    results::{Description, QueryErrorBuilder, QueryEvent},
+    results::{Description, QueryEvent},
     Sender,
 };
 use sqlparser::ast::{Expr, Ident, Query, Select, SelectItem, SetExpr, TableFactor, TableWithJoins};
@@ -56,9 +57,7 @@ impl<'sc> SelectCommand<'sc> {
                 }
                 _ => {
                     self.session
-                        .send(Err(QueryErrorBuilder::new()
-                            .feature_not_supported(self.raw_sql_query.to_owned())
-                            .build()))
+                        .send(Err(QueryError::feature_not_supported(self.raw_sql_query.to_owned())))
                         .expect("To Send Query Result to Client");
                     return Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()));
                 }
@@ -66,16 +65,16 @@ impl<'sc> SelectCommand<'sc> {
 
             if !self.storage.schema_exists(&schema_name) {
                 self.session
-                    .send(Err(QueryErrorBuilder::new().schema_does_not_exist(schema_name).build()))
+                    .send(Err(QueryError::schema_does_not_exist(schema_name)))
                     .expect("To Send Result to Client");
                 return Err(SystemError::runtime_check_failure("Schema Does Not Exist".to_owned()));
             }
 
             if !self.storage.table_exists(&schema_name, &table_name) {
                 self.session
-                    .send(Err(QueryErrorBuilder::new()
-                        .table_does_not_exist(schema_name + "." + table_name.as_str())
-                        .build()))
+                    .send(Err(QueryError::table_does_not_exist(
+                        schema_name + "." + table_name.as_str(),
+                    )))
                     .expect("To Send Result to Client");
                 return Err(SystemError::runtime_check_failure("Table Does Not Exist".to_owned()));
             }
@@ -97,9 +96,7 @@ impl<'sc> SelectCommand<'sc> {
                         SelectItem::UnnamedExpr(Expr::Identifier(Ident { value, .. })) => columns.push(value.clone()),
                         _ => {
                             self.session
-                                .send(Err(QueryErrorBuilder::new()
-                                    .feature_not_supported(self.raw_sql_query.to_owned())
-                                    .build()))
+                                .send(Err(QueryError::feature_not_supported(self.raw_sql_query.to_owned())))
                                 .expect("To Send Query Result to Client");
                             return Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()));
                         }
@@ -129,9 +126,7 @@ impl<'sc> SelectCommand<'sc> {
 
             if !non_existing_columns.is_empty() {
                 self.session
-                    .send(Err(QueryErrorBuilder::new()
-                        .column_does_not_exist(non_existing_columns)
-                        .build()))
+                    .send(Err(QueryError::column_does_not_exist(non_existing_columns)))
                     .expect("To Send Result to Client");
                 return Err(SystemError::runtime_check_failure("Column Does Not Exist".to_owned()));
             }
@@ -144,9 +139,7 @@ impl<'sc> SelectCommand<'sc> {
             Ok(description)
         } else {
             self.session
-                .send(Err(QueryErrorBuilder::new()
-                    .feature_not_supported(self.raw_sql_query.to_owned())
-                    .build()))
+                .send(Err(QueryError::feature_not_supported(self.raw_sql_query.to_owned())))
                 .expect("To Send Query Result to Client");
             Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()))
         }
@@ -165,9 +158,7 @@ impl<'sc> SelectCommand<'sc> {
                 }
                 _ => {
                     self.session
-                        .send(Err(QueryErrorBuilder::new()
-                            .feature_not_supported(self.raw_sql_query.to_owned())
-                            .build()))
+                        .send(Err(QueryError::feature_not_supported(self.raw_sql_query.to_owned())))
                         .expect("To Send Query Result to Client");
                     return Ok(());
                 }
@@ -175,16 +166,16 @@ impl<'sc> SelectCommand<'sc> {
 
             if !self.storage.schema_exists(&schema_name) {
                 self.session
-                    .send(Err(QueryErrorBuilder::new().schema_does_not_exist(schema_name).build()))
+                    .send(Err(QueryError::schema_does_not_exist(schema_name)))
                     .expect("To Send Result to Client");
                 return Ok(());
             }
 
             if !self.storage.table_exists(&schema_name, &table_name) {
                 self.session
-                    .send(Err(QueryErrorBuilder::new()
-                        .table_does_not_exist(schema_name + "." + table_name.as_str())
-                        .build()))
+                    .send(Err(QueryError::table_does_not_exist(
+                        schema_name + "." + table_name.as_str(),
+                    )))
                     .expect("To Send Result to Client");
                 return Ok(());
             }
@@ -206,9 +197,7 @@ impl<'sc> SelectCommand<'sc> {
                         SelectItem::UnnamedExpr(Expr::Identifier(Ident { value, .. })) => columns.push(value.clone()),
                         _ => {
                             self.session
-                                .send(Err(QueryErrorBuilder::new()
-                                    .feature_not_supported(self.raw_sql_query.to_owned())
-                                    .build()))
+                                .send(Err(QueryError::feature_not_supported(self.raw_sql_query.to_owned())))
                                 .expect("To Send Query Result to Client");
                             return Ok(());
                         }
@@ -243,9 +232,7 @@ impl<'sc> SelectCommand<'sc> {
 
                     if !non_existing_columns.is_empty() {
                         self.session
-                            .send(Err(QueryErrorBuilder::new()
-                                .column_does_not_exist(non_existing_columns)
-                                .build()))
+                            .send(Err(QueryError::column_does_not_exist(non_existing_columns)))
                             .expect("To Send Result to Client");
                         return Ok(());
                     }
@@ -284,9 +271,7 @@ impl<'sc> SelectCommand<'sc> {
             }
         } else {
             self.session
-                .send(Err(QueryErrorBuilder::new()
-                    .feature_not_supported(self.raw_sql_query.to_owned())
-                    .build()))
+                .send(Err(QueryError::feature_not_supported(self.raw_sql_query.to_owned())))
                 .expect("To Send Query Result to Client");
             Ok(())
         }

--- a/src/sql_engine/src/query/process.rs
+++ b/src/sql_engine/src/query/process.rs
@@ -19,7 +19,8 @@ use crate::{
     query::{SchemaId, SchemaNamingError, TableId, TableNamingError},
     ColumnDefinition,
 };
-use protocol::{results::QueryErrorBuilder, Sender};
+use protocol::results::QueryError;
+use protocol::Sender;
 use sql_types::SqlType;
 use sqlparser::ast::{ColumnDef, DataType, ObjectName, ObjectType, Statement};
 use std::{convert::TryFrom, sync::Arc};
@@ -44,16 +45,14 @@ impl<'qp> QueryProcessor {
                     Ok(schema_id) => schema_id,
                     Err(SchemaNamingError(message)) => {
                         self.session
-                            .send(Err(QueryErrorBuilder::new().syntax_error(message).build()))
+                            .send(Err(QueryError::syntax_error(message)))
                             .expect("To Send Query Result to Client");
                         return Err(());
                     }
                 };
                 if self.storage.schema_exists(schema_id.name()) {
                     self.session
-                        .send(Err(QueryErrorBuilder::new()
-                            .schema_already_exists(schema_id.name().to_string())
-                            .build()))
+                        .send(Err(QueryError::schema_already_exists(schema_id.name().to_string())))
                         .expect("To Send Query Result to Client");
                     Err(())
                 } else {
@@ -80,7 +79,7 @@ impl<'qp> QueryProcessor {
                 })),
                 Err(TableNamingError(message)) => {
                     self.session
-                        .send(Err(QueryErrorBuilder::new().syntax_error(message).build()))
+                        .send(Err(QueryError::syntax_error(message)))
                         .expect("To Send Query Result to Client");
                     Err(())
                 }
@@ -105,9 +104,10 @@ impl<'qp> QueryProcessor {
                     "bigserial" => Ok(SqlType::BigInt(1)),
                     other_type => {
                         self.session
-                            .send(Err(QueryErrorBuilder::new()
-                                .feature_not_supported(format!("{} type is not supported", other_type))
-                                .build()))
+                            .send(Err(QueryError::feature_not_supported(format!(
+                                "{} type is not supported",
+                                other_type
+                            ))))
                             .expect("To Send Query Result to Client");
                         Err(())
                     }
@@ -115,9 +115,10 @@ impl<'qp> QueryProcessor {
             }
             other_type => {
                 self.session
-                    .send(Err(QueryErrorBuilder::new()
-                        .feature_not_supported(format!("{} type is not supported", other_type))
-                        .build()))
+                    .send(Err(QueryError::feature_not_supported(format!(
+                        "{} type is not supported",
+                        other_type
+                    ))))
                     .expect("To Send Query Result to Client");
                 Err(())
             }
@@ -140,7 +141,7 @@ impl<'qp> QueryProcessor {
             Ok(table_id) => table_id,
             Err(TableNamingError(message)) => {
                 self.session
-                    .send(Err(QueryErrorBuilder::new().syntax_error(message).build()))
+                    .send(Err(QueryError::syntax_error(message)))
                     .expect("To Send Query Result to Client");
                 return Err(());
             }
@@ -149,16 +150,15 @@ impl<'qp> QueryProcessor {
         let table_name = table_id.name();
         if !self.storage.schema_exists(schema_name) {
             self.session
-                .send(Err(QueryErrorBuilder::new()
-                    .schema_does_not_exist(schema_name.to_string())
-                    .build()))
+                .send(Err(QueryError::schema_does_not_exist(schema_name.to_string())))
                 .expect("To Send Query Result to Client");
             Err(())
         } else if self.storage.table_exists(schema_name, table_name) {
             self.session
-                .send(Err(QueryErrorBuilder::new()
-                    .table_already_exists(format!("{}.{}", schema_name, table_name))
-                    .build()))
+                .send(Err(QueryError::table_already_exists(format!(
+                    "{}.{}",
+                    schema_name, table_name
+                ))))
                 .expect("To Send Query Result to Client");
             Err(())
         } else {
@@ -183,7 +183,7 @@ impl<'qp> QueryProcessor {
                         Ok(table_id) => table_id,
                         Err(TableNamingError(message)) => {
                             self.session
-                                .send(Err(QueryErrorBuilder::new().syntax_error(message).build()))
+                                .send(Err(QueryError::syntax_error(message)))
                                 .expect("To Send Query Result to Client");
                             return Err(());
                         }
@@ -192,16 +192,15 @@ impl<'qp> QueryProcessor {
                     let table_name = table_id.name();
                     if !self.storage.schema_exists(schema_name) {
                         self.session
-                            .send(Err(QueryErrorBuilder::new()
-                                .schema_does_not_exist(schema_name.to_string())
-                                .build()))
+                            .send(Err(QueryError::schema_does_not_exist(schema_name.to_string())))
                             .expect("To Send Query Result to Client");
                         return Err(());
                     } else if !self.storage.table_exists(schema_name, table_name) {
                         self.session
-                            .send(Err(QueryErrorBuilder::new()
-                                .table_does_not_exist(format!("{}.{}", schema_name, table_name))
-                                .build()))
+                            .send(Err(QueryError::table_does_not_exist(format!(
+                                "{}.{}",
+                                schema_name, table_name
+                            ))))
                             .expect("To Send Query Result to Client");
                         return Err(());
                     } else {
@@ -217,16 +216,14 @@ impl<'qp> QueryProcessor {
                         Ok(schema_id) => schema_id,
                         Err(SchemaNamingError(message)) => {
                             self.session
-                                .send(Err(QueryErrorBuilder::new().syntax_error(message).build()))
+                                .send(Err(QueryError::syntax_error(message)))
                                 .expect("To Send Query Result to Client");
                             return Err(());
                         }
                     };
                     if !self.storage.schema_exists(schema_id.name()) {
                         self.session
-                            .send(Err(QueryErrorBuilder::new()
-                                .schema_does_not_exist(schema_id.name().to_string())
-                                .build()))
+                            .send(Err(QueryError::schema_does_not_exist(schema_id.name().to_string())))
                             .expect("To Send Query Result to Client");
                         return Err(());
                     }

--- a/src/sql_engine/src/tests/delete.rs
+++ b/src/sql_engine/src/tests/delete.rs
@@ -14,10 +14,7 @@
 
 use super::*;
 use crate::{tests::Collector, QueryExecutor};
-use protocol::{
-    results::{QueryErrorBuilder, QueryEvent},
-    sql_types::PostgreSqlType,
-};
+use protocol::{results::QueryEvent, sql_types::PostgreSqlType};
 use std::sync::Arc;
 
 #[rstest::rstest]
@@ -29,9 +26,9 @@ fn delete_from_nonexistent_table(sql_engine_with_schema: (QueryExecutor, Arc<Col
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
-        Err(QueryErrorBuilder::new()
-            .table_does_not_exist("schema_name.table_name".to_owned())
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned())),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -59,17 +56,24 @@ fn delete_all_records(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
             vec![vec!["123".to_owned()], vec!["456".to_owned()]],
         ))),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsDeleted(2)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
             vec![],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ])
 }

--- a/src/sql_engine/src/tests/describe_prepared_statement.rs
+++ b/src/sql_engine/src/tests/describe_prepared_statement.rs
@@ -87,8 +87,6 @@ fn describe_not_existed_statement(sql_engine_with_schema: (QueryExecutor, Arc<Co
     collector.assert_content(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryErrorBuilder::new()
-            .prepared_statement_does_not_exist("non_existent".to_owned())
-            .build()),
+        Err(QueryError::prepared_statement_does_not_exist("non_existent".to_owned())),
     ]);
 }

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -24,9 +24,9 @@ fn insert_into_nonexistent_table(sql_engine_with_schema: (QueryExecutor, Arc<Col
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
-        Err(QueryErrorBuilder::new()
-            .table_does_not_exist("schema_name.table_name".to_owned())
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned())),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -42,10 +42,11 @@ fn insert_value_in_non_existent_column(sql_engine_with_schema: (QueryExecutor, A
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
-        Err(QueryErrorBuilder::new()
-            .column_does_not_exist(vec!["non_existent".to_owned()])
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::column_does_not_exist(vec!["non_existent".to_owned()])),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -65,12 +66,16 @@ fn insert_and_select_single_row(sql_engine_with_schema: (QueryExecutor, Arc<Coll
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
             vec![vec!["123".to_owned()]],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -96,17 +101,23 @@ fn insert_and_select_multiple_rows(sql_engine_with_schema: (QueryExecutor, Arc<C
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
             vec![vec!["123".to_owned()]],
         ))),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
             vec![vec!["123".to_owned()], vec!["456".to_owned()]],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -125,8 +136,11 @@ fn insert_and_select_named_columns(sql_engine_with_schema: (QueryExecutor, Arc<C
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(2)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("col1".to_owned(), PostgreSqlType::SmallInt),
@@ -138,6 +152,7 @@ fn insert_and_select_named_columns(sql_engine_with_schema: (QueryExecutor, Arc<C
                 vec!["6".to_owned(), "4".to_owned(), "5".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -156,8 +171,11 @@ fn insert_multiple_rows(sql_engine_with_schema: (QueryExecutor, Arc<Collector>))
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(3)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_1".to_owned(), PostgreSqlType::SmallInt),
@@ -170,6 +188,7 @@ fn insert_multiple_rows(sql_engine_with_schema: (QueryExecutor, Arc<Collector>))
                 vec!["3".to_owned(), "6".to_owned(), "9".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -191,9 +210,13 @@ fn insert_and_select_different_integer_types(sql_engine_with_schema: (QueryExecu
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_si".to_owned(), PostgreSqlType::SmallInt),
@@ -216,6 +239,7 @@ fn insert_and_select_different_integer_types(sql_engine_with_schema: (QueryExecu
                 ],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -237,9 +261,13 @@ fn insert_and_select_different_character_types(sql_engine_with_schema: (QueryExe
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_c".to_owned(), PostgreSqlType::Char),
@@ -250,6 +278,7 @@ fn insert_and_select_different_character_types(sql_engine_with_schema: (QueryExe
                 vec!["12345abcde".to_owned(), "abcde".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -271,10 +300,15 @@ fn insert_booleans(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -312,12 +346,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["3".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -333,12 +371,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["-1".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -354,12 +396,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["6".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -375,12 +421,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["4".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -396,12 +446,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["0".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -420,12 +474,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["64".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -443,12 +501,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["4".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -466,12 +528,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["2".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -489,12 +555,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["120".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -512,12 +582,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["120".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -535,12 +609,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["5".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -556,12 +634,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["1".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -577,12 +659,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["7".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -600,12 +686,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["-2".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -623,12 +713,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["16".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -646,12 +740,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["2".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -667,12 +765,16 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["5".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
         }
@@ -704,12 +806,16 @@ mod operators {
 
             collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::TableCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsInserted(1)),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsSelected((
                     vec![("strings".to_owned(), PostgreSqlType::Char)],
                     vec![vec!["12345".to_owned()]],
                 ))),
+                Ok(QueryEvent::QueryComplete),
             ]);
         }
 
@@ -728,13 +834,18 @@ mod operators {
 
             collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::TableCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsInserted(1)),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsInserted(1)),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsSelected((
                     vec![("strings".to_owned(), PostgreSqlType::Char)],
                     vec![vec!["145".to_owned()], vec!["451".to_owned()]],
                 ))),
+                Ok(QueryEvent::QueryComplete),
             ]);
         }
 
@@ -748,10 +859,15 @@ mod operators {
 
             collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::TableCreated),
-                Err(QueryErrorBuilder::new()
-                    .undefined_function("||".to_owned(), "NUMBER".to_owned(), "NUMBER".to_owned())
-                    .build()),
+                Ok(QueryEvent::QueryComplete),
+                Err(QueryError::undefined_function(
+                    "||".to_owned(),
+                    "NUMBER".to_owned(),
+                    "NUMBER".to_owned(),
+                )),
+                Ok(QueryEvent::QueryComplete),
             ]);
         }
     }

--- a/src/sql_engine/src/tests/mod.rs
+++ b/src/sql_engine/src/tests/mod.rs
@@ -33,7 +33,7 @@ mod update;
 
 use super::*;
 use crate::{catalog_manager::CatalogManager, QueryExecutor};
-use protocol::results::QueryResult;
+use protocol::results::{QueryError, QueryResult};
 use std::{
     io,
     ops::Deref,
@@ -65,10 +65,6 @@ impl Collector {
 
     fn assert_content_for_single_queries(&self, expected: Vec<QueryResult>) {
         let actual = self.0.lock().expect("locked");
-        let expected: Vec<QueryResult> = expected
-            .iter()
-            .flat_map(|result| vec![result.clone(), Ok(QueryEvent::QueryComplete)])
-            .collect();
         assert_eq!(actual.deref(), &expected)
     }
 }

--- a/src/sql_engine/src/tests/parse.rs
+++ b/src/sql_engine/src/tests/parse.rs
@@ -57,9 +57,7 @@ fn parse_select_statement_with_not_existed_table(sql_engine_with_schema: (QueryE
     collector.assert_content(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryErrorBuilder::new()
-            .table_does_not_exist("schema_name.non_existent".to_owned())
-            .build()),
+        Err(QueryError::table_does_not_exist("schema_name.non_existent".to_owned())),
     ]);
 }
 
@@ -86,9 +84,9 @@ fn parse_select_statement_with_not_existed_column(sql_engine_with_schema: (Query
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryErrorBuilder::new()
-            .column_does_not_exist(vec!["column_not_in_table".to_owned()])
-            .build()),
+        Err(QueryError::column_does_not_exist(
+            vec!["column_not_in_table".to_owned()],
+        )),
     ]);
 }
 

--- a/src/sql_engine/src/tests/select.rs
+++ b/src/sql_engine/src/tests/select.rs
@@ -24,9 +24,9 @@ fn select_from_not_existed_table(sql_engine_with_schema: (QueryExecutor, Arc<Col
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
-        Err(QueryErrorBuilder::new()
-            .table_does_not_exist("schema_name.non_existent".to_owned())
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::table_does_not_exist("schema_name.non_existent".to_owned())),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -39,9 +39,9 @@ fn select_named_columns_from_non_existent_table(sql_engine_with_schema: (QueryEx
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
-        Err(QueryErrorBuilder::new()
-            .table_does_not_exist("schema_name.non_existent".to_owned())
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::table_does_not_exist("schema_name.non_existent".to_owned())),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -60,8 +60,11 @@ fn select_all_from_table_with_multiple_columns(sql_engine_with_schema: (QueryExe
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_1".to_owned(), PostgreSqlType::SmallInt),
@@ -70,6 +73,7 @@ fn select_all_from_table_with_multiple_columns(sql_engine_with_schema: (QueryExe
             ],
             vec![vec!["123".to_owned(), "456".to_owned(), "789".to_owned()]],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -88,8 +92,11 @@ fn select_not_all_columns(sql_engine_with_schema: (QueryExecutor, Arc<Collector>
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(3)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_3".to_owned(), PostgreSqlType::SmallInt),
@@ -101,6 +108,7 @@ fn select_not_all_columns(sql_engine_with_schema: (QueryExecutor, Arc<Collector>
                 vec!["9".to_owned(), "6".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -116,13 +124,14 @@ fn select_non_existing_columns_from_table(sql_engine_with_schema: (QueryExecutor
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
-        Err(QueryErrorBuilder::new()
-            .column_does_not_exist(vec![
-                "column_not_in_table1".to_owned(),
-                "column_not_in_table2".to_owned(),
-            ])
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::column_does_not_exist(vec![
+            "column_not_in_table1".to_owned(),
+            "column_not_in_table2".to_owned(),
+        ])),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -150,10 +159,15 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_3".to_owned(), PostgreSqlType::SmallInt),
@@ -165,6 +179,7 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(
                 vec!["9".to_owned(), "7".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -193,10 +208,15 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_3".to_owned(), PostgreSqlType::SmallInt),
@@ -209,6 +229,7 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(
                 vec!["9".to_owned(), "7".to_owned(), "8".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -234,10 +255,15 @@ fn select_with_column_name_duplication(sql_engine_with_schema: (QueryExecutor, A
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_3".to_owned(), PostgreSqlType::SmallInt),
@@ -270,6 +296,7 @@ fn select_with_column_name_duplication(sql_engine_with_schema: (QueryExecutor, A
                 ],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -297,10 +324,15 @@ fn select_different_integer_types(sql_engine_with_schema: (QueryExecutor, Arc<Co
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_si".to_owned(), PostgreSqlType::SmallInt),
@@ -313,6 +345,7 @@ fn select_different_integer_types(sql_engine_with_schema: (QueryExecutor, Arc<Co
                 vec!["7000".to_owned(), "8000000".to_owned(), "9000000000".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -340,10 +373,15 @@ fn select_different_character_strings_types(sql_engine_with_schema: (QueryExecut
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("char_10".to_owned(), PostgreSqlType::Char),
@@ -355,5 +393,6 @@ fn select_different_character_strings_types(sql_engine_with_schema: (QueryExecut
                 vec!["12345".to_owned(), "1234567890".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }

--- a/src/sql_engine/src/tests/table.rs
+++ b/src/sql_engine/src/tests/table.rs
@@ -26,9 +26,10 @@ mod schemaless {
             .execute("create table schema_name.table_name (column_name smallint);")
             .expect("no system errors");
 
-        collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
-            .schema_does_not_exist("schema_name".to_owned())
-            .build())]);
+        collector.assert_content_for_single_queries(vec![
+            Err(QueryError::schema_does_not_exist("schema_name".to_owned())),
+            Ok(QueryEvent::QueryComplete),
+        ]);
     }
 
     #[rstest::rstest]
@@ -38,9 +39,10 @@ mod schemaless {
             .execute("drop table schema_name.table_name;")
             .expect("no system errors");
 
-        collector.assert_content_for_single_queries(vec![Err(QueryErrorBuilder::new()
-            .schema_does_not_exist("schema_name".to_owned())
-            .build())]);
+        collector.assert_content_for_single_queries(vec![
+            Err(QueryError::schema_does_not_exist("schema_name".to_owned())),
+            Ok(QueryEvent::QueryComplete),
+        ]);
     }
 }
 
@@ -52,7 +54,12 @@ fn create_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
         .execute("create table schema_name.table_name (column_name smallint);")
         .expect("no system errors");
 
-    collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+    collector.assert_content_for_single_queries(vec![
+        Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
+        Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
+    ]);
 }
 
 #[rstest::rstest]
@@ -67,10 +74,11 @@ fn create_same_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
-        Err(QueryErrorBuilder::new()
-            .table_already_exists("schema_name.table_name".to_owned())
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::table_already_exists("schema_name.table_name".to_owned())),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -89,9 +97,13 @@ fn drop_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableDropped),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -104,9 +116,9 @@ fn drop_non_existent_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
-        Err(QueryErrorBuilder::new()
-            .table_does_not_exist("schema_name.table_name".to_owned())
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned())),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -127,7 +139,12 @@ mod different_types {
             )
             .expect("no system errors");
 
-        collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+        collector.assert_content_for_single_queries(vec![
+            Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
+            Ok(QueryEvent::TableCreated),
+            Ok(QueryEvent::QueryComplete),
+        ]);
     }
 
     #[rstest::rstest]
@@ -142,7 +159,12 @@ mod different_types {
             )
             .expect("no system errors");
 
-        collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+        collector.assert_content_for_single_queries(vec![
+            Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
+            Ok(QueryEvent::TableCreated),
+            Ok(QueryEvent::QueryComplete),
+        ]);
     }
 
     #[rstest::rstest]
@@ -156,7 +178,12 @@ mod different_types {
             )
             .expect("no system errors");
 
-        collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+        collector.assert_content_for_single_queries(vec![
+            Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
+            Ok(QueryEvent::TableCreated),
+            Ok(QueryEvent::QueryComplete),
+        ]);
     }
 
     #[rstest::rstest]
@@ -172,6 +199,11 @@ mod different_types {
             )
             .expect("no system errors");
 
-        collector.assert_content_for_single_queries(vec![Ok(QueryEvent::SchemaCreated), Ok(QueryEvent::TableCreated)]);
+        collector.assert_content_for_single_queries(vec![
+            Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
+            Ok(QueryEvent::TableCreated),
+            Ok(QueryEvent::QueryComplete),
+        ]);
     }
 }

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::*;
-use protocol::{results::QueryErrorBuilder, sql_types::PostgreSqlType};
+use protocol::sql_types::PostgreSqlType;
 
 #[rstest::fixture]
 fn int_table(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) -> (QueryExecutor, Arc<Collector>) {
@@ -52,8 +52,6 @@ mod insert {
     #[rstest::rstest]
     fn out_of_range(int_table: (QueryExecutor, Arc<Collector>)) {
         let (mut engine, collector) = int_table;
-        let mut builder = QueryErrorBuilder::new();
-        builder.out_of_range(PostgreSqlType::SmallInt, "col".to_string(), 1);
 
         engine
             .execute("insert into schema_name.table_name values (32768);")
@@ -61,16 +59,17 @@ mod insert {
 
         collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
-            Err(builder.build()),
+            Ok(QueryEvent::QueryComplete),
+            Err(QueryError::out_of_range(PostgreSqlType::SmallInt, "col".to_string(), 1)),
+            Ok(QueryEvent::QueryComplete),
         ]);
     }
 
     #[rstest::rstest]
     fn type_mismatch(int_table: (QueryExecutor, Arc<Collector>)) {
         let (mut engine, collector) = int_table;
-        let mut builder = QueryErrorBuilder::new();
-        builder.type_mismatch("str", PostgreSqlType::SmallInt, "col".to_string(), 1);
 
         engine
             .execute("insert into schema_name.table_name values ('str');")
@@ -78,8 +77,16 @@ mod insert {
 
         collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
-            Err(builder.build()),
+            Ok(QueryEvent::QueryComplete),
+            Err(QueryError::type_mismatch(
+                "str",
+                PostgreSqlType::SmallInt,
+                "col".to_string(),
+                1,
+            )),
+            Ok(QueryEvent::QueryComplete),
         ]);
     }
 
@@ -90,30 +97,70 @@ mod insert {
             .execute("insert into schema_name.table_name values (-32769, -2147483649, 100), (100, -2147483649, -9223372036854775809);")
             .expect("no system errors");
 
-        let mut builder = QueryErrorBuilder::new();
-        builder.out_of_range(PostgreSqlType::SmallInt, "column_si".to_owned(), 1);
-        builder.out_of_range(PostgreSqlType::Integer, "column_i".to_owned(), 1);
+        collector.assert_content_for_single_queries(vec![
+            Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
+            Ok(QueryEvent::TableCreated),
+            Ok(QueryEvent::QueryComplete),
+            Err(QueryError::out_of_range(
+                PostgreSqlType::SmallInt,
+                "column_si".to_owned(),
+                1,
+            )),
+            Err(QueryError::out_of_range(
+                PostgreSqlType::Integer,
+                "column_i".to_owned(),
+                1,
+            )),
+            Ok(QueryEvent::QueryComplete),
+        ]);
+    }
+
+    #[rstest::rstest]
+    fn violation_in_the_second_row(multiple_ints_table: (QueryExecutor, Arc<Collector>)) {
+        let (mut engine, collector) = multiple_ints_table;
+        engine
+            .execute("insert into schema_name.table_name values (-32768, -2147483648, 100), (100, -2147483649, -9223372036854775809);")
+            .expect("no system errors");
 
         collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
-            Err(builder.build()),
+            Ok(QueryEvent::QueryComplete),
+            Err(QueryError::out_of_range(
+                PostgreSqlType::Integer,
+                "column_i".to_owned(),
+                2,
+            )),
+            Err(QueryError::out_of_range(
+                PostgreSqlType::BigInt,
+                "column_bi".to_owned(),
+                2,
+            )),
+            Ok(QueryEvent::QueryComplete),
         ]);
     }
 
     #[rstest::rstest]
     fn value_too_long(str_table: (QueryExecutor, Arc<Collector>)) {
         let (mut engine, collector) = str_table;
-        let mut builder = QueryErrorBuilder::new();
-        builder.string_length_mismatch(PostgreSqlType::VarChar, 5, "col".to_string(), 1);
         engine
             .execute("insert into schema_name.table_name values ('123457890');")
             .expect("no system errors");
 
         collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
-            Err(builder.build()),
+            Ok(QueryEvent::QueryComplete),
+            Err(QueryError::string_length_mismatch(
+                PostgreSqlType::VarChar,
+                5,
+                "col".to_string(),
+                1,
+            )),
+            Ok(QueryEvent::QueryComplete),
         ]);
     }
 }
@@ -125,8 +172,6 @@ mod update {
     #[rstest::rstest]
     fn out_of_range(int_table: (QueryExecutor, Arc<Collector>)) {
         let (mut engine, collector) = int_table;
-        let mut builder = QueryErrorBuilder::new();
-        builder.out_of_range(PostgreSqlType::SmallInt, "col".to_string(), 1);
 
         engine
             .execute("insert into schema_name.table_name values (32767);")
@@ -137,17 +182,19 @@ mod update {
 
         collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::RecordsInserted(1)),
-            Err(builder.build()),
+            Ok(QueryEvent::QueryComplete),
+            Err(QueryError::out_of_range(PostgreSqlType::SmallInt, "col".to_string(), 1)),
+            Ok(QueryEvent::QueryComplete),
         ]);
     }
 
     #[rstest::rstest]
     fn type_mismatch(int_table: (QueryExecutor, Arc<Collector>)) {
         let (mut engine, collector) = int_table;
-        let mut builder = QueryErrorBuilder::new();
-        builder.type_mismatch("str", PostgreSqlType::SmallInt, "col".to_string(), 1);
         engine
             .execute("insert into schema_name.table_name values (32767);")
             .expect("no system errors");
@@ -157,17 +204,24 @@ mod update {
 
         collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::RecordsInserted(1)),
-            Err(builder.build()),
+            Ok(QueryEvent::QueryComplete),
+            Err(QueryError::type_mismatch(
+                "str",
+                PostgreSqlType::SmallInt,
+                "col".to_string(),
+                1,
+            )),
+            Ok(QueryEvent::QueryComplete),
         ]);
     }
 
     #[rstest::rstest]
     fn value_too_long(str_table: (QueryExecutor, Arc<Collector>)) {
         let (mut engine, collector) = str_table;
-        let mut builder = QueryErrorBuilder::new();
-        builder.string_length_mismatch(PostgreSqlType::VarChar, 5, "col".to_string(), 1);
 
         engine
             .execute("insert into schema_name.table_name values ('str');")
@@ -178,16 +232,24 @@ mod update {
 
         collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::RecordsInserted(1)),
-            Err(builder.build()),
+            Ok(QueryEvent::QueryComplete),
+            Err(QueryError::string_length_mismatch(
+                PostgreSqlType::VarChar,
+                5,
+                "col".to_string(),
+                1,
+            )),
+            Ok(QueryEvent::QueryComplete),
         ]);
     }
 
     #[rstest::rstest]
     fn multiple_columns_violation(multiple_ints_table: (QueryExecutor, Arc<Collector>)) {
         let (mut engine, collector) = multiple_ints_table;
-        let mut builder = QueryErrorBuilder::new();
 
         engine
             .execute("insert into schema_name.table_name values (100, 100, 100), (100, 100, 100);")
@@ -197,14 +259,24 @@ mod update {
             .execute("update schema_name.table_name set column_si = -32769, column_i= -2147483649, column_bi=100;")
             .expect("no system errors");
 
-        builder.out_of_range(PostgreSqlType::SmallInt, "column_si".to_owned(), 1);
-        builder.out_of_range(PostgreSqlType::Integer, "column_i".to_owned(), 1);
-
         collector.assert_content_for_single_queries(vec![
             Ok(QueryEvent::SchemaCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
+            Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::RecordsInserted(2)),
-            Err(builder.build()),
+            Ok(QueryEvent::QueryComplete),
+            Err(QueryError::out_of_range(
+                PostgreSqlType::SmallInt,
+                "column_si".to_owned(),
+                1,
+            )),
+            Err(QueryError::out_of_range(
+                PostgreSqlType::Integer,
+                "column_i".to_owned(),
+                1,
+            )),
+            Ok(QueryEvent::QueryComplete),
         ]);
     }
 }

--- a/src/sql_engine/src/tests/update.rs
+++ b/src/sql_engine/src/tests/update.rs
@@ -39,18 +39,25 @@ fn update_all_records(sql_engine_with_schema: (QueryExecutor, Arc<Collector>)) {
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
             vec![vec!["123".to_owned()], vec!["456".to_owned()]],
         ))),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsUpdated(2)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
             vec![vec!["789".to_owned()], vec!["789".to_owned()]],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -78,9 +85,13 @@ fn update_single_column_of_all_records(sql_engine_with_schema: (QueryExecutor, A
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("col1".to_owned(), PostgreSqlType::SmallInt),
@@ -91,7 +102,9 @@ fn update_single_column_of_all_records(sql_engine_with_schema: (QueryExecutor, A
                 vec!["456".to_owned(), "789".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsUpdated(2)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("col1".to_owned(), PostgreSqlType::SmallInt),
@@ -102,6 +115,7 @@ fn update_single_column_of_all_records(sql_engine_with_schema: (QueryExecutor, A
                 vec!["456".to_owned(), "357".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -129,9 +143,13 @@ fn update_multiple_columns_of_all_records(sql_engine_with_schema: (QueryExecutor
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("col1".to_owned(), PostgreSqlType::SmallInt),
@@ -143,7 +161,9 @@ fn update_multiple_columns_of_all_records(sql_engine_with_schema: (QueryExecutor
                 vec!["444".to_owned(), "555".to_owned(), "666".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsUpdated(2)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("col1".to_owned(), PostgreSqlType::SmallInt),
@@ -155,6 +175,7 @@ fn update_multiple_columns_of_all_records(sql_engine_with_schema: (QueryExecutor
                 vec!["999".to_owned(), "555".to_owned(), "777".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -179,8 +200,11 @@ fn update_all_records_in_multiple_columns(sql_engine_with_schema: (QueryExecutor
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(3)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_1".to_owned(), PostgreSqlType::SmallInt),
@@ -193,7 +217,9 @@ fn update_all_records_in_multiple_columns(sql_engine_with_schema: (QueryExecutor
                 vec!["7".to_owned(), "8".to_owned(), "9".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsUpdated(3)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![
                 ("column_1".to_owned(), PostgreSqlType::SmallInt),
@@ -206,6 +232,7 @@ fn update_all_records_in_multiple_columns(sql_engine_with_schema: (QueryExecutor
                 vec!["10".to_owned(), "-20".to_owned(), "30".to_owned()],
             ],
         ))),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -218,9 +245,9 @@ fn update_records_in_nonexistent_table(sql_engine_with_schema: (QueryExecutor, A
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
-        Err(QueryErrorBuilder::new()
-            .table_does_not_exist("schema_name.table_name".to_owned())
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned())),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -242,15 +269,21 @@ fn update_non_existent_columns_of_records(sql_engine_with_schema: (QueryExecutor
 
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
+        Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsSelected((
             vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
             vec![vec!["123".to_owned()]],
         ))),
-        Err(QueryErrorBuilder::new()
-            .column_does_not_exist(vec!["col1".to_owned(), "col2".to_owned()])
-            .build()),
+        Ok(QueryEvent::QueryComplete),
+        Err(QueryError::column_does_not_exist(vec![
+            "col1".to_owned(),
+            "col2".to_owned(),
+        ])),
+        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -292,13 +325,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["3".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -314,13 +352,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["-1".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -336,13 +379,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["6".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -358,13 +406,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["4".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -380,13 +433,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["0".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -405,13 +463,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["64".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -429,13 +492,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["4".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -453,13 +521,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["2".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -477,13 +550,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["120".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -501,13 +579,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["120".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -525,13 +608,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["5".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -547,13 +635,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["1".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -569,13 +662,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["7".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -593,13 +691,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["-2".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -617,13 +720,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["16".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -641,13 +749,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["2".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
 
@@ -663,13 +776,18 @@ mod operators {
 
                 collector.assert_content_for_single_queries(vec![
                     Ok(QueryEvent::SchemaCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::TableCreated),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsInserted(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
+                    Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsSelected((
                         vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
                         vec![vec!["5".to_owned()]],
                     ))),
+                    Ok(QueryEvent::QueryComplete),
                 ]);
             }
         }
@@ -705,13 +823,18 @@ mod operators {
 
             collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::TableCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsInserted(1)),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsUpdated(1)),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsSelected((
                     vec![("strings".to_owned(), PostgreSqlType::Char)],
                     vec![vec!["12345".to_owned()]],
                 ))),
+                Ok(QueryEvent::QueryComplete),
             ]);
         }
 
@@ -733,18 +856,25 @@ mod operators {
 
             collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::TableCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsInserted(1)),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsUpdated(1)),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsSelected((
                     vec![("strings".to_owned(), PostgreSqlType::Char)],
                     vec![vec!["145".to_owned()]],
                 ))),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsUpdated(1)),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsSelected((
                     vec![("strings".to_owned(), PostgreSqlType::Char)],
                     vec![vec!["451".to_owned()]],
                 ))),
+                Ok(QueryEvent::QueryComplete),
             ]);
         }
 
@@ -757,11 +887,17 @@ mod operators {
 
             collector.assert_content_for_single_queries(vec![
                 Ok(QueryEvent::SchemaCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::TableCreated),
+                Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsInserted(1)),
-                Err(QueryErrorBuilder::new()
-                    .undefined_function("||".to_owned(), "NUMBER".to_owned(), "NUMBER".to_owned())
-                    .build()),
+                Ok(QueryEvent::QueryComplete),
+                Err(QueryError::undefined_function(
+                    "||".to_owned(),
+                    "NUMBER".to_owned(),
+                    "NUMBER".to_owned(),
+                )),
+                Ok(QueryEvent::QueryComplete),
             ]);
         }
     }


### PR DESCRIPTION
Closes #200

#### Description
`QueryError` represents single error

#### Client output
no changes to client output
