### PR TITLE
generalise and move prepared_statement to protocol

### DIFF
--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -46,12 +46,16 @@ use std::{
 pub mod messages;
 /// Module contains functionality to represent query result
 pub mod results;
+/// Module contains functionality to represent server side client session
+pub mod session;
 /// Module contains functionality to represent SQL format
 pub mod sql_formats;
 /// Module contains functionality to represent SQL type system
 pub mod sql_types;
 /// Module contains functionality to represent SQL data value
 pub mod sql_values;
+/// Module contains functionality to hold data about `PreparedStatement`
+pub mod statement;
 
 /// Protocol version
 pub type Version = i32;

--- a/src/protocol/src/session.rs
+++ b/src/protocol/src/session.rs
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod statement;
-
-use protocol::sql_formats::PostgreSqlFormat;
-use sqlparser::ast::Statement;
-use statement::{Portal, PreparedStatement};
+use crate::{
+    sql_formats::PostgreSqlFormat,
+    statement::{Portal, PreparedStatement},
+};
 use std::collections::HashMap;
 
 /// A `Session` holds SQL state that is attached to a session.
 #[derive(Clone, Debug)]
-pub struct Session {
+pub struct Session<S> {
     /// A map from statement names to parameterized statements
-    prepared_statements: HashMap<String, PreparedStatement>,
+    prepared_statements: HashMap<String, PreparedStatement<S>>,
     /// A map from statement names to bound statements
-    portals: HashMap<String, Portal>,
+    portals: HashMap<String, Portal<S>>,
 }
 
-impl Session {
+impl<S> Session<S> {
+    /// create new client session
     pub fn new() -> Self {
         Self {
             prepared_statements: HashMap::new(),
@@ -36,23 +36,27 @@ impl Session {
         }
     }
 
-    pub fn get_prepared_statement(&self, name: &str) -> Option<&PreparedStatement> {
+    /// get `PreparedStatement` by its name
+    pub fn get_prepared_statement(&self, name: &str) -> Option<&PreparedStatement<S>> {
         self.prepared_statements.get(name)
     }
 
-    pub fn set_prepared_statement(&mut self, name: String, statement: PreparedStatement) {
+    /// save `PreparedStatement` associated with a name
+    pub fn set_prepared_statement(&mut self, name: String, statement: PreparedStatement<S>) {
         self.prepared_statements.insert(name, statement);
     }
 
-    pub fn get_portal(&self, name: &str) -> Option<&Portal> {
+    /// get `Portal` by its name
+    pub fn get_portal(&self, name: &str) -> Option<&Portal<S>> {
         self.portals.get(name)
     }
 
+    /// save `Portal` associated with a name
     pub fn set_portal(
         &mut self,
         portal_name: String,
         statement_name: String,
-        stmt: Statement,
+        stmt: S,
         result_formats: Vec<PostgreSqlFormat>,
     ) {
         let new_portal = Portal::new(statement_name, stmt, result_formats);

--- a/src/protocol/src/session.rs
+++ b/src/protocol/src/session.rs
@@ -27,15 +27,16 @@ pub struct Session<S> {
     portals: HashMap<String, Portal<S>>,
 }
 
-impl<S> Session<S> {
-    /// create new client session
-    pub fn new() -> Self {
-        Self {
-            prepared_statements: HashMap::new(),
-            portals: HashMap::new(),
+impl<S> Default for Session<S> {
+    fn default() -> Session<S> {
+        Session {
+            prepared_statements: HashMap::default(),
+            portals: HashMap::default(),
         }
     }
+}
 
+impl<S> Session<S> {
     /// get `PreparedStatement` by its name
     pub fn get_prepared_statement(&self, name: &str) -> Option<&PreparedStatement<S>> {
         self.prepared_statements.get(name)

--- a/src/protocol/src/statement.rs
+++ b/src/protocol/src/statement.rs
@@ -30,27 +30,26 @@
 //! 3. The client issues a `Bind` message, which provides a name for a portal,
 //!    and associates that name with a previously-named prepared statement. This
 //!    is the point at which all possible parameters are associated with the
-//!    statement, there are no longer any free variables permited.
+//!    statement, there are no longer any free variables permitted.
 //! 4. The client issues an `Execute` message with the name of a portal, causing
 //!    that portal to actually start scanning and returning results.
 
-use protocol::{results::Description, sql_formats::PostgreSqlFormat, sql_types::PostgreSqlType};
-use sqlparser::ast::Statement;
+use crate::{results::Description, sql_formats::PostgreSqlFormat, sql_types::PostgreSqlType};
 
 /// A prepared statement.
 #[derive(Clone, Debug)]
-pub struct PreparedStatement {
+pub struct PreparedStatement<S> {
     /// The raw prepared SQL statement will be bound to a portal.
-    stmt: Statement,
+    stmt: S,
     /// The types of any bound parameters.
     param_types: Vec<PostgreSqlType>,
     /// The type of the rows that will be returned.
     description: Description,
 }
 
-impl PreparedStatement {
+impl<S> PreparedStatement<S> {
     /// Constructs a new `PreparedStatement`.
-    pub fn new(stmt: Statement, param_types: Vec<PostgreSqlType>, description: Description) -> PreparedStatement {
+    pub fn new(stmt: S, param_types: Vec<PostgreSqlType>, description: Description) -> PreparedStatement<S> {
         PreparedStatement {
             stmt,
             param_types,
@@ -59,7 +58,7 @@ impl PreparedStatement {
     }
 
     /// Returns the raw prepared SQL statement.
-    pub fn stmt(&self) -> &Statement {
+    pub fn stmt(&self) -> &S {
         &self.stmt
     }
 
@@ -76,18 +75,18 @@ impl PreparedStatement {
 
 /// A portal represents the execution state of a running or runnable query.
 #[derive(Clone, Debug)]
-pub struct Portal {
+pub struct Portal<S> {
     /// The name of the prepared statement that is bound to this portal.
     statement_name: String,
     /// The bound SQL statement from the prepared statement.
-    stmt: Statement,
+    stmt: S,
     /// The desired output format for each column in the result set.
     result_formats: Vec<PostgreSqlFormat>,
 }
 
-impl Portal {
+impl<S> Portal<S> {
     /// Constructs a new `Portal`.
-    pub fn new(statement_name: String, stmt: Statement, result_formats: Vec<PostgreSqlFormat>) -> Self {
+    pub fn new(statement_name: String, stmt: S, result_formats: Vec<PostgreSqlFormat>) -> Self {
         Self {
             statement_name,
             stmt,
@@ -96,7 +95,7 @@ impl Portal {
     }
 
     /// Returns the bound SQL statement.
-    pub fn stmt(&self) -> &Statement {
+    pub fn stmt(&self) -> &S {
         &self.stmt
     }
 }

--- a/src/sql_engine/src/ddl/drop_table.rs
+++ b/src/sql_engine/src/ddl/drop_table.rs
@@ -14,8 +14,10 @@
 
 use crate::{catalog_manager::CatalogManager, query::TableId};
 use kernel::SystemResult;
-use protocol::results::QueryError;
-use protocol::{results::QueryEvent, Sender};
+use protocol::{
+    results::{QueryError, QueryEvent},
+    Sender,
+};
 use std::sync::Arc;
 
 pub(crate) struct DropTableCommand {

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -23,15 +23,16 @@ use crate::{
     },
     dml::{delete::DeleteCommand, insert::InsertCommand, select::SelectCommand, update::UpdateCommand},
     query::{bind::ParamBinder, plan::Plan, process::QueryProcessor},
-    session::{statement::PreparedStatement, Session},
 };
 use itertools::izip;
 use kernel::SystemResult;
 use protocol::{
     results::{QueryError, QueryEvent},
+    session::Session,
     sql_formats::PostgreSqlFormat,
     sql_types::PostgreSqlType,
     sql_values::PostgreSqlValue,
+    statement::PreparedStatement,
     Sender,
 };
 use serde::{Deserialize, Serialize};
@@ -47,7 +48,6 @@ pub mod catalog_manager;
 mod ddl;
 mod dml;
 mod query;
-mod session;
 
 pub type Projection = (Vec<ColumnDefinition>, Vec<Vec<String>>);
 
@@ -81,7 +81,7 @@ impl ColumnDefinition {
 pub struct QueryExecutor {
     storage: Arc<CatalogManager>,
     sender: Arc<dyn Sender>,
-    session: Session,
+    session: Session<Statement>,
     processor: QueryProcessor,
     param_binder: ParamBinder,
 }

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -91,7 +91,7 @@ impl QueryExecutor {
         Self {
             storage: storage.clone(),
             sender: sender.clone(),
-            session: Session::new(),
+            session: Session::default(),
             processor: QueryProcessor::new(storage, sender.clone()),
             param_binder: ParamBinder::new(sender),
         }


### PR DESCRIPTION
no issue to close

#### Description
abstract away `PreparedStatement` from `sqlparser`

#### Client output
no changes to client output

