### PR TITLE
Refactor query planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,6 +898,7 @@ dependencies = [
  "itertools",
  "kernel",
  "protocol",
+ "rstest",
  "sql_model",
  "sqlparser",
 ]
@@ -1212,6 +1213,7 @@ dependencies = [
  "protocol",
  "rstest",
  "serde",
+ "sqlparser",
 ]
 
 [[package]]

--- a/src/protocol/src/results.rs
+++ b/src/protocol/src/results.rs
@@ -306,90 +306,90 @@ impl Into<BackendMessage> for QueryError {
 
 impl QueryError {
     /// schema already exists error constructor
-    pub fn schema_already_exists(schema_name: String) -> QueryError {
+    pub fn schema_already_exists<S: ToString>(schema_name: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::SchemaAlreadyExists(schema_name),
+            kind: QueryErrorKind::SchemaAlreadyExists(schema_name.to_string()),
         }
     }
 
     /// schema does not exist error constructor
-    pub fn schema_does_not_exist(schema_name: String) -> QueryError {
+    pub fn schema_does_not_exist<S: ToString>(schema_name: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::SchemaDoesNotExist(schema_name),
+            kind: QueryErrorKind::SchemaDoesNotExist(schema_name.to_string()),
         }
     }
 
     /// schema has dependent objects error constructor
-    pub fn schema_has_dependent_objects(schema_name: String) -> QueryError {
+    pub fn schema_has_dependent_objects<S: ToString>(schema_name: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::SchemaHasDependentObjects(schema_name),
+            kind: QueryErrorKind::SchemaHasDependentObjects(schema_name.to_string()),
         }
     }
 
     /// table already exists error constructor
-    pub fn table_already_exists(table_name: String) -> QueryError {
+    pub fn table_already_exists<S: ToString>(table_name: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::TableAlreadyExists(table_name),
+            kind: QueryErrorKind::TableAlreadyExists(table_name.to_string()),
         }
     }
 
     /// table does not exist error constructor
-    pub fn table_does_not_exist(table_name: String) -> QueryError {
+    pub fn table_does_not_exist<S: ToString>(table_name: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::TableDoesNotExist(table_name),
+            kind: QueryErrorKind::TableDoesNotExist(table_name.to_string()),
         }
     }
 
     /// column does not exists error constructor
-    pub fn column_does_not_exist(non_existing_column: String) -> QueryError {
+    pub fn column_does_not_exist<S: ToString>(non_existing_column: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::ColumnDoesNotExist(non_existing_column),
+            kind: QueryErrorKind::ColumnDoesNotExist(non_existing_column.to_string()),
         }
     }
 
     /// invalid parameter value error constructor
-    pub fn invalid_parameter_value(message: String) -> QueryError {
+    pub fn invalid_parameter_value<S: ToString>(message: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::InvalidParameterValue(message),
+            kind: QueryErrorKind::InvalidParameterValue(message.to_string()),
         }
     }
 
     /// prepared statement does not exist error constructor
-    pub fn prepared_statement_does_not_exist(statement_name: String) -> QueryError {
+    pub fn prepared_statement_does_not_exist<S: ToString>(statement_name: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::PreparedStatementDoesNotExist(statement_name),
+            kind: QueryErrorKind::PreparedStatementDoesNotExist(statement_name.to_string()),
         }
     }
 
     /// portal does not exist error constructor
-    pub fn portal_does_not_exist(portal_name: String) -> QueryError {
+    pub fn portal_does_not_exist<S: ToString>(portal_name: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::PortalDoesNotExist(portal_name),
+            kind: QueryErrorKind::PortalDoesNotExist(portal_name.to_string()),
         }
     }
 
     /// protocol violation error constructor
-    pub fn protocol_violation(message: String) -> QueryError {
+    pub fn protocol_violation<S: ToString>(message: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::ProtocolViolation(message),
+            kind: QueryErrorKind::ProtocolViolation(message.to_string()),
         }
     }
 
     /// not supported operation error constructor
-    pub fn feature_not_supported(feature_description: String) -> QueryError {
+    pub fn feature_not_supported<S: ToString>(feature_description: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::FeatureNotSupported(feature_description),
+            kind: QueryErrorKind::FeatureNotSupported(feature_description.to_string()),
         }
     }
 
@@ -402,71 +402,80 @@ impl QueryError {
     }
 
     /// syntax error in the expression as part of query
-    pub fn syntax_error(expression: String) -> QueryError {
+    pub fn syntax_error<S: ToString>(expression: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::SyntaxError(expression),
+            kind: QueryErrorKind::SyntaxError(expression.to_string()),
         }
     }
 
     /// operator or function is not found for operands
-    pub fn undefined_function(operator: String, left_type: String, right_type: String) -> QueryError {
+    pub fn undefined_function<S: ToString>(operator: S, left_type: S, right_type: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
             kind: QueryErrorKind::UndefinedFunction {
-                operator,
-                left_type,
-                right_type,
+                operator: operator.to_string(),
+                left_type: left_type.to_string(),
+                right_type: right_type.to_string(),
             },
         }
     }
 
     /// when the name of a column is ambiguous in a multi-table context
-    pub fn ambiguous_column(column: String) -> QueryError {
+    pub fn ambiguous_column<S: ToString>(column: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::AmbiguousColumnName { column },
+            kind: QueryErrorKind::AmbiguousColumnName {
+                column: column.to_string(),
+            },
         }
     }
 
     /// user of an undefined column
-    pub fn undefined_column(column: String) -> QueryError {
+    pub fn undefined_column<S: ToString>(column: S) -> QueryError {
         QueryError {
             severity: Severity::Error,
-            kind: QueryErrorKind::UndefinedColumn { column },
+            kind: QueryErrorKind::UndefinedColumn {
+                column: column.to_string(),
+            },
         }
     }
 
     /// numeric out of range constructor
-    pub fn out_of_range(pg_type: PostgreSqlType, column_name: String, row_index: usize) -> QueryError {
+    pub fn out_of_range<S: ToString>(pg_type: PostgreSqlType, column_name: S, row_index: usize) -> QueryError {
         QueryError {
             severity: Severity::Error,
             kind: QueryErrorKind::NumericTypeOutOfRange {
                 pg_type,
-                column_name,
+                column_name: column_name.to_string(),
                 row_index,
             },
         }
     }
 
     /// type mismatch constructor
-    pub fn type_mismatch(value: &str, pg_type: PostgreSqlType, column_name: String, row_index: usize) -> QueryError {
+    pub fn type_mismatch<S: ToString>(
+        value: S,
+        pg_type: PostgreSqlType,
+        column_name: S,
+        row_index: usize,
+    ) -> QueryError {
         QueryError {
             severity: Severity::Error,
             kind: QueryErrorKind::DataTypeMismatch {
                 pg_type,
-                value: value.to_owned(),
-                column_name,
+                value: value.to_string(),
+                column_name: column_name.to_string(),
                 row_index,
             },
         }
     }
 
     /// length of string types do not match constructor
-    pub fn string_length_mismatch(
+    pub fn string_length_mismatch<S: ToString>(
         pg_type: PostgreSqlType,
         len: u64,
-        column_name: String,
+        column_name: S,
         row_index: usize,
     ) -> QueryError {
         QueryError {
@@ -474,7 +483,7 @@ impl QueryError {
             kind: QueryErrorKind::StringTypeLengthMismatch {
                 pg_type,
                 len,
-                column_name,
+                column_name: column_name.to_string(),
                 row_index,
             },
         }
@@ -624,8 +633,8 @@ mod tests {
 
         #[test]
         fn schema_already_exists() {
-            let schema_name = "some_table_name".to_owned();
-            let message: BackendMessage = QueryError::schema_already_exists(schema_name.clone()).into();
+            let schema_name = "some_table_name";
+            let message: BackendMessage = QueryError::schema_already_exists(schema_name).into();
             assert_eq!(
                 message,
                 BackendMessage::ErrorResponse(
@@ -638,8 +647,8 @@ mod tests {
 
         #[test]
         fn schema_does_not_exists() {
-            let schema_name = "some_table_name".to_owned();
-            let message: BackendMessage = QueryError::schema_does_not_exist(schema_name.clone()).into();
+            let schema_name = "some_table_name";
+            let message: BackendMessage = QueryError::schema_does_not_exist(schema_name).into();
             assert_eq!(
                 message,
                 BackendMessage::ErrorResponse(
@@ -652,8 +661,8 @@ mod tests {
 
         #[test]
         fn table_already_exists() {
-            let table_name = "some_table_name".to_owned();
-            let message: BackendMessage = QueryError::table_already_exists(table_name.clone()).into();
+            let table_name = "some_table_name";
+            let message: BackendMessage = QueryError::table_already_exists(table_name).into();
             assert_eq!(
                 message,
                 BackendMessage::ErrorResponse(
@@ -666,8 +675,8 @@ mod tests {
 
         #[test]
         fn table_does_not_exists() {
-            let table_name = "some_table_name".to_owned();
-            let message: BackendMessage = QueryError::table_does_not_exist(table_name.clone()).into();
+            let table_name = "some_table_name";
+            let message: BackendMessage = QueryError::table_does_not_exist(table_name).into();
             assert_eq!(
                 message,
                 BackendMessage::ErrorResponse(
@@ -680,7 +689,7 @@ mod tests {
 
         #[test]
         fn one_column_does_not_exists() {
-            let message: BackendMessage = QueryError::column_does_not_exist("column_not_in_table".to_owned()).into();
+            let message: BackendMessage = QueryError::column_does_not_exist("column_not_in_table").into();
             assert_eq!(
                 message,
                 BackendMessage::ErrorResponse(
@@ -693,8 +702,7 @@ mod tests {
 
         #[test]
         fn invalid_parameter_value() {
-            let messages: BackendMessage =
-                QueryError::invalid_parameter_value("Wrong parameter value".to_owned()).into();
+            let messages: BackendMessage = QueryError::invalid_parameter_value("Wrong parameter value").into();
             assert_eq!(
                 messages,
                 BackendMessage::ErrorResponse(Some("ERROR"), Some("22023"), Some("Wrong parameter value".to_owned()))
@@ -703,8 +711,7 @@ mod tests {
 
         #[test]
         fn prepared_statement_does_not_exists() {
-            let messages: BackendMessage =
-                QueryError::prepared_statement_does_not_exist("statement_name".to_owned()).into();
+            let messages: BackendMessage = QueryError::prepared_statement_does_not_exist("statement_name").into();
             assert_eq!(
                 messages,
                 BackendMessage::ErrorResponse(
@@ -717,7 +724,7 @@ mod tests {
 
         #[test]
         fn portal_does_not_exists() {
-            let messages: BackendMessage = QueryError::portal_does_not_exist("portal_name".to_owned()).into();
+            let messages: BackendMessage = QueryError::portal_does_not_exist("portal_name").into();
             assert_eq!(
                 messages,
                 BackendMessage::ErrorResponse(
@@ -730,7 +737,7 @@ mod tests {
 
         #[test]
         fn protocol_violation() {
-            let messages: BackendMessage = QueryError::protocol_violation("Wrong protocol data".to_owned()).into();
+            let messages: BackendMessage = QueryError::protocol_violation("Wrong protocol data").into();
             assert_eq!(
                 messages,
                 BackendMessage::ErrorResponse(Some("ERROR"), Some("08P01"), Some("Wrong protocol data".to_owned()))
@@ -739,8 +746,8 @@ mod tests {
 
         #[test]
         fn feature_not_supported() {
-            let raw_sql_query = "some SQL query".to_owned();
-            let message: BackendMessage = QueryError::feature_not_supported(raw_sql_query.clone()).into();
+            let raw_sql_query = "some SQL query";
+            let message: BackendMessage = QueryError::feature_not_supported(raw_sql_query).into();
             assert_eq!(
                 message,
                 BackendMessage::ErrorResponse(
@@ -780,8 +787,7 @@ mod tests {
 
         #[test]
         fn type_mismatch_constraint_violation() {
-            let message: BackendMessage =
-                QueryError::type_mismatch("abc", PostgreSqlType::SmallInt, "col1".to_string(), 1).into();
+            let message: BackendMessage = QueryError::type_mismatch("abc", PostgreSqlType::SmallInt, "col1", 1).into();
             assert_eq!(
                 message,
                 BackendMessage::ErrorResponse(

--- a/src/protocol/src/tests/hand_shake.rs
+++ b/src/protocol/src/tests/hand_shake.rs
@@ -52,7 +52,7 @@ fn trying_read_from_empty_stream() {
         )
         .await;
 
-        assert!(result.is_err());
+        assert!(matches!(result, Err(_)));
     });
 }
 
@@ -70,7 +70,7 @@ fn trying_read_only_length_of_ssl_message() {
         )
         .await;
 
-        assert!(result.is_err());
+        assert!(matches!(result, Err(_)));
     });
 }
 
@@ -88,7 +88,7 @@ fn sending_reject_notification_for_none_secure() {
         )
         .await;
 
-        assert!(result.is_err());
+        assert!(matches!(result, Err(_)));
 
         let actual_content = test_case.read_result().await;
         let mut expected_content = Vec::new();
@@ -111,7 +111,7 @@ fn sending_accept_notification_for_ssl_only_secure() {
         )
         .await;
 
-        assert!(result.is_err());
+        assert!(matches!(result, Err(_)));
 
         let actual_content = test_case.read_result().await;
         let mut expected_content = Vec::new();
@@ -146,7 +146,7 @@ fn successful_connection_handshake_for_none_secure() {
         )
         .await;
 
-        assert!(result.is_ok());
+        assert!(matches!(result, Ok(_)));
 
         let actual_content = test_case.read_result().await;
         let mut expected_content = Vec::new();
@@ -199,7 +199,7 @@ fn successful_connection_handshake_for_ssl_only_secure() {
         )
         .await;
 
-        assert!(result.is_ok());
+        assert!(matches!(result, Ok(_)));
 
         let actual_content = test_case.read_result().await;
         let mut expected_content = Vec::new();

--- a/src/query_planner/Cargo.toml
+++ b/src/query_planner/Cargo.toml
@@ -12,3 +12,6 @@ data_manager = { path = "../data_manager" }
 protocol = { path = "../protocol" }
 kernel = { path = "../kernel" }
 itertools = "0.9.0"
+
+[dev-dependencies]
+rstest = "0.6.4"

--- a/src/query_planner/src/plan.rs
+++ b/src/query_planner/src/plan.rs
@@ -13,14 +13,10 @@
 // limitations under the License.
 
 ///! represents a plan to be executed by the engine.
-use sqlparser::ast::{Assignment, Ident, Query, Statement};
-
-use crate::{FullTableName, SchemaName};
-use data_manager::ColumnDefinition;
-
-///! represents a plan to be executed by the engine.
 use crate::{SchemaId, TableId};
+use data_manager::ColumnDefinition;
 use sql_model::Id;
+use sqlparser::ast::{Assignment, Ident, Query, Statement};
 
 #[derive(Debug, Clone)]
 pub struct TableCreationInfo {

--- a/src/query_planner/src/plan.rs
+++ b/src/query_planner/src/plan.rs
@@ -48,6 +48,14 @@ pub struct SchemaCreationInfo {
     pub schema_name: String,
 }
 
+impl SchemaCreationInfo {
+    pub(crate) fn new<S: ToString>(schema_name: S) -> SchemaCreationInfo {
+        SchemaCreationInfo {
+            schema_name: schema_name.to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TableInserts {
     pub full_table_name: TableId,

--- a/src/query_planner/src/plan.rs
+++ b/src/query_planner/src/plan.rs
@@ -12,19 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+///! represents a plan to be executed by the engine.
 use sqlparser::ast::{Assignment, Ident, Query, Statement};
 
+use crate::{FullTableName, SchemaName};
 use data_manager::ColumnDefinition;
 
 ///! represents a plan to be executed by the engine.
 use crate::{SchemaId, TableId};
+use sql_model::Id;
 
 #[derive(Debug, Clone)]
 pub struct TableCreationInfo {
-    pub schema_id: SchemaId,
-    pub schema_name: String,
+    pub schema_id: Id,
     pub table_name: String,
-    pub columns: Vec<ColumnDefinition>, // pub table_constraints: Vec<TableConstraints> ??
+    pub columns: Vec<ColumnDefinition>,
+}
+
+impl TableCreationInfo {
+    pub(crate) fn new<S: ToString>(schema_id: Id, table_name: S, columns: Vec<ColumnDefinition>) -> TableCreationInfo {
+        TableCreationInfo {
+            schema_id,
+            table_name: table_name.to_string(),
+            columns,
+        }
+    }
+
+    pub fn as_tuple(&self) -> (Id, &str, &[ColumnDefinition]) {
+        (self.schema_id, self.table_name.as_str(), self.columns.as_slice())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -34,20 +50,20 @@ pub struct SchemaCreationInfo {
 
 #[derive(Debug, Clone)]
 pub struct TableInserts {
-    pub table_id: TableId,
+    pub full_table_name: TableId,
     pub column_indices: Vec<Ident>,
     pub input: Box<Query>,
 }
 
 #[derive(Debug, Clone)]
 pub struct TableUpdates {
-    pub table_id: TableId,
+    pub full_table_name: TableId,
     pub assignments: Vec<Assignment>,
 }
 
 #[derive(Debug, Clone)]
 pub struct TableDeletes {
-    pub table_id: TableId,
+    pub full_table_name: TableId,
 }
 
 #[derive(Debug, Clone)]

--- a/src/query_planner/src/planner/create_schema.rs
+++ b/src/query_planner/src/planner/create_schema.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::plan::{Plan, SchemaCreationInfo};
-use crate::{planner::Planner, planner::Result, SchemaName};
+use crate::{
+    plan::{Plan, SchemaCreationInfo},
+    planner::{Planner, Result},
+    SchemaName,
+};
 use data_manager::DataManager;
-use protocol::results::QueryError;
-use protocol::Sender;
+use protocol::{results::QueryError, Sender};
 use sqlparser::ast::ObjectName;
-use std::convert::TryFrom;
-use std::sync::Arc;
+use std::{convert::TryFrom, sync::Arc};
 
 pub(crate) struct CreateSchemaPlanner {
     schema_name: ObjectName,

--- a/src/query_planner/src/planner/create_schema.rs
+++ b/src/query_planner/src/planner/create_schema.rs
@@ -1,0 +1,54 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::plan::{Plan, SchemaCreationInfo};
+use crate::{planner::Planner, planner::Result, SchemaName};
+use data_manager::DataManager;
+use protocol::results::QueryError;
+use protocol::Sender;
+use sqlparser::ast::ObjectName;
+use std::convert::TryFrom;
+use std::sync::Arc;
+
+pub(crate) struct CreateSchemaPlanner {
+    schema_name: ObjectName,
+}
+
+impl CreateSchemaPlanner {
+    pub(crate) fn new(schema_name: ObjectName) -> CreateSchemaPlanner {
+        CreateSchemaPlanner { schema_name }
+    }
+}
+
+impl Planner for CreateSchemaPlanner {
+    fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
+        match SchemaName::try_from(self.schema_name) {
+            Ok(schema_name) => match data_manager.schema_exists(schema_name.name()) {
+                Some(_) => {
+                    sender
+                        .send(Err(QueryError::schema_already_exists(schema_name)))
+                        .expect("To Send Query Result to Client");
+                    Err(())
+                }
+                None => Ok(Plan::CreateSchema(SchemaCreationInfo::new(schema_name))),
+            },
+            Err(error) => {
+                sender
+                    .send(Err(QueryError::syntax_error(error)))
+                    .expect("To Send Query Result to Client");
+                Err(())
+            }
+        }
+    }
+}

--- a/src/query_planner/src/planner/create_table.rs
+++ b/src/query_planner/src/planner/create_table.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::planner::Planner;
 use crate::{
     plan::{Plan, TableCreationInfo},
-    planner::Result,
+    planner::{Planner, Result},
     FullTableName,
 };
 use data_manager::{ColumnDefinition, DataManager};

--- a/src/query_planner/src/planner/create_table.rs
+++ b/src/query_planner/src/planner/create_table.rs
@@ -1,0 +1,95 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    plan::{Plan, TableCreationInfo},
+    planner::Result,
+    FullTableName, TableNamingError,
+};
+use data_manager::{ColumnDefinition, DataManager};
+use protocol::{results::QueryError, Sender};
+use sql_model::sql_types::SqlType;
+use sqlparser::ast::{ColumnDef, ObjectName};
+use std::{convert::TryFrom, sync::Arc};
+
+pub(crate) struct CreateTablePlanner {
+    data_manager: Arc<DataManager>,
+    sender: Arc<dyn Sender>,
+    name: ObjectName,
+    columns: Vec<ColumnDef>,
+}
+
+impl CreateTablePlanner {
+    pub(crate) fn new(
+        data_manager: Arc<DataManager>,
+        sender: Arc<dyn Sender>,
+        name: ObjectName,
+        columns: Vec<ColumnDef>,
+    ) -> CreateTablePlanner {
+        CreateTablePlanner {
+            data_manager,
+            sender,
+            name,
+            columns,
+        }
+    }
+
+    pub(crate) fn plan(self) -> Result<Plan> {
+        match FullTableName::try_from(self.name) {
+            Ok(full_table_name) => {
+                let (schema_name, table_name) = full_table_name.as_tuple();
+                match self.data_manager.table_exists(&schema_name, &table_name) {
+                    None => {
+                        self.sender
+                            .send(Err(QueryError::schema_does_not_exist(schema_name)))
+                            .expect("To Send Query Result to Client");
+                        Err(())
+                    }
+                    Some((_, Some(_))) => {
+                        self.sender
+                            .send(Err(QueryError::table_already_exists(full_table_name)))
+                            .expect("To Send Query Result to Client");
+                        Err(())
+                    }
+                    Some((schema_id, None)) => {
+                        let mut column_defs = Vec::new();
+                        for column in self.columns {
+                            let sql_type = match SqlType::try_from(&column.data_type) {
+                                Ok(sql_type) => sql_type,
+                                Err(error) => {
+                                    self.sender
+                                        .send(Err(QueryError::feature_not_supported(error)))
+                                        .expect("To Send Result to Client");
+                                    return Err(());
+                                }
+                            };
+                            column_defs.push(ColumnDefinition::new(column.name.value.as_str(), sql_type));
+                        }
+                        Ok(Plan::CreateTable(TableCreationInfo::new(
+                            schema_id,
+                            table_name,
+                            column_defs,
+                        )))
+                    }
+                }
+            }
+            Err(TableNamingError(message)) => {
+                self.sender
+                    .send(Err(QueryError::syntax_error(message)))
+                    .expect("To Send Query Result to Client");
+                Err(())
+            }
+        }
+    }
+}

--- a/src/query_planner/src/planner/delete.rs
+++ b/src/query_planner/src/planner/delete.rs
@@ -19,8 +19,7 @@ use crate::{
 };
 use data_manager::DataManager;
 use itertools::Itertools;
-use protocol::results::QueryError;
-use protocol::Sender;
+use protocol::{results::QueryError, Sender};
 use sqlparser::ast::ObjectName;
 use std::sync::Arc;
 
@@ -36,8 +35,8 @@ impl DeletePlanner {
 
 impl Planner for DeletePlanner {
     fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
-        let schema_name = (&self.table_name).0.first().unwrap().value.clone();
-        let table_name = (&self.table_name).0.iter().skip(1).join(".");
+        let schema_name = self.table_name.0.first().unwrap().value.clone();
+        let table_name = self.table_name.0.iter().skip(1).join(".");
         let (table_id, _, _) = (match data_manager.table_exists(&schema_name, &table_name) {
             None => {
                 sender

--- a/src/query_planner/src/planner/delete.rs
+++ b/src/query_planner/src/planner/delete.rs
@@ -1,0 +1,63 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    plan::{Plan, TableDeletes},
+    planner::{Planner, Result},
+    TableId,
+};
+use data_manager::DataManager;
+use itertools::Itertools;
+use protocol::results::QueryError;
+use protocol::Sender;
+use sqlparser::ast::ObjectName;
+use std::sync::Arc;
+
+pub(crate) struct DeletePlanner {
+    table_name: ObjectName,
+}
+
+impl DeletePlanner {
+    pub(crate) fn new(table_name: ObjectName) -> DeletePlanner {
+        DeletePlanner { table_name }
+    }
+}
+
+impl Planner for DeletePlanner {
+    fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
+        let schema_name = (&self.table_name).0.first().unwrap().value.clone();
+        let table_name = (&self.table_name).0.iter().skip(1).join(".");
+        let (table_id, _, _) = (match data_manager.table_exists(&schema_name, &table_name) {
+            None => {
+                sender
+                    .send(Err(QueryError::schema_does_not_exist(schema_name.to_owned())))
+                    .expect("To Send Query Result to Client");
+                return Err(());
+            }
+            Some((_, None)) => {
+                sender
+                    .send(Err(QueryError::table_does_not_exist(format!(
+                        "{}.{}",
+                        schema_name, table_name
+                    ))))
+                    .expect("To Send Query Result to Client");
+                return Err(());
+            }
+            Some((schema_id, Some(table_id))) => Ok((TableId(schema_id, table_id), schema_name, table_name)),
+        })?;
+        Ok(Plan::Delete(TableDeletes {
+            full_table_name: table_id,
+        }))
+    }
+}

--- a/src/query_planner/src/planner/drop_schema.rs
+++ b/src/query_planner/src/planner/drop_schema.rs
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::plan::Plan;
 use crate::{
+    plan::Plan,
     planner::{Planner, Result},
     SchemaId, SchemaName, SchemaNamingError,
 };
 use data_manager::DataManager;
-use protocol::results::QueryError;
-use protocol::Sender;
+use protocol::{results::QueryError, Sender};
 use sqlparser::ast::ObjectName;
-use std::convert::TryFrom;
-use std::sync::Arc;
+use std::{convert::TryFrom, sync::Arc};
 
 pub(crate) struct DropSchemaPlanner<'dsp> {
     names: &'dsp [ObjectName],

--- a/src/query_planner/src/planner/drop_schema.rs
+++ b/src/query_planner/src/planner/drop_schema.rs
@@ -1,0 +1,63 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::plan::Plan;
+use crate::{
+    planner::{Planner, Result},
+    SchemaId, SchemaName, SchemaNamingError,
+};
+use data_manager::DataManager;
+use protocol::results::QueryError;
+use protocol::Sender;
+use sqlparser::ast::ObjectName;
+use std::convert::TryFrom;
+use std::sync::Arc;
+
+pub(crate) struct DropSchemaPlanner<'dsp> {
+    names: &'dsp [ObjectName],
+    cascade: bool,
+}
+
+impl DropSchemaPlanner<'_> {
+    pub(crate) fn new(names: &[ObjectName], cascade: bool) -> DropSchemaPlanner<'_> {
+        DropSchemaPlanner { names, cascade }
+    }
+}
+
+impl Planner for DropSchemaPlanner<'_> {
+    fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
+        let mut schema_names = Vec::with_capacity(self.names.len());
+        for name in self.names {
+            let schema_id = match SchemaName::try_from(name.clone()) {
+                Ok(schema_id) => schema_id,
+                Err(SchemaNamingError(message)) => {
+                    sender
+                        .send(Err(QueryError::syntax_error(message)))
+                        .expect("To Send Query Result to Client");
+                    return Err(());
+                }
+            };
+            match data_manager.schema_exists(schema_id.name()) {
+                None => {
+                    sender
+                        .send(Err(QueryError::schema_does_not_exist(schema_id.name())))
+                        .expect("To Send Query Result to Client");
+                    return Err(());
+                }
+                Some(schema_id) => schema_names.push((SchemaId(schema_id), self.cascade)),
+            }
+        }
+        Ok(Plan::DropSchemas(schema_names))
+    }
+}

--- a/src/query_planner/src/planner/drop_tables.rs
+++ b/src/query_planner/src/planner/drop_tables.rs
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::plan::Plan;
 use crate::{
+    plan::Plan,
     planner::{Planner, Result},
     FullTableName, TableId,
 };
 use data_manager::DataManager;
-use protocol::results::QueryError;
-use protocol::Sender;
+use protocol::{results::QueryError, Sender};
 use sqlparser::ast::ObjectName;
-use std::convert::TryFrom;
-use std::sync::Arc;
+use std::{convert::TryFrom, sync::Arc};
 
 pub(crate) struct DropTablesPlanner<'dtp> {
     names: &'dtp [ObjectName],

--- a/src/query_planner/src/planner/drop_tables.rs
+++ b/src/query_planner/src/planner/drop_tables.rs
@@ -1,0 +1,70 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::plan::Plan;
+use crate::{
+    planner::{Planner, Result},
+    FullTableName, TableId,
+};
+use data_manager::DataManager;
+use protocol::results::QueryError;
+use protocol::Sender;
+use sqlparser::ast::ObjectName;
+use std::convert::TryFrom;
+use std::sync::Arc;
+
+pub(crate) struct DropTablesPlanner<'dtp> {
+    names: &'dtp [ObjectName],
+}
+
+impl DropTablesPlanner<'_> {
+    pub(crate) fn new(names: &[ObjectName]) -> DropTablesPlanner {
+        DropTablesPlanner { names }
+    }
+}
+
+impl Planner for DropTablesPlanner<'_> {
+    fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
+        let mut table_names = Vec::with_capacity(self.names.len());
+        for name in self.names {
+            match FullTableName::try_from(name.clone()) {
+                Ok(full_table_name) => {
+                    let (schema_name, table_name) = full_table_name.as_tuple();
+                    match data_manager.table_exists(&schema_name, &table_name) {
+                        None => {
+                            sender
+                                .send(Err(QueryError::schema_does_not_exist(schema_name)))
+                                .expect("To Send Query Result to Client");
+                            return Err(());
+                        }
+                        Some((_, None)) => {
+                            sender
+                                .send(Err(QueryError::table_does_not_exist(full_table_name)))
+                                .expect("To Send Query Result to Client");
+                            return Err(());
+                        }
+                        Some((schema_id, Some(table_id))) => table_names.push(TableId(schema_id, table_id)),
+                    }
+                }
+                Err(error) => {
+                    sender
+                        .send(Err(QueryError::syntax_error(error)))
+                        .expect("To Send Query Result to Client");
+                    return Err(());
+                }
+            }
+        }
+        Ok(Plan::DropTables(table_names))
+    }
+}

--- a/src/query_planner/src/planner/insert.rs
+++ b/src/query_planner/src/planner/insert.rs
@@ -1,0 +1,71 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    plan::{Plan, TableInserts},
+    planner::{Planner, Result},
+    TableId,
+};
+use data_manager::DataManager;
+use itertools::Itertools;
+use protocol::results::QueryError;
+use protocol::Sender;
+use sqlparser::ast::{Ident, ObjectName, Query};
+use std::sync::Arc;
+
+pub(crate) struct InsertPlanner {
+    table_name: ObjectName,
+    columns: Vec<Ident>,
+    source: Box<Query>,
+}
+
+impl InsertPlanner {
+    pub(crate) fn new(table_name: ObjectName, columns: Vec<Ident>, source: Box<Query>) -> InsertPlanner {
+        InsertPlanner {
+            table_name,
+            columns,
+            source,
+        }
+    }
+}
+
+impl Planner for InsertPlanner {
+    fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
+        let schema_name = (&self.table_name).0.first().unwrap().value.clone();
+        let table_name = (&self.table_name).0.iter().skip(1).join(".");
+        let (table_id, _, _) = (match data_manager.table_exists(&schema_name, &table_name) {
+            None => {
+                sender
+                    .send(Err(QueryError::schema_does_not_exist(schema_name.to_owned())))
+                    .expect("To Send Query Result to Client");
+                Err(())
+            }
+            Some((_, None)) => {
+                sender
+                    .send(Err(QueryError::table_does_not_exist(format!(
+                        "{}.{}",
+                        schema_name, table_name
+                    ))))
+                    .expect("To Send Query Result to Client");
+                Err(())
+            }
+            Some((schema_id, Some(table_id))) => Ok((TableId(schema_id, table_id), schema_name, table_name)),
+        })?;
+        Ok(Plan::Insert(TableInserts {
+            full_table_name: table_id,
+            column_indices: self.columns,
+            input: self.source,
+        }))
+    }
+}

--- a/src/query_planner/src/planner/insert.rs
+++ b/src/query_planner/src/planner/insert.rs
@@ -19,8 +19,7 @@ use crate::{
 };
 use data_manager::DataManager;
 use itertools::Itertools;
-use protocol::results::QueryError;
-use protocol::Sender;
+use protocol::{results::QueryError, Sender};
 use sqlparser::ast::{Ident, ObjectName, Query};
 use std::sync::Arc;
 
@@ -42,8 +41,8 @@ impl InsertPlanner {
 
 impl Planner for InsertPlanner {
     fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
-        let schema_name = (&self.table_name).0.first().unwrap().value.clone();
-        let table_name = (&self.table_name).0.iter().skip(1).join(".");
+        let schema_name = self.table_name.0.first().unwrap().value.clone();
+        let table_name = self.table_name.0.iter().skip(1).join(".");
         let (table_id, _, _) = (match data_manager.table_exists(&schema_name, &table_name) {
             None => {
                 sender

--- a/src/query_planner/src/planner/mod.rs
+++ b/src/query_planner/src/planner/mod.rs
@@ -13,36 +13,53 @@
 // limitations under the License.
 
 ///! Module for transforming the input Query AST into representation the engine can process.
-use crate::plan::{Plan, SchemaCreationInfo, SelectInput, TableCreationInfo, TableDeletes, TableInserts, TableUpdates};
-use crate::{SchemaId, TableId};
-use data_manager::{ColumnDefinition, DataManager};
-use itertools::Itertools;
-use kernel::{SystemError, SystemResult};
 mod create_schema;
 mod create_table;
+mod delete;
 mod drop_schema;
 mod drop_tables;
+mod insert;
+mod select;
+mod update;
 
-use sqlparser::ast::{
-    ColumnDef, Expr, Ident, ObjectName, ObjectType, Query, Select, SelectItem, SetExpr, Statement, TableFactor,
-    TableWithJoins,
-};
-
-use crate::planner::create_schema::CreateSchemaPlanner;
-use crate::planner::drop_schema::DropSchemaPlanner;
-use crate::planner::drop_tables::DropTablesPlanner;
 use crate::{
-    planner::create_table::CreateTablePlanner, FullTableName, SchemaName, SchemaNamingError, TableNamingError,
+    plan::Plan,
+    planner::{
+        create_schema::CreateSchemaPlanner, create_table::CreateTablePlanner, delete::DeletePlanner,
+        drop_schema::DropSchemaPlanner, drop_tables::DropTablesPlanner, insert::InsertPlanner, select::SelectPlanner,
+        update::UpdatePlanner,
+    },
+    SchemaId,
 };
+use data_manager::DataManager;
+use itertools::Itertools;
 use protocol::{results::QueryError, Sender};
-use sql_model::sql_types::SqlType;
-use std::convert::TryFrom;
-use std::{ops::Deref, sync::Arc};
+use sqlparser::ast::{ObjectName, ObjectType, Statement};
+use std::sync::Arc;
 
 type Result<T> = std::result::Result<T, ()>;
 
 trait Planner {
     fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan>;
+
+    fn resolve_schema_name(
+        &self,
+        name: &ObjectName,
+        data_manager: Arc<DataManager>,
+        sender: Arc<dyn Sender>,
+    ) -> Result<(SchemaId, String)> {
+        let schema_name = name.0.iter().join(".");
+
+        match data_manager.schema_exists(&schema_name) {
+            None => {
+                sender
+                    .send(Err(QueryError::schema_does_not_exist(schema_name)))
+                    .expect("To Send Query Result to Client");
+                Err(())
+            }
+            Some(schema_id) => Ok((SchemaId(schema_id), schema_name)),
+        }
+    }
 }
 
 pub struct QueryPlanner {
@@ -55,50 +72,12 @@ impl QueryPlanner {
         Self { data_manager, sender }
     }
 
-    fn resolve_table_name(&self, name: &ObjectName) -> Result<(TableId, String, String)> {
-        let schema_name = name.0.first().unwrap().value.clone();
-        let table_name = name.0.iter().skip(1).join(".");
-        match self.data_manager.table_exists(&schema_name, &table_name) {
-            None => {
-                self.sender
-                    .send(Err(QueryError::schema_does_not_exist(schema_name.to_owned())))
-                    .expect("To Send Query Result to Client");
-                Err(())
-            }
-            Some((_, None)) => {
-                self.sender
-                    .send(Err(QueryError::table_does_not_exist(format!(
-                        "{}.{}",
-                        schema_name, table_name
-                    ))))
-                    .expect("To Send Query Result to Client");
-                Err(())
-            }
-            Some((schema_id, Some(table_id))) => Ok((TableId(schema_id, table_id), schema_name, table_name)),
-        }
-    }
-
-    fn resolve_schema_name(&self, name: &ObjectName) -> Result<(SchemaId, String)> {
-        let schema_name = name.0.iter().join(".");
-
-        match self.data_manager.schema_exists(&schema_name) {
-            None => {
-                self.sender
-                    .send(Err(QueryError::schema_does_not_exist(schema_name)))
-                    .expect("To Send Query Result to Client");
-                Err(())
-            }
-            Some(schema_id) => Ok((SchemaId(schema_id), schema_name)),
-        }
-    }
-
     pub fn plan(&self, stmt: Statement) -> Result<Plan> {
-        match stmt {
-            Statement::CreateTable { name, columns, .. } => {
-                CreateTablePlanner::new(name, columns).plan(self.data_manager.clone(), self.sender.clone())
-            }
+        match &stmt {
+            Statement::CreateTable { name, columns, .. } => CreateTablePlanner::new(name.clone(), columns.clone())
+                .plan(self.data_manager.clone(), self.sender.clone()),
             Statement::CreateSchema { schema_name, .. } => {
-                CreateSchemaPlanner::new(schema_name).plan(self.data_manager.clone(), self.sender.clone())
+                CreateSchemaPlanner::new(schema_name.clone()).plan(self.data_manager.clone(), self.sender.clone())
             }
             Statement::Drop {
                 object_type,
@@ -110,187 +89,34 @@ impl QueryPlanner {
                     DropTablesPlanner::new(&names).plan(self.data_manager.clone(), self.sender.clone())
                 }
                 ObjectType::Schema => {
-                    DropSchemaPlanner::new(&names, cascade).plan(self.data_manager.clone(), self.sender.clone())
+                    DropSchemaPlanner::new(&names, *cascade).plan(self.data_manager.clone(), self.sender.clone())
                 }
-                _ => unimplemented!(),
+                _ => {
+                    self.sender
+                        .send(Err(QueryError::syntax_error(stmt)))
+                        .expect("To Send Result to Client");
+                    Err(())
+                }
             },
             Statement::Insert {
                 table_name,
                 columns,
                 source,
-            } => {
-                let (table_id, _, _) = self.resolve_table_name(&table_name)?;
-                Ok(Plan::Insert(TableInserts {
-                    full_table_name: table_id,
-                    column_indices: columns,
-                    input: source,
-                }))
-            }
+            } => InsertPlanner::new(table_name.clone(), columns.clone(), source.clone())
+                .plan(self.data_manager.clone(), self.sender.clone()),
             Statement::Update {
                 table_name,
                 assignments,
                 ..
-            } => {
-                let (table_id, _, _) = self.resolve_table_name(&table_name)?;
-                Ok(Plan::Update(TableUpdates {
-                    full_table_name: table_id,
-                    assignments,
-                }))
-            }
+            } => UpdatePlanner::new(table_name.clone(), assignments.clone())
+                .plan(self.data_manager.clone(), self.sender.clone()),
             Statement::Delete { table_name, .. } => {
-                let (table_id, _, _) = self.resolve_table_name(&table_name)?;
-                Ok(Plan::Delete(TableDeletes {
-                    full_table_name: table_id,
-                }))
+                DeletePlanner::new(table_name.clone()).plan(self.data_manager.clone(), self.sender.clone())
             }
-            // TODO: ad-hock solution, duh
             Statement::Query(query) => {
-                let result = self.parse_select_input(query);
-                Ok(Plan::Select(result.map_err(|_| ())?))
+                SelectPlanner::new(query.clone()).plan(self.data_manager.clone(), self.sender.clone())
             }
             _ => Ok(Plan::NotProcessed(Box::new(stmt.clone()))),
-        }
-    }
-
-    fn parse_select_input(&self, query: Box<Query>) -> SystemResult<SelectInput> {
-        let Query { body, .. } = &*query;
-        if let SetExpr::Select(select) = body {
-            let Select { projection, from, .. } = select.deref();
-            let TableWithJoins { relation, .. } = &from[0];
-            let (schema_name, table_name) = match relation {
-                TableFactor::Table { name, .. } => {
-                    let table_name = name.0[1].to_string();
-                    let schema_name = name.0[0].to_string();
-                    (schema_name, table_name)
-                }
-                _ => {
-                    self.sender
-                        .send(Err(QueryError::feature_not_supported(query)))
-                        .expect("To Send Query Result to Client");
-                    return Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()));
-                }
-            };
-
-            match self.data_manager.table_exists(&schema_name, &table_name) {
-                None => {
-                    self.sender
-                        .send(Err(QueryError::schema_does_not_exist(schema_name)))
-                        .expect("To Send Result to Client");
-                    Err(SystemError::runtime_check_failure("Schema Does Not Exist".to_owned()))
-                }
-                Some((_, None)) => {
-                    self.sender
-                        .send(Err(QueryError::table_does_not_exist(
-                            schema_name + "." + table_name.as_str(),
-                        )))
-                        .expect("To Send Result to Client");
-                    Err(SystemError::runtime_check_failure("Table Does Not Exist".to_owned()))
-                }
-                Some((schema_id, Some(table_id))) => {
-                    let selected_columns = {
-                        let projection = projection.clone();
-                        let mut columns: Vec<String> = vec![];
-                        for item in projection {
-                            match item {
-                                SelectItem::Wildcard => {
-                                    let all_columns = self.data_manager.table_columns(schema_id, table_id)?;
-                                    columns.extend(
-                                        all_columns
-                                            .into_iter()
-                                            .map(|column_definition| column_definition.name())
-                                            .collect::<Vec<String>>(),
-                                    )
-                                }
-                                SelectItem::UnnamedExpr(Expr::Identifier(Ident { value, .. })) => {
-                                    columns.push(value.clone())
-                                }
-                                _ => {
-                                    self.sender
-                                        .send(Err(QueryError::feature_not_supported(query)))
-                                        .expect("To Send Query Result to Client");
-                                    return Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()));
-                                }
-                            }
-                        }
-                        columns
-                    };
-
-                    Ok(SelectInput {
-                        table_id: TableId(schema_id, table_id),
-                        selected_columns,
-                    })
-                }
-            }
-        } else {
-            self.sender
-                .send(Err(QueryError::feature_not_supported(query)))
-                .expect("To Send Query Result to Client");
-            Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()))
-        }
-    }
-
-    fn resolve_column_definitions(&self, columns: &[ColumnDef]) -> Result<Vec<ColumnDefinition>> {
-        let mut column_defs = Vec::new();
-        for column in columns {
-            let sql_type = SqlType::try_from(&column.data_type).map_err(|_| ())?;
-            // maybe a different type should be used to represent this instead of the storage's representation.
-            let column_definition = ColumnDefinition::new(column.name.value.as_str(), sql_type);
-            column_defs.push(column_definition);
-        }
-        Ok(column_defs)
-    }
-
-    fn handle_create_table(&self, name: ObjectName, columns: &[ColumnDef]) -> Result<Plan> {
-        let schema_name = name.0.first().unwrap().value.clone();
-        let table_name = name.0.iter().skip(1).join(".");
-
-        match self.data_manager.table_exists(&schema_name, &table_name) {
-            None => {
-                self.sender
-                    .send(Err(QueryError::schema_does_not_exist(schema_name)))
-                    .expect("To Send Query Result to Client");
-                Err(())
-            }
-            Some((_, Some(_))) => {
-                self.sender
-                    .send(Err(QueryError::table_already_exists(format!(
-                        "{}.{}",
-                        schema_name, table_name
-                    ))))
-                    .expect("To Send Query Result to Client");
-                Err(())
-            }
-            Some((schema_id, None)) => {
-                let columns = self.resolve_column_definitions(columns)?;
-                let table_info = TableCreationInfo {
-                    schema_id,
-                    table_name,
-                    columns,
-                };
-                Ok(Plan::CreateTable(table_info))
-            }
-        }
-    }
-
-    fn handle_drop(&self, object_type: &ObjectType, names: &[ObjectName], cascade: bool) -> Result<Plan> {
-        match object_type {
-            ObjectType::Table => {
-                let mut table_names = Vec::with_capacity(names.len());
-                for name in names {
-                    let (table_id, _, _) = self.resolve_table_name(name)?;
-                    table_names.push(table_id);
-                }
-                Ok(Plan::DropTables(table_names))
-            }
-            ObjectType::Schema => {
-                let mut schema_names = Vec::with_capacity(names.len());
-                for name in names {
-                    let (schema_id, _) = self.resolve_schema_name(name)?;
-                    schema_names.push((schema_id, cascade));
-                }
-                Ok(Plan::DropSchemas(schema_names))
-            }
-            _ => unimplemented!(),
         }
     }
 }

--- a/src/query_planner/src/planner/select.rs
+++ b/src/query_planner/src/planner/select.rs
@@ -1,0 +1,123 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    plan::{Plan, SelectInput},
+    planner::{Planner, Result},
+    TableId,
+};
+use data_manager::DataManager;
+use kernel::{SystemError, SystemResult};
+use protocol::{results::QueryError, Sender};
+use sqlparser::ast::{Expr, Ident, Query, Select, SelectItem, SetExpr, TableFactor, TableWithJoins};
+use std::{ops::Deref, sync::Arc};
+
+pub(crate) struct SelectPlanner {
+    query: Box<Query>,
+}
+
+impl SelectPlanner {
+    pub(crate) fn new(query: Box<Query>) -> SelectPlanner {
+        SelectPlanner { query }
+    }
+
+    fn parse_select_input(
+        &self,
+        query: Box<Query>,
+        data_manager: Arc<DataManager>,
+        sender: Arc<dyn Sender>,
+    ) -> SystemResult<SelectInput> {
+        let Query { body, .. } = &*query;
+        if let SetExpr::Select(select) = body {
+            let Select { projection, from, .. } = select.deref();
+            let TableWithJoins { relation, .. } = &from[0];
+            let (schema_name, table_name) = match relation {
+                TableFactor::Table { name, .. } => {
+                    let table_name = name.0[1].to_string();
+                    let schema_name = name.0[0].to_string();
+                    (schema_name, table_name)
+                }
+                _ => {
+                    sender
+                        .send(Err(QueryError::feature_not_supported(query)))
+                        .expect("To Send Query Result to Client");
+                    return Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()));
+                }
+            };
+
+            match data_manager.table_exists(&schema_name, &table_name) {
+                None => {
+                    sender
+                        .send(Err(QueryError::schema_does_not_exist(schema_name)))
+                        .expect("To Send Result to Client");
+                    Err(SystemError::runtime_check_failure("Schema Does Not Exist".to_owned()))
+                }
+                Some((_, None)) => {
+                    sender
+                        .send(Err(QueryError::table_does_not_exist(
+                            schema_name + "." + table_name.as_str(),
+                        )))
+                        .expect("To Send Result to Client");
+                    Err(SystemError::runtime_check_failure("Table Does Not Exist".to_owned()))
+                }
+                Some((schema_id, Some(table_id))) => {
+                    let selected_columns = {
+                        let projection = projection.clone();
+                        let mut columns: Vec<String> = vec![];
+                        for item in projection {
+                            match item {
+                                SelectItem::Wildcard => {
+                                    let all_columns = data_manager.table_columns(schema_id, table_id)?;
+                                    columns.extend(
+                                        all_columns
+                                            .into_iter()
+                                            .map(|column_definition| column_definition.name())
+                                            .collect::<Vec<String>>(),
+                                    )
+                                }
+                                SelectItem::UnnamedExpr(Expr::Identifier(Ident { value, .. })) => {
+                                    columns.push(value.clone())
+                                }
+                                _ => {
+                                    sender
+                                        .send(Err(QueryError::feature_not_supported(query)))
+                                        .expect("To Send Query Result to Client");
+                                    return Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()));
+                                }
+                            }
+                        }
+                        columns
+                    };
+
+                    Ok(SelectInput {
+                        table_id: TableId(schema_id, table_id),
+                        selected_columns,
+                    })
+                }
+            }
+        } else {
+            sender
+                .send(Err(QueryError::feature_not_supported(query)))
+                .expect("To Send Query Result to Client");
+            Err(SystemError::runtime_check_failure("Feature Not Supported".to_owned()))
+        }
+    }
+}
+
+impl Planner for SelectPlanner {
+    fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
+        let result = self.parse_select_input(self.query.clone(), data_manager, sender);
+        Ok(Plan::Select(result.map_err(|_| ())?))
+    }
+}

--- a/src/query_planner/src/planner/update.rs
+++ b/src/query_planner/src/planner/update.rs
@@ -1,0 +1,68 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    plan::{Plan, TableUpdates},
+    planner::{Planner, Result},
+    TableId,
+};
+use data_manager::DataManager;
+use itertools::Itertools;
+use protocol::results::QueryError;
+use protocol::Sender;
+use sqlparser::ast::{Assignment, ObjectName};
+use std::sync::Arc;
+
+pub(crate) struct UpdatePlanner {
+    table_name: ObjectName,
+    assignments: Vec<Assignment>,
+}
+
+impl UpdatePlanner {
+    pub(crate) fn new(table_name: ObjectName, assignments: Vec<Assignment>) -> UpdatePlanner {
+        UpdatePlanner {
+            table_name,
+            assignments,
+        }
+    }
+}
+
+impl Planner for UpdatePlanner {
+    fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
+        let schema_name = (&self.table_name).0.first().unwrap().value.clone();
+        let table_name = (&self.table_name).0.iter().skip(1).join(".");
+        let (table_id, _, _) = match data_manager.table_exists(&schema_name, &table_name) {
+            None => {
+                sender
+                    .send(Err(QueryError::schema_does_not_exist(schema_name.to_owned())))
+                    .expect("To Send Query Result to Client");
+                Err(())
+            }
+            Some((_, None)) => {
+                sender
+                    .send(Err(QueryError::table_does_not_exist(format!(
+                        "{}.{}",
+                        schema_name, table_name
+                    ))))
+                    .expect("To Send Query Result to Client");
+                Err(())
+            }
+            Some((schema_id, Some(table_id))) => Ok((TableId(schema_id, table_id), schema_name, table_name)),
+        }?;
+        Ok(Plan::Update(TableUpdates {
+            full_table_name: table_id,
+            assignments: self.assignments,
+        }))
+    }
+}

--- a/src/query_planner/src/planner/update.rs
+++ b/src/query_planner/src/planner/update.rs
@@ -19,8 +19,7 @@ use crate::{
 };
 use data_manager::DataManager;
 use itertools::Itertools;
-use protocol::results::QueryError;
-use protocol::Sender;
+use protocol::{results::QueryError, Sender};
 use sqlparser::ast::{Assignment, ObjectName};
 use std::sync::Arc;
 
@@ -40,8 +39,8 @@ impl UpdatePlanner {
 
 impl Planner for UpdatePlanner {
     fn plan(self, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> Result<Plan> {
-        let schema_name = (&self.table_name).0.first().unwrap().value.clone();
-        let table_name = (&self.table_name).0.iter().skip(1).join(".");
+        let schema_name = self.table_name.0.first().unwrap().value.clone();
+        let table_name = self.table_name.0.iter().skip(1).join(".");
         let (table_id, _, _) = match data_manager.table_exists(&schema_name, &table_name) {
             None => {
                 sender

--- a/src/query_planner/src/tests/create_schema.rs
+++ b/src/query_planner/src/tests/create_schema.rs
@@ -1,0 +1,37 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use protocol::results::QueryError;
+use sqlparser::ast::Statement;
+
+#[rstest::rstest]
+fn create_schema_with_unqualified_name(planner_and_sender: (QueryPlanner, ResultCollector)) {
+    let (query_planner, collector) = planner_and_sender;
+    assert!(matches!(
+        query_planner.plan(Statement::CreateSchema {
+            schema_name: ObjectName(vec![
+                ident("first_part"),
+                ident("second_part"),
+                ident("third_part"),
+                ident("fourth_part")
+            ])
+        }),
+        Err(_)
+    ));
+
+    collector.assert_content(vec![Err(QueryError::syntax_error(
+        "only unqualified schema names are supported, 'first_part.second_part.third_part.fourth_part'",
+    ))])
+}

--- a/src/query_planner/src/tests/create_table.rs
+++ b/src/query_planner/src/tests/create_table.rs
@@ -14,11 +14,11 @@
 
 use super::*;
 use protocol::results::QueryError;
-use sqlparser::ast::{ColumnDef, DataType, Ident, Statement};
+use sqlparser::ast::{ColumnDef, DataType, Statement};
 
 #[rstest::rstest]
-fn create_table_with_unsupported_type(planner_and_sender: (QueryPlanner, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender;
+fn create_table_with_unsupported_type(planner_and_sender_with_schema: (QueryPlanner, ResultCollector)) {
+    let (query_planner, collector) = planner_and_sender_with_schema;
     assert!(matches!(
         query_planner.plan(Statement::CreateTable {
             name: ObjectName(vec![ident("schema_name"), ident("table_name"),]),
@@ -45,9 +45,65 @@ fn create_table_with_unsupported_type(planner_and_sender: (QueryPlanner, ResultC
     ))])
 }
 
-fn ident<S: ToString>(name: S) -> Ident {
-    Ident {
-        value: name.to_string(),
-        quote_style: None,
-    }
+#[rstest::rstest]
+fn create_table_with_unqualified_name(planner_and_sender_with_schema: (QueryPlanner, ResultCollector)) {
+    let (query_planner, collector) = planner_and_sender_with_schema;
+    assert!(matches!(
+        query_planner.plan(Statement::CreateTable {
+            name: ObjectName(vec![ident("only_schema_in_the_name")]),
+            columns: vec![ColumnDef {
+                name: ident("column_name"),
+                data_type: DataType::Custom(ObjectName(vec![ident("strange_type_name_whatever")])),
+                collation: None,
+                options: vec![]
+            }],
+            constraints: vec![],
+            with_options: vec![],
+            if_not_exists: false,
+            external: false,
+            file_format: None,
+            location: None,
+            query: None,
+            without_rowid: false,
+        }),
+        Err(_)
+    ));
+
+    collector.assert_content(vec![Err(QueryError::syntax_error(
+        "unsupported table name 'only_schema_in_the_name'. All table names must be qualified",
+    ))])
+}
+
+#[rstest::rstest]
+fn create_table_with_unsupported_name(planner_and_sender_with_schema: (QueryPlanner, ResultCollector)) {
+    let (query_planner, collector) = planner_and_sender_with_schema;
+    assert!(matches!(
+        query_planner.plan(Statement::CreateTable {
+            name: ObjectName(vec![
+                ident("first_part"),
+                ident("second_part"),
+                ident("third_part"),
+                ident("fourth_part")
+            ]),
+            columns: vec![ColumnDef {
+                name: ident("column_name"),
+                data_type: DataType::Custom(ObjectName(vec![ident("strange_type_name_whatever")])),
+                collation: None,
+                options: vec![]
+            }],
+            constraints: vec![],
+            with_options: vec![],
+            if_not_exists: false,
+            external: false,
+            file_format: None,
+            location: None,
+            query: None,
+            without_rowid: false,
+        }),
+        Err(_)
+    ));
+
+    collector.assert_content(vec![Err(QueryError::syntax_error(
+        "unable to process table name 'first_part.second_part.third_part.fourth_part'",
+    ))])
 }

--- a/src/query_planner/src/tests/create_table.rs
+++ b/src/query_planner/src/tests/create_table.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use protocol::results::QueryError;
+use sqlparser::ast::{ColumnDef, DataType, Ident, Statement};
+
+#[rstest::rstest]
+fn create_table_with_unsupported_type(planner_and_sender: (QueryPlanner, ResultCollector)) {
+    let (query_planner, collector) = planner_and_sender;
+    assert!(matches!(
+        query_planner.plan(Statement::CreateTable {
+            name: ObjectName(vec![ident("schema_name"), ident("table_name"),]),
+            columns: vec![ColumnDef {
+                name: ident("column_name"),
+                data_type: DataType::Custom(ObjectName(vec![ident("strange_type_name_whatever")])),
+                collation: None,
+                options: vec![]
+            }],
+            constraints: vec![],
+            with_options: vec![],
+            if_not_exists: false,
+            external: false,
+            file_format: None,
+            location: None,
+            query: None,
+            without_rowid: false,
+        }),
+        Err(_)
+    ));
+
+    collector.assert_content(vec![Err(QueryError::feature_not_supported(
+        "strange_type_name_whatever type is not supported",
+    ))])
+}
+
+fn ident<S: ToString>(name: S) -> Ident {
+    Ident {
+        value: name.to_string(),
+        quote_style: None,
+    }
+}

--- a/src/query_planner/src/tests/mod.rs
+++ b/src/query_planner/src/tests/mod.rs
@@ -16,12 +16,15 @@ use super::*;
 use crate::planner::QueryPlanner;
 use data_manager::DataManager;
 use protocol::{results::QueryResult, Sender};
+use sqlparser::ast::Ident;
 use std::{
     io,
     ops::Deref,
     sync::{Arc, Mutex},
 };
 
+#[cfg(test)]
+mod create_schema;
 #[cfg(test)]
 mod create_table;
 
@@ -56,6 +59,20 @@ fn sender() -> ResultCollector {
 fn planner_and_sender() -> (QueryPlanner, ResultCollector) {
     let collector = Arc::new(Collector(Mutex::new(vec![])));
     let manager = DataManager::in_memory().expect("to create data manager");
+    (QueryPlanner::new(Arc::new(manager), collector.clone()), collector)
+}
+
+#[rstest::fixture]
+fn planner_and_sender_with_schema() -> (QueryPlanner, ResultCollector) {
+    let collector = Arc::new(Collector(Mutex::new(vec![])));
+    let manager = DataManager::in_memory().expect("to create data manager");
     manager.create_schema("schema_name").expect("schema created");
     (QueryPlanner::new(Arc::new(manager), collector.clone()), collector)
+}
+
+fn ident<S: ToString>(name: S) -> Ident {
+    Ident {
+        value: name.to_string(),
+        quote_style: None,
+    }
 }

--- a/src/query_planner/src/tests/mod.rs
+++ b/src/query_planner/src/tests/mod.rs
@@ -1,0 +1,61 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use crate::planner::QueryPlanner;
+use data_manager::DataManager;
+use protocol::{results::QueryResult, Sender};
+use std::{
+    io,
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
+
+#[cfg(test)]
+mod create_table;
+
+struct Collector(Mutex<Vec<QueryResult>>);
+
+impl Sender for Collector {
+    fn flush(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn send(&self, query_result: QueryResult) -> io::Result<()> {
+        self.0.lock().expect("locked").push(query_result);
+        Ok(())
+    }
+}
+
+impl Collector {
+    fn assert_content(&self, expected: Vec<QueryResult>) {
+        let result = self.0.lock().expect("locked");
+        assert_eq!(result.deref(), &expected)
+    }
+}
+
+type ResultCollector = Arc<Collector>;
+
+#[rstest::fixture]
+fn sender() -> ResultCollector {
+    Arc::new(Collector(Mutex::new(vec![])))
+}
+
+#[rstest::fixture]
+fn planner_and_sender() -> (QueryPlanner, ResultCollector) {
+    let collector = Arc::new(Collector(Mutex::new(vec![])));
+    let manager = DataManager::in_memory().expect("to create data manager");
+    manager.create_schema("schema_name").expect("schema created");
+    (QueryPlanner::new(Arc::new(manager), collector.clone()), collector)
+}

--- a/src/sql_engine/src/ddl/create_schema.rs
+++ b/src/sql_engine/src/ddl/create_schema.rs
@@ -21,26 +21,26 @@ use query_planner::plan::SchemaCreationInfo;
 
 pub(crate) struct CreateSchemaCommand {
     schema_info: SchemaCreationInfo,
-    storage: Arc<DataManager>,
+    data_manager: Arc<DataManager>,
     sender: Arc<dyn Sender>,
 }
 
 impl CreateSchemaCommand {
     pub(crate) fn new(
         schema_info: SchemaCreationInfo,
-        storage: Arc<DataManager>,
+        data_manager: Arc<DataManager>,
         sender: Arc<dyn Sender>,
     ) -> CreateSchemaCommand {
         CreateSchemaCommand {
             schema_info,
-            storage,
+            data_manager,
             sender,
         }
     }
 
     pub(crate) fn execute(&mut self) -> SystemResult<()> {
         let schema_name = &self.schema_info.schema_name;
-        match self.storage.create_schema(schema_name) {
+        match self.data_manager.create_schema(schema_name) {
             Err(error) => Err(error),
             Ok(_schema_id) => {
                 self.sender

--- a/src/sql_engine/src/ddl/drop_schema.rs
+++ b/src/sql_engine/src/ddl/drop_schema.rs
@@ -22,7 +22,7 @@ use query_planner::SchemaId;
 pub(crate) struct DropSchemaCommand {
     name: SchemaId,
     cascade: bool,
-    storage: Arc<DataManager>,
+    data_manager: Arc<DataManager>,
     sender: Arc<dyn Sender>,
 }
 
@@ -30,13 +30,13 @@ impl DropSchemaCommand {
     pub(crate) fn new(
         name: SchemaId,
         cascade: bool,
-        storage: Arc<DataManager>,
+        data_manager: Arc<DataManager>,
         sender: Arc<dyn Sender>,
     ) -> DropSchemaCommand {
         DropSchemaCommand {
             name,
             cascade,
-            storage,
+            data_manager,
             sender,
         }
     }
@@ -47,7 +47,7 @@ impl DropSchemaCommand {
         } else {
             DropStrategy::Restrict
         };
-        match self.storage.drop_schema(self.name.name(), strategy) {
+        match self.data_manager.drop_schema(self.name.0, strategy) {
             Err(error) => Err(error),
             Ok(Err(DropSchemaError::CatalogDoesNotExist)) => {
                 //ignore. Catalogs are not implemented

--- a/src/sql_engine/src/ddl/drop_table.rs
+++ b/src/sql_engine/src/ddl/drop_table.rs
@@ -20,20 +20,24 @@ use protocol::{results::QueryEvent, Sender};
 use query_planner::TableId;
 
 pub(crate) struct DropTableCommand {
-    name: TableId,
-    storage: Arc<DataManager>,
+    full_table_name: TableId,
+    data_manager: Arc<DataManager>,
     sender: Arc<dyn Sender>,
 }
 
 impl DropTableCommand {
-    pub(crate) fn new(name: TableId, storage: Arc<DataManager>, sender: Arc<dyn Sender>) -> DropTableCommand {
-        DropTableCommand { name, storage, sender }
+    pub(crate) fn new(name: TableId, data_manager: Arc<DataManager>, sender: Arc<dyn Sender>) -> DropTableCommand {
+        DropTableCommand {
+            full_table_name: name,
+            data_manager,
+            sender,
+        }
     }
 
     pub(crate) fn execute(&mut self) -> SystemResult<()> {
-        let schema_id = self.name.schema().name();
-        let table_id = self.name.name();
-        match self.storage.drop_table(schema_id, table_id) {
+        let schema_id = self.full_table_name.schema().0;
+        let table_id = self.full_table_name.name();
+        match self.data_manager.drop_table(schema_id, table_id) {
             Err(error) => Err(error),
             Ok(()) => {
                 self.sender

--- a/src/sql_engine/src/query/expr.rs
+++ b/src/sql_engine/src/query/expr.rs
@@ -92,9 +92,9 @@ impl ExpressionEvaluation {
                                         meta_data.column().name(),
                                         meta_data.index(),
                                     ),
-                                    EvalError::UnsupportedOperation => QueryError::feature_not_supported(
-                                        "Use of unsupported expression feature".to_string(),
-                                    ),
+                                    EvalError::UnsupportedOperation => {
+                                        QueryError::feature_not_supported("Use of unsupported expression feature")
+                                    }
                                 }
                             } else {
                                 match e {
@@ -104,9 +104,9 @@ impl ExpressionEvaluation {
                                     EvalError::OutOfRangeNumeric(ty) => {
                                         QueryError::out_of_range(ty.to_pg_types(), String::new(), 0)
                                     }
-                                    EvalError::UnsupportedOperation => QueryError::feature_not_supported(
-                                        "Use of unsupported expression feature".to_string(),
-                                    ),
+                                    EvalError::UnsupportedOperation => {
+                                        QueryError::feature_not_supported("Use of unsupported expression feature")
+                                    }
                                 }
                             };
                             self.session.send(Err(err)).expect("To Send Query Result to Client");
@@ -140,7 +140,7 @@ impl ExpressionEvaluation {
                         lhs.scalar_type().to_string(),
                         rhs.scalar_type().to_string(),
                     );
-                    self.session.send(Err(kind)).expect("To Senc Query Result to Client");
+                    self.session.send(Err(kind)).expect("To Send Query Result to Client");
                     Err(())
                 }
             }
@@ -158,7 +158,7 @@ impl ExpressionEvaluation {
                                 meta_data.index(),
                             ),
                             EvalError::UnsupportedOperation => {
-                                QueryError::feature_not_supported("Use of unsupported expression feature".to_string())
+                                QueryError::feature_not_supported("Use of unsupported expression feature")
                             }
                         }
                     } else {
@@ -170,7 +170,7 @@ impl ExpressionEvaluation {
                                 QueryError::out_of_range(ty.to_pg_types(), String::new(), 0)
                             }
                             EvalError::UnsupportedOperation => {
-                                QueryError::feature_not_supported("Use of unsupported expression feature".to_string())
+                                QueryError::feature_not_supported("Use of unsupported expression feature")
                             }
                         }
                     };
@@ -210,7 +210,7 @@ impl ExpressionEvaluation {
         let (destination, _column_def) = if let Some((idx, def)) = self.find_column_by_name(id.value.as_str())? {
             (idx, def)
         } else {
-            let kind = QueryError::column_does_not_exist(id.value.clone());
+            let kind = QueryError::column_does_not_exist(id.value.as_str());
             self.session.send(Err(kind)).expect("To Send Query Result to Client");
             return Err(());
         };
@@ -359,7 +359,7 @@ impl<'a> EvalScalarOp<'a> {
                             .send(Err(QueryError::type_mismatch(
                                 &value,
                                 (&column.sql_type()).into(),
-                                column.name(),
+                                &column.name(),
                                 row_idx + 1,
                             )))
                             .expect("To Send Query Result to client");

--- a/src/sql_engine/src/query/relation.rs
+++ b/src/sql_engine/src/query/relation.rs
@@ -45,7 +45,7 @@ pub enum RelationOp {
     Scan {
         // Id the table that needs to be loaded.
         // and maybe some other information we need about it.
-        table: FullTableName,
+        full_table_name: FullTableName,
     },
 
     Join {

--- a/src/sql_engine/src/tests/delete.rs
+++ b/src/sql_engine/src/tests/delete.rs
@@ -28,7 +28,7 @@ fn delete_from_nonexistent_table(sql_engine_with_schema: (QueryExecutor, ResultC
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned())),
+        Err(QueryError::table_does_not_exist("schema_name.table_name")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }

--- a/src/sql_engine/src/tests/describe_prepared_statement.rs
+++ b/src/sql_engine/src/tests/describe_prepared_statement.rs
@@ -88,6 +88,6 @@ fn describe_not_existed_statement(sql_engine_with_schema: (QueryExecutor, Result
     collector.assert_content(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::prepared_statement_does_not_exist("non_existent".to_owned())),
+        Err(QueryError::prepared_statement_does_not_exist("non_existent")),
     ]);
 }

--- a/src/sql_engine/src/tests/error_responses.rs
+++ b/src/sql_engine/src/tests/error_responses.rs
@@ -23,7 +23,7 @@ fn parse_wrong_select_syntax(sql_engine: (QueryExecutor, ResultCollector)) {
 
     collector.assert_content_for_single_queries(vec![
         Err(QueryError::syntax_error(
-            "\"selec col from schema_name.table_name\" can\'t be parsed".into(),
+            "\"selec col from schema_name.table_name\" can\'t be parsed",
         )),
         Ok(QueryEvent::QueryComplete),
     ]);

--- a/src/sql_engine/src/tests/insert.rs
+++ b/src/sql_engine/src/tests/insert.rs
@@ -26,7 +26,7 @@ fn insert_into_nonexistent_table(sql_engine_with_schema: (QueryExecutor, ResultC
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned())),
+        Err(QueryError::table_does_not_exist("schema_name.table_name")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -46,7 +46,7 @@ fn insert_value_in_non_existent_column(sql_engine_with_schema: (QueryExecutor, R
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::column_does_not_exist("non_existent".to_owned())),
+        Err(QueryError::column_does_not_exist("non_existent")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }

--- a/src/sql_engine/src/tests/parse_prepared_statement.rs
+++ b/src/sql_engine/src/tests/parse_prepared_statement.rs
@@ -63,7 +63,7 @@ fn parse_select_statement_with_not_existed_table(sql_engine_with_schema: (QueryE
     collector.assert_content(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.non_existent".to_owned())),
+        Err(QueryError::table_does_not_exist("schema_name.non_existent")),
         Ok(QueryEvent::ParseComplete), // TODO should be removed
     ]);
 }
@@ -88,7 +88,7 @@ fn parse_select_statement_with_not_existed_column(sql_engine_with_schema: (Query
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::column_does_not_exist("column_not_in_table".to_owned())),
+        Err(QueryError::column_does_not_exist("column_not_in_table")),
     ]);
 }
 

--- a/src/sql_engine/src/tests/schema.rs
+++ b/src/sql_engine/src/tests/schema.rs
@@ -57,7 +57,7 @@ fn drop_non_existent_schema(sql_engine: (QueryExecutor, ResultCollector)) {
     engine.execute("drop schema non_existent;").expect("no system errors");
 
     collector.assert_content_for_single_queries(vec![
-        Err(QueryError::schema_does_not_exist("non_existent".to_owned())),
+        Err(QueryError::schema_does_not_exist("non_existent")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -71,7 +71,7 @@ fn select_from_nonexistent_schema(sql_engine: (QueryExecutor, ResultCollector)) 
         .expect("no system errors");
 
     collector.assert_content_for_single_queries(vec![
-        Err(QueryError::schema_does_not_exist("non_existent".to_owned())),
+        Err(QueryError::schema_does_not_exist("non_existent")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -84,7 +84,7 @@ fn select_named_columns_from_nonexistent_schema(sql_engine: (QueryExecutor, Resu
         .expect("no system errors");
 
     collector.assert_content_for_single_queries(vec![
-        Err(QueryError::schema_does_not_exist("schema_name".to_owned())),
+        Err(QueryError::schema_does_not_exist("schema_name")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -97,7 +97,7 @@ fn insert_into_table_in_nonexistent_schema(sql_engine: (QueryExecutor, ResultCol
         .expect("no system errors");
 
     collector.assert_content_for_single_queries(vec![
-        Err(QueryError::schema_does_not_exist("schema_name".to_owned())),
+        Err(QueryError::schema_does_not_exist("schema_name")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -110,7 +110,7 @@ fn update_records_in_table_from_non_existent_schema(sql_engine: (QueryExecutor, 
         .expect("no system errors");
 
     collector.assert_content_for_single_queries(vec![
-        Err(QueryError::schema_does_not_exist("schema_name".to_owned())),
+        Err(QueryError::schema_does_not_exist("schema_name")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -123,7 +123,7 @@ fn delete_from_table_in_nonexistent_schema(sql_engine: (QueryExecutor, ResultCol
         .expect("no system errors");
 
     collector.assert_content_for_single_queries(vec![
-        Err(QueryError::schema_does_not_exist("schema_name".to_owned())),
+        Err(QueryError::schema_does_not_exist("schema_name")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }

--- a/src/sql_engine/src/tests/select.rs
+++ b/src/sql_engine/src/tests/select.rs
@@ -26,7 +26,7 @@ fn select_from_not_existed_table(sql_engine_with_schema: (QueryExecutor, ResultC
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.non_existent".to_owned())),
+        Err(QueryError::table_does_not_exist("schema_name.non_existent")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -41,7 +41,7 @@ fn select_named_columns_from_non_existent_table(sql_engine_with_schema: (QueryEx
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.non_existent".to_owned())),
+        Err(QueryError::table_does_not_exist("schema_name.non_existent")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -128,8 +128,8 @@ fn select_non_existing_columns_from_table(sql_engine_with_schema: (QueryExecutor
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::column_does_not_exist("column_not_in_table1".to_owned())),
-        Err(QueryError::column_does_not_exist("column_not_in_table2".to_owned())),
+        Err(QueryError::column_does_not_exist("column_not_in_table1")),
+        Err(QueryError::column_does_not_exist("column_not_in_table2")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }

--- a/src/sql_engine/src/tests/table.rs
+++ b/src/sql_engine/src/tests/table.rs
@@ -27,7 +27,7 @@ mod schemaless {
             .expect("no system errors");
 
         collector.assert_content_for_single_queries(vec![
-            Err(QueryError::schema_does_not_exist("schema_name".to_owned())),
+            Err(QueryError::schema_does_not_exist("schema_name")),
             Ok(QueryEvent::QueryComplete),
         ]);
     }
@@ -40,7 +40,7 @@ mod schemaless {
             .expect("no system errors");
 
         collector.assert_content_for_single_queries(vec![
-            Err(QueryError::schema_does_not_exist("schema_name".to_owned())),
+            Err(QueryError::schema_does_not_exist("schema_name")),
             Ok(QueryEvent::QueryComplete),
         ]);
     }
@@ -77,7 +77,7 @@ fn create_same_table(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_already_exists("schema_name.table_name".to_owned())),
+        Err(QueryError::table_already_exists("schema_name.table_name")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -117,7 +117,7 @@ fn drop_non_existent_table(sql_engine_with_schema: (QueryExecutor, ResultCollect
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned())),
+        Err(QueryError::table_does_not_exist("schema_name.table_name")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -81,19 +81,14 @@ mod insert {
             Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
             Ok(QueryEvent::QueryComplete),
-            Err(QueryError::type_mismatch(
-                "str",
-                PostgreSqlType::SmallInt,
-                "col".to_string(),
-                1,
-            )),
+            Err(QueryError::type_mismatch("str", PostgreSqlType::SmallInt, "col", 1)),
             Ok(QueryEvent::QueryComplete),
         ]);
     }
 
     #[rstest::rstest]
     #[ignore]
-    // currently the ExpressionEvaluator doesn't have contexual information to create the right
+    // currently the ExpressionEvaluator doesn't have contextual information to create the right
     // error messages.
     fn multiple_columns_multiple_row_violation(multiple_ints_table: (QueryExecutor, Arc<Collector>)) {
         let (mut engine, collector) = multiple_ints_table;
@@ -106,16 +101,8 @@ mod insert {
             Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::TableCreated),
             Ok(QueryEvent::QueryComplete),
-            Err(QueryError::out_of_range(
-                PostgreSqlType::SmallInt,
-                "column_si".to_owned(),
-                1,
-            )),
-            Err(QueryError::out_of_range(
-                PostgreSqlType::Integer,
-                "column_i".to_owned(),
-                1,
-            )),
+            Err(QueryError::out_of_range(PostgreSqlType::SmallInt, "column_si", 1)),
+            Err(QueryError::out_of_range(PostgreSqlType::Integer, "column_i", 1)),
             Ok(QueryEvent::QueryComplete),
         ]);
     }
@@ -213,12 +200,7 @@ mod update {
             Ok(QueryEvent::QueryComplete),
             Ok(QueryEvent::RecordsInserted(1)),
             Ok(QueryEvent::QueryComplete),
-            Err(QueryError::type_mismatch(
-                "str",
-                PostgreSqlType::SmallInt,
-                "col".to_string(),
-                1,
-            )),
+            Err(QueryError::type_mismatch("str", PostgreSqlType::SmallInt, "col", 1)),
             Ok(QueryEvent::QueryComplete),
         ]);
     }

--- a/src/sql_engine/src/tests/update.rs
+++ b/src/sql_engine/src/tests/update.rs
@@ -247,7 +247,7 @@ fn update_records_in_nonexistent_table(sql_engine_with_schema: (QueryExecutor, R
     collector.assert_content_for_single_queries(vec![
         Ok(QueryEvent::SchemaCreated),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.table_name".to_owned())),
+        Err(QueryError::table_does_not_exist("schema_name.table_name")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -280,8 +280,8 @@ fn update_non_existent_columns_of_records(sql_engine_with_schema: (QueryExecutor
             vec![vec!["123".to_owned()]],
         ))),
         Ok(QueryEvent::QueryComplete),
-        Err(QueryError::column_does_not_exist("col1".to_owned())),
-        Err(QueryError::column_does_not_exist("col2".to_owned())),
+        Err(QueryError::column_does_not_exist("col1")),
+        Err(QueryError::column_does_not_exist("col2")),
         Ok(QueryEvent::QueryComplete),
     ]);
 }

--- a/src/sql_model/Cargo.toml
+++ b/src/sql_model/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 lexical = "5.2.0"
 serde = { version = "1.0.115", features = ["derive"] }
 protocol = { path = "../protocol" }
+sqlparser = { version = "0.6.1", features = ["bigdecimal"] }
 
 [dev-dependencies]
 rstest = "0.6.4"


### PR DESCRIPTION
No issue to close

#### Description
splitting `QueryPlanner` into separate structs

#### Client output
no changes to client output

