### PR TITLE
migrate write_to, full_scan and drop_from to use schema and table id

### DIFF
--- a/src/sql_engine/src/catalog_manager/tests/persistence.rs
+++ b/src/sql_engine/src/catalog_manager/tests/persistence.rs
@@ -78,7 +78,7 @@ fn created_table_is_preserved_after_restart(persistent: (CatalogManager, TempDir
 fn stored_data_is_preserved_after_restart(persistent: (CatalogManager, TempDir)) {
     let (catalog_manager, root_path) = persistent;
     let schema_id = catalog_manager.create_schema(SCHEMA).expect("to create a schema");
-    catalog_manager
+    let table_id = catalog_manager
         .create_table(
             schema_id,
             "table_name",
@@ -87,8 +87,8 @@ fn stored_data_is_preserved_after_restart(persistent: (CatalogManager, TempDir))
         .expect("to create a table");
     catalog_manager
         .write_into(
-            SCHEMA,
-            "table_name",
+            schema_id,
+            table_id,
             vec![(
                 Binary::pack(&[Datum::from_u64(0)]),
                 Binary::pack(&[Datum::from_bool(true)]),
@@ -98,7 +98,7 @@ fn stored_data_is_preserved_after_restart(persistent: (CatalogManager, TempDir))
 
     assert_eq!(
         catalog_manager
-            .full_scan(SCHEMA, "table_name")
+            .full_scan(schema_id, table_id)
             .expect("to scan a table")
             .map(|item| item.expect("no io error").expect("no platform error"))
             .collect::<Vec<Row>>(),
@@ -113,7 +113,7 @@ fn stored_data_is_preserved_after_restart(persistent: (CatalogManager, TempDir))
 
     assert_eq!(
         catalog_manager
-            .full_scan(SCHEMA, "table_name")
+            .full_scan(schema_id, table_id)
             .expect("to scan a table")
             .map(|item| item.expect("no io error").expect("no platform error"))
             .collect::<Vec<Row>>(),

--- a/src/sql_engine/src/catalog_manager/tests/queries/delete.rs
+++ b/src/sql_engine/src/catalog_manager/tests/queries/delete.rs
@@ -21,7 +21,7 @@ fn delete_all_from_table(catalog_manager_with_schema: CatalogManager) {
     let schema_id = catalog_manager_with_schema
         .schema_exists(SCHEMA)
         .expect("schema exists");
-    catalog_manager_with_schema
+    let table_id = catalog_manager_with_schema
         .create_table(
             schema_id,
             "table_name",
@@ -34,8 +34,8 @@ fn delete_all_from_table(catalog_manager_with_schema: CatalogManager) {
 
     catalog_manager_with_schema
         .write_into(
-            SCHEMA,
-            "table_name",
+            schema_id,
+            table_id,
             vec![(
                 Binary::pack(&[Datum::from_u64(1)]),
                 Binary::pack(&[Datum::from_i16(123)]),
@@ -44,8 +44,8 @@ fn delete_all_from_table(catalog_manager_with_schema: CatalogManager) {
         .expect("values are inserted");
     catalog_manager_with_schema
         .write_into(
-            SCHEMA,
-            "table_name",
+            schema_id,
+            table_id,
             vec![(
                 Binary::pack(&[Datum::from_u64(2)]),
                 Binary::pack(&[Datum::from_i16(456)]),
@@ -54,8 +54,8 @@ fn delete_all_from_table(catalog_manager_with_schema: CatalogManager) {
         .expect("values are inserted");
     catalog_manager_with_schema
         .write_into(
-            SCHEMA,
-            "table_name",
+            table_id,
+            schema_id,
             vec![(
                 Binary::pack(&[Datum::from_u64(3)]),
                 Binary::pack(&[Datum::from_i16(789)]),
@@ -65,8 +65,8 @@ fn delete_all_from_table(catalog_manager_with_schema: CatalogManager) {
 
     assert_eq!(
         catalog_manager_with_schema.delete_from(
-            SCHEMA,
-            "table_name",
+            schema_id,
+            table_id,
             vec![
                 Binary::pack(&[Datum::from_u64(1)]),
                 Binary::pack(&[Datum::from_u64(2)]),
@@ -78,7 +78,7 @@ fn delete_all_from_table(catalog_manager_with_schema: CatalogManager) {
 
     assert_eq!(
         catalog_manager_with_schema
-            .full_scan(SCHEMA, "table_name")
+            .full_scan(schema_id, table_id)
             .map(|iter| iter.map(Result::unwrap).map(Result::unwrap).collect()),
         Ok(vec![])
     );

--- a/src/sql_engine/src/catalog_manager/tests/queries/select.rs
+++ b/src/sql_engine/src/catalog_manager/tests/queries/select.rs
@@ -37,10 +37,15 @@ fn with_small_ints_table(catalog_manager_with_schema: CatalogManager) -> Catalog
 
 #[rstest::rstest]
 fn select_all_from_table_with_many_columns(with_small_ints_table: CatalogManager) {
+    let full_table_id = with_small_ints_table
+        .table_exists(SCHEMA, "table_name")
+        .expect("schema exists");
+    let schema_id = full_table_id.0;
+    let table_id = full_table_id.1.expect("table exist");
     with_small_ints_table
         .write_into(
-            SCHEMA,
-            "table_name",
+            schema_id,
+            table_id,
             vec![(
                 Binary::pack(&[Datum::from_u64(1)]),
                 Binary::pack(&[Datum::from_i16(1), Datum::from_i16(2), Datum::from_i16(3)]),
@@ -49,7 +54,7 @@ fn select_all_from_table_with_many_columns(with_small_ints_table: CatalogManager
         .expect("values are inserted");
 
     assert_eq!(
-        with_small_ints_table.full_scan(SCHEMA, "table_name").map(|read| read
+        with_small_ints_table.full_scan(schema_id, table_id).map(|read| read
             .map(Result::unwrap)
             .map(Result::unwrap)
             .map(|(_key, values)| values)

--- a/src/sql_engine/src/dml/delete.rs
+++ b/src/sql_engine/src/dml/delete.rs
@@ -47,8 +47,8 @@ impl DeleteCommand {
                     schema_name + "." + table_name.as_str(),
                 )))
                 .expect("To Send Result to Client"),
-            Some((_, Some(_))) => {
-                match self.storage.full_scan(&schema_name, &table_name) {
+            Some((schema_id, Some(table_id))) => {
+                match self.storage.full_scan(schema_id, table_id) {
                     Err(e) => return Err(e),
                     Ok(reads) => {
                         let keys = reads
@@ -57,7 +57,7 @@ impl DeleteCommand {
                             .map(|(key, _)| key)
                             .collect();
 
-                        match self.storage.delete_from(&schema_name, &table_name, keys) {
+                        match self.storage.delete_from(schema_id, table_id, keys) {
                             Err(e) => return Err(e),
                             Ok(records_number) => self
                                 .sender

--- a/src/sql_engine/src/dml/insert.rs
+++ b/src/sql_engine/src/dml/insert.rs
@@ -229,7 +229,7 @@ impl<'ic> InsertCommand<'ic> {
                             to_write.push((Binary::with_data(key), Binary::pack(&record)));
                         }
 
-                        match self.storage.write_into(&schema_name, &table_name, to_write) {
+                        match self.storage.write_into(schema_id, table_id, to_write) {
                             Err(error) => return Err(error),
                             Ok(size) => self
                                 .sender

--- a/src/sql_engine/src/dml/select.rs
+++ b/src/sql_engine/src/dml/select.rs
@@ -125,7 +125,7 @@ impl<'sc> SelectCommand<'sc> {
                     .expect("To Send Result to Client");
                 Err(SystemError::runtime_check_failure("Table Does Not Exist".to_owned()))
             }
-            Some((schema_id, Some(table_id))) => match self.storage.full_scan(&input.schema_name, &input.table_name) {
+            Some((schema_id, Some(table_id))) => match self.storage.full_scan(schema_id, table_id) {
                 Err(error) => Err(error),
                 Ok(records) => {
                     let all_columns = self.storage.table_columns(schema_id, table_id)?;

--- a/src/sql_engine/src/dml/update.rs
+++ b/src/sql_engine/src/dml/update.rs
@@ -167,7 +167,7 @@ impl UpdateCommand {
                     return Ok(());
                 }
 
-                let to_update: Vec<Row> = match self.storage.full_scan(&schema_name, &table_name) {
+                let to_update: Vec<Row> = match self.storage.full_scan(schema_id, table_id) {
                     Err(error) => return Err(error),
                     Ok(reads) => reads
                         .map(Result::unwrap)
@@ -182,7 +182,7 @@ impl UpdateCommand {
                         .collect(),
                 };
 
-                match self.storage.write_into(&schema_name, &table_name, to_update) {
+                match self.storage.write_into(schema_id, table_id, to_update) {
                     Err(error) => return Err(error),
                     Ok(records_number) => {
                         self.sender


### PR DESCRIPTION
no issue to close

#### Description
migrate `CatalogManager::write_to`, `CatalogManager::full_scan` and `CatalogManager::drop_from` to use `u64` schema and table id

#### Client output
no changes to client output

