### PR TITLE
drop table with schema and table id

### DIFF
--- a/src/sql_engine/src/catalog_manager/tests/persistence.rs
+++ b/src/sql_engine/src/catalog_manager/tests/persistence.rs
@@ -45,9 +45,8 @@ fn created_schema_is_preserved_after_restart(persistent: (CatalogManager, TempDi
 #[rstest::rstest]
 fn created_table_is_preserved_after_restart(persistent: (CatalogManager, TempDir)) {
     let (catalog_manager, root_path) = persistent;
-    catalog_manager.create_schema(SCHEMA).expect("to create a schema");
-    let schema_id = catalog_manager.schema_exists(SCHEMA).expect("schema exists");
-    catalog_manager
+    let schema_id = catalog_manager.create_schema(SCHEMA).expect("to create a schema");
+    let table_id = catalog_manager
         .create_table(
             schema_id,
             "table_name",
@@ -67,11 +66,6 @@ fn created_table_is_preserved_after_restart(persistent: (CatalogManager, TempDir
         catalog_manager.table_exists(SCHEMA, "table_name"),
         Some((_, Some(_)))
     ));
-    let table_id = catalog_manager
-        .table_exists(SCHEMA, "table_name")
-        .expect("schema exists")
-        .1
-        .expect("table exists");
     assert_eq!(
         catalog_manager
             .table_columns(schema_id, table_id)
@@ -83,8 +77,7 @@ fn created_table_is_preserved_after_restart(persistent: (CatalogManager, TempDir
 #[rstest::rstest]
 fn stored_data_is_preserved_after_restart(persistent: (CatalogManager, TempDir)) {
     let (catalog_manager, root_path) = persistent;
-    catalog_manager.create_schema(SCHEMA).expect("to create a schema");
-    let schema_id = catalog_manager.schema_exists(SCHEMA).expect("schema exists");
+    let schema_id = catalog_manager.create_schema(SCHEMA).expect("to create a schema");
     catalog_manager
         .create_table(
             schema_id,

--- a/src/sql_engine/src/catalog_manager/tests/schema.rs
+++ b/src/sql_engine/src/catalog_manager/tests/schema.rs
@@ -17,17 +17,16 @@ use sql_types::SqlType;
 
 #[rstest::rstest]
 fn create_schemas_with_different_names(catalog_manager: CatalogManager) {
-    assert_eq!(catalog_manager.create_schema(SCHEMA_1), Ok(()));
-    assert_eq!(catalog_manager.create_schema(SCHEMA_2), Ok(()));
+    assert!(matches!(catalog_manager.create_schema(SCHEMA_1), Ok(_)));
+    assert!(matches!(catalog_manager.create_schema(SCHEMA_2), Ok(_)));
 }
 
 #[rstest::rstest]
 fn same_table_names_with_different_columns_in_different_schemas(catalog_manager: CatalogManager) {
-    catalog_manager.create_schema(SCHEMA_1).expect("schema is created");
-    catalog_manager.create_schema(SCHEMA_2).expect("schema is created");
+    let schema_1_id = catalog_manager.create_schema(SCHEMA_1).expect("schema is created");
+    let schema_2_id = catalog_manager.create_schema(SCHEMA_2).expect("schema is created");
 
-    let schema_1_id = catalog_manager.schema_exists(SCHEMA_1).expect("schema exists");
-    catalog_manager
+    let table_1_id = catalog_manager
         .create_table(
             schema_1_id,
             "table_name",
@@ -38,26 +37,13 @@ fn same_table_names_with_different_columns_in_different_schemas(catalog_manager:
         )
         .expect("table is created");
 
-    let schema_2_id = catalog_manager.schema_exists(SCHEMA_2).expect("schema exists");
-    catalog_manager
+    let table_2_id = catalog_manager
         .create_table(
             schema_2_id,
             "table_name",
             &[ColumnDefinition::new("sn_2_column", SqlType::BigInt(i64::min_value()))],
         )
         .expect("table is created");
-
-    let table_1_id = catalog_manager
-        .table_exists(SCHEMA_1, "table_name")
-        .expect("schema exists")
-        .1
-        .expect("table exists");
-
-    let table_2_id = catalog_manager
-        .table_exists(SCHEMA_2, "table_name")
-        .expect("schema exists")
-        .1
-        .expect("table exists");
 
     assert_eq!(
         catalog_manager.table_columns(schema_1_id, table_1_id),
@@ -86,7 +72,7 @@ fn drop_schema(catalog_manager_with_schema: CatalogManager) {
             .expect("no system errors"),
         Ok(())
     );
-    assert_eq!(catalog_manager_with_schema.create_schema(SCHEMA), Ok(()));
+    assert!(matches!(catalog_manager_with_schema.create_schema(SCHEMA), Ok(_)));
 }
 
 #[rstest::rstest]
@@ -140,11 +126,10 @@ fn cascade_drop_schema_drops_tables_in_it(catalog_manager_with_schema: CatalogMa
             .expect("no system errors"),
         Ok(())
     );
-    assert_eq!(catalog_manager_with_schema.create_schema(SCHEMA), Ok(()));
     let schema_id = catalog_manager_with_schema
-        .schema_exists(SCHEMA)
+        .create_schema(SCHEMA)
         .expect("schema exists");
-    assert_eq!(
+    assert!(matches!(
         catalog_manager_with_schema.create_table(
             schema_id,
             "table_name_1",
@@ -153,9 +138,9 @@ fn cascade_drop_schema_drops_tables_in_it(catalog_manager_with_schema: CatalogMa
                 SqlType::SmallInt(i16::min_value())
             )]
         ),
-        Ok(())
-    );
-    assert_eq!(
+        Ok(_)
+    ));
+    assert!(matches!(
         catalog_manager_with_schema.create_table(
             schema_id,
             "table_name_2",
@@ -164,6 +149,6 @@ fn cascade_drop_schema_drops_tables_in_it(catalog_manager_with_schema: CatalogMa
                 SqlType::SmallInt(i16::min_value())
             )]
         ),
-        Ok(())
-    );
+        Ok(_)
+    ));
 }

--- a/src/sql_engine/src/catalog_manager/tests/table.rs
+++ b/src/sql_engine/src/catalog_manager/tests/table.rs
@@ -20,7 +20,7 @@ fn create_tables_with_different_names(catalog_manager_with_schema: CatalogManage
     let schema_id = catalog_manager_with_schema
         .schema_exists(SCHEMA)
         .expect("schema exists");
-    assert_eq!(
+    assert!(matches!(
         catalog_manager_with_schema.create_table(
             schema_id,
             "table_name_1",
@@ -29,9 +29,9 @@ fn create_tables_with_different_names(catalog_manager_with_schema: CatalogManage
                 SqlType::SmallInt(i16::min_value())
             )]
         ),
-        Ok(())
-    );
-    assert_eq!(
+        Ok(_)
+    ));
+    assert!(matches!(
         catalog_manager_with_schema.create_table(
             schema_id,
             "table_name_2",
@@ -40,17 +40,16 @@ fn create_tables_with_different_names(catalog_manager_with_schema: CatalogManage
                 SqlType::SmallInt(i16::min_value())
             )]
         ),
-        Ok(())
-    );
+        Ok(_)
+    ));
 }
 
 #[rstest::rstest]
 fn create_table_with_the_same_name_in_different_schemas(catalog_manager: CatalogManager) {
-    catalog_manager.create_schema(SCHEMA_1).expect("schema is created");
-    catalog_manager.create_schema(SCHEMA_2).expect("schema is created");
+    let schema_1_id = catalog_manager.create_schema(SCHEMA_1).expect("schema is created");
+    let schema_2_id = catalog_manager.create_schema(SCHEMA_2).expect("schema is created");
 
-    let schema_1_id = catalog_manager.schema_exists(SCHEMA_1).expect("schema exists");
-    assert_eq!(
+    assert!(matches!(
         catalog_manager.create_table(
             schema_1_id,
             "table_name",
@@ -59,11 +58,10 @@ fn create_table_with_the_same_name_in_different_schemas(catalog_manager: Catalog
                 SqlType::SmallInt(i16::min_value())
             )]
         ),
-        Ok(())
-    );
+        Ok(_)
+    ));
 
-    let schema_2_id = catalog_manager.schema_exists(SCHEMA_2).expect("schema exists");
-    assert_eq!(
+    assert!(matches!(
         catalog_manager.create_table(
             schema_2_id,
             "table_name",
@@ -72,8 +70,8 @@ fn create_table_with_the_same_name_in_different_schemas(catalog_manager: Catalog
                 SqlType::SmallInt(i16::min_value())
             )]
         ),
-        Ok(())
-    );
+        Ok(_)
+    ));
 }
 
 #[rstest::rstest]
@@ -81,7 +79,7 @@ fn drop_table(catalog_manager_with_schema: CatalogManager) {
     let schema_id = catalog_manager_with_schema
         .schema_exists(SCHEMA)
         .expect("schema exists");
-    catalog_manager_with_schema
+    let table_id = catalog_manager_with_schema
         .create_table(
             schema_id,
             "table_name",
@@ -91,8 +89,9 @@ fn drop_table(catalog_manager_with_schema: CatalogManager) {
             )],
         )
         .expect("table is created");
-    assert_eq!(catalog_manager_with_schema.drop_table(SCHEMA, "table_name"), Ok(()));
-    assert_eq!(
+
+    assert_eq!(catalog_manager_with_schema.drop_table(schema_id, table_id), Ok(()));
+    assert!(matches!(
         catalog_manager_with_schema.create_table(
             schema_id,
             "table_name",
@@ -101,8 +100,8 @@ fn drop_table(catalog_manager_with_schema: CatalogManager) {
                 SqlType::SmallInt(i16::min_value())
             )]
         ),
-        Ok(())
-    );
+        Ok(_)
+    ));
 }
 
 #[rstest::rstest]
@@ -111,15 +110,9 @@ fn table_columns_on_empty_table(catalog_manager_with_schema: CatalogManager) {
         .schema_exists(SCHEMA)
         .expect("schema exists");
     let column_names = vec![];
-    catalog_manager_with_schema
+    let table_id = catalog_manager_with_schema
         .create_table(schema_id, "table_name", column_names.as_slice())
         .expect("table is created");
-
-    let table_id = catalog_manager_with_schema
-        .table_exists(SCHEMA, "table_name")
-        .expect("schema exists")
-        .1
-        .expect("table exists");
 
     assert_eq!(
         catalog_manager_with_schema

--- a/src/sql_engine/src/ddl/create_schema.rs
+++ b/src/sql_engine/src/ddl/create_schema.rs
@@ -20,19 +20,19 @@ use std::sync::Arc;
 pub(crate) struct CreateSchemaCommand {
     schema_info: SchemaCreationInfo,
     storage: Arc<CatalogManager>,
-    session: Arc<dyn Sender>,
+    sender: Arc<dyn Sender>,
 }
 
 impl CreateSchemaCommand {
     pub(crate) fn new(
         schema_info: SchemaCreationInfo,
         storage: Arc<CatalogManager>,
-        session: Arc<dyn Sender>,
+        sender: Arc<dyn Sender>,
     ) -> CreateSchemaCommand {
         CreateSchemaCommand {
             schema_info,
             storage,
-            session,
+            sender,
         }
     }
 
@@ -40,8 +40,8 @@ impl CreateSchemaCommand {
         let schema_name = &self.schema_info.schema_name;
         match self.storage.create_schema(schema_name) {
             Err(error) => Err(error),
-            Ok(()) => {
-                self.session
+            Ok(_schema_id) => {
+                self.sender
                     .send(Ok(QueryEvent::SchemaCreated))
                     .expect("To Send Query Result to Client");
                 Ok(())

--- a/src/sql_engine/src/ddl/drop_table.rs
+++ b/src/sql_engine/src/ddl/drop_table.rs
@@ -14,31 +14,43 @@
 
 use crate::{catalog_manager::CatalogManager, query::TableId};
 use kernel::SystemResult;
+use protocol::results::QueryError;
 use protocol::{results::QueryEvent, Sender};
 use std::sync::Arc;
 
 pub(crate) struct DropTableCommand {
     name: TableId,
     storage: Arc<CatalogManager>,
-    session: Arc<dyn Sender>,
+    sender: Arc<dyn Sender>,
 }
 
 impl DropTableCommand {
-    pub(crate) fn new(name: TableId, storage: Arc<CatalogManager>, session: Arc<dyn Sender>) -> DropTableCommand {
-        DropTableCommand { name, storage, session }
+    pub(crate) fn new(name: TableId, storage: Arc<CatalogManager>, sender: Arc<dyn Sender>) -> DropTableCommand {
+        DropTableCommand { name, storage, sender }
     }
 
     pub(crate) fn execute(&mut self) -> SystemResult<()> {
         let table_name = self.name.name();
         let schema_name = self.name.schema_name();
-        match self.storage.drop_table(schema_name, table_name) {
-            Err(error) => Err(error),
-            Ok(()) => {
-                self.session
+        match self.storage.table_exists(schema_name, table_name) {
+            None => self
+                .sender
+                .send(Err(QueryError::schema_does_not_exist(schema_name.to_owned())))
+                .expect("To Send Query Result to Client"),
+            Some((_, None)) => self
+                .sender
+                .send(Err(QueryError::table_does_not_exist(
+                    schema_name.to_owned() + "." + table_name,
+                )))
+                .expect("To Send Query Result to Client"),
+            Some((schema_id, Some(table_id))) => match self.storage.drop_table(schema_id, table_id) {
+                Err(error) => return Err(error),
+                Ok(()) => self
+                    .sender
                     .send(Ok(QueryEvent::TableDropped))
-                    .expect("To Send Query Result to Client");
-                Ok(())
-            }
+                    .expect("To Send Query Result to Client"),
+            },
         }
+        Ok(())
     }
 }

--- a/src/sql_engine/src/dml/select.rs
+++ b/src/sql_engine/src/dml/select.rs
@@ -33,13 +33,13 @@ impl<'sc> SelectCommand<'sc> {
         raw_sql_query: &'sc str,
         query: Box<Query>,
         storage: Arc<CatalogManager>,
-        session: Arc<dyn Sender>,
+        sender: Arc<dyn Sender>,
     ) -> SelectCommand<'sc> {
         SelectCommand {
             raw_sql_query,
             query,
             storage,
-            sender: session,
+            sender,
         }
     }
 


### PR DESCRIPTION
no issue to close

#### Description
`CatalogManager::drop_table` uses `u64` schema and table ids

#### Client output
no changes to client output

