### PR TITLE
Fixes regression of when same column name occurs multiple times in insert and update assignments

### DIFF
--- a/src/query_planner/src/planner/insert.rs
+++ b/src/query_planner/src/planner/insert.rs
@@ -21,8 +21,7 @@ use ast::operations::ScalarOp;
 use data_manager::DataManager;
 use protocol::{results::QueryError, Sender};
 use sqlparser::ast::{Ident, ObjectName, Query, SetExpr};
-use std::collections::HashSet;
-use std::{convert::TryFrom, sync::Arc};
+use std::{collections::HashSet, convert::TryFrom, sync::Arc};
 
 pub(crate) struct InsertPlanner<'ip> {
     table_name: &'ip ObjectName,

--- a/src/query_planner/src/planner/insert.rs
+++ b/src/query_planner/src/planner/insert.rs
@@ -21,6 +21,7 @@ use ast::operations::ScalarOp;
 use data_manager::DataManager;
 use protocol::{results::QueryError, Sender};
 use sqlparser::ast::{Ident, ObjectName, Query, SetExpr};
+use std::collections::HashSet;
 use std::{convert::TryFrom, sync::Arc};
 
 pub(crate) struct InsertPlanner<'ip> {
@@ -96,12 +97,20 @@ impl Planner for InsertPlanner<'_> {
                                         .map(|(index, col_def)| (index, col_def.name(), col_def.sql_type()))
                                         .collect::<Vec<_>>()
                                 } else {
+                                    let mut columns = HashSet::new();
                                     let mut index_cols = vec![];
                                     let mut has_error = false;
                                     for column_name in self.columns.iter().map(|id| id.value.as_str()) {
                                         let mut found = None;
                                         for (index, column_definition) in all_columns.iter().enumerate() {
                                             if column_definition.has_name(column_name) {
+                                                if columns.contains(column_name) {
+                                                    sender
+                                                        .send(Err(QueryError::duplicate_column(column_name)))
+                                                        .expect("To Send Result to Client");
+                                                    has_error = true;
+                                                }
+                                                columns.insert(column_name.to_owned());
                                                 found =
                                                     Some((index, column_name.to_owned(), column_definition.sql_type()));
                                                 break;

--- a/src/query_planner/src/planner/update.rs
+++ b/src/query_planner/src/planner/update.rs
@@ -21,8 +21,7 @@ use ast::operations::ScalarOp;
 use data_manager::DataManager;
 use protocol::{results::QueryError, Sender};
 use sqlparser::ast::{Assignment, ObjectName};
-use std::collections::HashSet;
-use std::{convert::TryFrom, sync::Arc};
+use std::{collections::HashSet, convert::TryFrom, sync::Arc};
 
 pub(crate) struct UpdatePlanner<'up> {
     table_name: &'up ObjectName,

--- a/src/query_planner/src/planner/update.rs
+++ b/src/query_planner/src/planner/update.rs
@@ -21,6 +21,7 @@ use ast::operations::ScalarOp;
 use data_manager::DataManager;
 use protocol::{results::QueryError, Sender};
 use sqlparser::ast::{Assignment, ObjectName};
+use std::collections::HashSet;
 use std::{convert::TryFrom, sync::Arc};
 
 pub(crate) struct UpdatePlanner<'up> {
@@ -64,6 +65,7 @@ impl Planner for UpdatePlanner<'_> {
                         let mut column_indices = vec![];
                         let mut input = vec![];
                         let mut has_error = false;
+                        let mut columns = HashSet::new();
                         for Assignment { id, value } in self.assignments.iter() {
                             let mut found = None;
                             let column_name = id.to_string();
@@ -84,6 +86,16 @@ impl Planner for UpdatePlanner<'_> {
                                                 .expect("To Send Result to Client");
                                         }
                                     }
+                                    if columns.contains(&column_name) {
+                                        has_error = true;
+                                        sender
+                                            .send(Err(QueryError::syntax_error(format!(
+                                                "multiple assignments to same column \"{}\"",
+                                                column_name
+                                            ))))
+                                            .expect("To Send Result to Client");
+                                    }
+                                    columns.insert(column_name.clone());
                                     found = Some((index, column_definition.name(), column_definition.sql_type()));
                                     break;
                                 }


### PR DESCRIPTION
No issue to close

#### Description
Fixes regression of when same column name occurs multiple times in insert and update assignments

#### Client output

e.g. for `psql`

```
alex-dukhno=> insert into s.t (i, i) values (1, 2);
ERROR:  column "i" specified more than once
alex-dukhno=> update s.t set i = 2 + i, i = 2 * i;
ERROR:  syntax error: multiple assignments to same column "i"
```

