### PR TITLE
drop shema by id

### DIFF
--- a/src/sql_engine/src/catalog_manager/data_definition.rs
+++ b/src/sql_engine/src/catalog_manager/data_definition.rs
@@ -746,10 +746,10 @@ impl DataDefinition {
         }
     }
 
-    pub(crate) fn create_schema(&self, catalog_name: &str, schema_name: &str) {
+    pub(crate) fn create_schema(&self, catalog_name: &str, schema_name: &str) -> InnerFullSchemaId {
         let catalog = match self.catalog(catalog_name) {
             Some(catalog) => catalog,
-            None => return,
+            None => return None,
         };
         let schema_id = catalog.create_schema(schema_name);
         if let Some(system_catalog) = self.system_catalog.as_ref() {
@@ -766,6 +766,7 @@ impl DataDefinition {
                 .expect("no platform error")
                 .expect("to save schema");
         }
+        Some((catalog.id(), Some(schema_id)))
     }
 
     pub(crate) fn schema_exists(&self, catalog_name: &str, schema_name: &str) -> InnerFullSchemaId {

--- a/src/sql_engine/src/catalog_manager/mod.rs
+++ b/src/sql_engine/src/catalog_manager/mod.rs
@@ -14,11 +14,13 @@
 
 use crate::{catalog_manager::data_definition::DataDefinition, ColumnDefinition};
 use kernel::{Object, Operation, SystemError, SystemResult};
-use std::collections::HashMap;
-use std::sync::RwLock;
 use std::{
+    collections::HashMap,
     path::PathBuf,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        RwLock,
+    },
 };
 use storage::{Database, InMemoryDatabase, InitStatus, Key, PersistentDatabase, ReadCursor, Row};
 
@@ -44,7 +46,6 @@ pub struct CatalogManager {
     data_storage: Box<dyn Database>,
     data_definition: DataDefinition,
     schemas: RwLock<HashMap<u64, String>>,
-    tables: RwLock<HashMap<(u64, u64), String>>,
 }
 
 impl Default for CatalogManager {
@@ -67,7 +68,6 @@ impl CatalogManager {
             data_storage: Box::new(InMemoryDatabase::default()),
             data_definition,
             schemas: RwLock::default(),
-            tables: RwLock::default(),
         })
     }
 
@@ -110,7 +110,6 @@ impl CatalogManager {
             data_storage: Box::new(catalog),
             data_definition,
             schemas: RwLock::default(),
-            tables: RwLock::default(),
         })
     }
 

--- a/src/sql_engine/src/catalog_manager/tests/schema.rs
+++ b/src/sql_engine/src/catalog_manager/tests/schema.rs
@@ -62,9 +62,12 @@ fn same_table_names_with_different_columns_in_different_schemas(storage: Catalog
 
 #[rstest::rstest]
 fn drop_schema(default_schema_name: &str, storage_with_schema: CatalogManager) {
+    let schema_id = storage_with_schema
+        .schema_exists(default_schema_name)
+        .expect("schema exists");
     assert_eq!(
         storage_with_schema
-            .drop_schema(default_schema_name, DropStrategy::Restrict)
+            .drop_schema(schema_id, DropStrategy::Restrict)
             .expect("no system errors"),
         Ok(())
     );
@@ -79,9 +82,12 @@ fn restrict_drop_schema_does_not_drop_schema_with_table(
     storage_with_schema
         .create_table(default_schema_name, "table_name", &[])
         .expect("no system errors");
+    let schema_id = storage_with_schema
+        .schema_exists(default_schema_name)
+        .expect("schema exists");
     assert_eq!(
         storage_with_schema
-            .drop_schema(default_schema_name, DropStrategy::Restrict)
+            .drop_schema(schema_id, DropStrategy::Restrict)
             .expect("no system errors"),
         Err(DropSchemaError::HasDependentObjects)
     );
@@ -109,10 +115,13 @@ fn cascade_drop_schema_drops_tables_in_it(default_schema_name: &str, storage_wit
             )],
         )
         .expect("table is created");
+    let schema_id = storage_with_schema
+        .schema_exists(default_schema_name)
+        .expect("schema exists");
 
     assert_eq!(
         storage_with_schema
-            .drop_schema(default_schema_name, DropStrategy::Cascade)
+            .drop_schema(schema_id, DropStrategy::Cascade)
             .expect("no system errors"),
         Ok(())
     );


### PR DESCRIPTION
no issue to closes

#### Description
`CatalogManager::drop_schema` requires u64 schema id instead of name

#### Client output
no changes to output

