### PR TITLE
Fix to always return ReadyForQuery after an ErrorResponse

### DIFF
--- a/src/sql_engine/src/tests/error_responses.rs
+++ b/src/sql_engine/src/tests/error_responses.rs
@@ -1,0 +1,30 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[rstest::rstest]
+fn parse_wrong_select_syntax(sql_engine: (QueryExecutor, ResultCollector)) {
+    let (mut engine, collector) = sql_engine;
+    engine
+        .execute("selec col from schema_name.table_name")
+        .expect("no system errors");
+
+    collector.assert_content_for_single_queries(vec![
+        Err(QueryError::syntax_error(
+            "\"selec col from schema_name.table_name\" can\'t be parsed".into(),
+        )),
+        Ok(QueryEvent::QueryComplete),
+    ]);
+}

--- a/src/sql_engine/src/tests/mod.rs
+++ b/src/sql_engine/src/tests/mod.rs
@@ -33,6 +33,8 @@ mod delete;
 #[cfg(test)]
 mod describe_prepared_statement;
 #[cfg(test)]
+mod error_responses;
+#[cfg(test)]
 mod execute_portal;
 #[cfg(test)]
 mod insert;


### PR DESCRIPTION
#### Description

As @alex-dukhno mentioned, `psql` is stuck after inputting wrong SQL syntax (as `selec * from table`).

Fixes to always return `ReadyForQuery` message (as `QueryEvent::QueryComplete`) after both `CommandComplete` or `ErrorResponse` messages. I missed to return `ReadyForQuery` after `ErrorResponse` before.

#### Client output

After adding this fix, the `psql` could display the error message without stuck.

```
psql (12.1, server 0.0.0)
Type "help" for help.

xxx=> selec * from table;
ERROR:  syntax error in "selec * from table;" can't be parsed
```

