### PR TITLE
QueryEvent maps to single BackendMessage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Closes #(issue number)
 #### Description
 short description what was changed
 
-#### Is it a feature?
+#### Is it a feature that change user experience?
 Please add compatibility tests or provide possible sql queries that we can add
 to our compatibility test suite. Thank you!
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,6 @@ dependencies = [
  "binary",
  "bincode",
  "fail",
- "itertools",
  "kernel",
  "log",
  "rstest",

--- a/src/ast/src/values.rs
+++ b/src/ast/src/values.rs
@@ -125,8 +125,8 @@ impl ScalarValue {
                 }
             }
             (ScalarValue::Null, _) => Ok(ScalarValue::Null),
-            (ScalarValue::String(str), SqlType::Char(len)) | (ScalarValue::String(str), SqlType::VarChar(len)) => {
-                Ok(ScalarValue::String(str.chars().take(*len as usize).collect()))
+            (ScalarValue::String(str), SqlType::Char(_)) | (ScalarValue::String(str), SqlType::VarChar(_)) => {
+                Ok(ScalarValue::String(str.trim().to_owned()))
             }
             (ScalarValue::Number(number), SqlType::SmallInt(_))
             | (ScalarValue::Number(number), SqlType::Integer(_))
@@ -429,11 +429,19 @@ mod tests {
         fn string_to_string() {
             assert_eq!(
                 ScalarValue::String("123".to_owned()).cast(&SqlType::Char(1)),
-                Ok(ScalarValue::String("1".to_string()))
+                Ok(ScalarValue::String("123".to_string()))
             );
             assert_eq!(
                 ScalarValue::String("123".to_owned()).cast(&SqlType::VarChar(4)),
                 Ok(ScalarValue::String("123".to_string()))
+            );
+            assert_eq!(
+                ScalarValue::String("123      ".to_owned()).cast(&SqlType::VarChar(4)),
+                Ok(ScalarValue::String("123".to_string()))
+            );
+            assert_eq!(
+                ScalarValue::String("12345678".to_owned()).cast(&SqlType::VarChar(4)),
+                Ok(ScalarValue::String("12345678".to_string()))
             );
         }
 

--- a/src/data_manager/Cargo.toml
+++ b/src/data_manager/Cargo.toml
@@ -14,7 +14,6 @@ serde = { version = "1.0.115", features = ["derive"] }
 bincode = "1.3.1"
 binary = { path = "../binary" }
 ast = { path = "../ast" }
-itertools = "0.9.0"
 fail = { version = "0.4.0", features = ["failpoints"] }
 
 [dev-dependencies]

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -455,30 +455,14 @@ impl<RW: AsyncRead + AsyncWrite + Unpin> Sender for ResponseSender<RW> {
     fn send(&self, query_result: QueryResult) -> io::Result<()> {
         log::debug!("[{:?}] query result sent to client", query_result);
         block_on(async {
-            match query_result {
-                Ok(event) => {
-                    let messages: Vec<BackendMessage> = event.into();
-                    for message in messages {
-                        log::debug!("response message {:?}", message);
-                        self.channel
-                            .lock()
-                            .await
-                            .write_all(message.as_vec().as_slice())
-                            .await
-                            .expect("OK");
-                    }
-                }
-                Err(error) => {
-                    let message: BackendMessage = error.into();
-                    log::debug!("response message {:?}", message);
-                    self.channel
-                        .lock()
-                        .await
-                        .write_all(message.as_vec().as_slice())
-                        .await
-                        .expect("OK");
-                }
-            }
+            let message: BackendMessage = query_result.into();
+            log::debug!("response message {:?}", message);
+            self.channel
+                .lock()
+                .await
+                .write_all(message.as_vec().as_slice())
+                .await
+                .expect("OK");
             log::debug!("end of the command is sent");
         });
         Ok(())

--- a/src/protocol/src/messages.rs
+++ b/src/protocol/src/messages.rs
@@ -17,7 +17,7 @@ use std::convert::TryFrom;
 use byteorder::{ByteOrder, NetworkEndian};
 
 use crate::{
-    pgsql_types::{PostgreSqlFormat, PostgreSqlType},
+    pgsql_types::{Oid, PostgreSqlFormat, PostgreSqlType},
     Error, Result,
 };
 
@@ -365,18 +365,18 @@ pub struct ColumnMetadata {
     /// name of the column that was specified in query
     pub name: String,
     /// PostgreSQL data type id
-    pub type_id: u32,
+    pub type_id: Oid,
     /// PostgreSQL data type size
     pub type_size: i16,
 }
 
 impl ColumnMetadata {
     /// Creates new column metadata
-    pub fn new(name: String, type_id: u32, type_size: i16) -> Self {
+    pub fn new<S: ToString>(name: S, pg_type: PostgreSqlType) -> Self {
         Self {
-            name,
-            type_id,
-            type_size,
+            name: name.to_string(),
+            type_id: pg_type.pg_oid(),
+            type_size: pg_type.pg_len(),
         }
     }
 }
@@ -798,7 +798,7 @@ mod serializing_backend_messages {
     #[test]
     fn row_description() {
         assert_eq!(
-            BackendMessage::RowDescription(vec![ColumnMetadata::new("c1".to_owned(), 23, 4)]).as_vec(),
+            BackendMessage::RowDescription(vec![ColumnMetadata::new("c1", PostgreSqlType::Integer)]).as_vec(),
             vec![
                 ROW_DESCRIPTION,
                 0,

--- a/src/protocol/src/messages.rs
+++ b/src/protocol/src/messages.rs
@@ -372,12 +372,19 @@ pub struct ColumnMetadata {
 
 impl ColumnMetadata {
     /// Creates new column metadata
-    pub fn new<S: ToString>(name: S, pg_type: PostgreSqlType) -> Self {
+    pub fn new<S: ToString>(name: S, pg_type: PostgreSqlType) -> ColumnMetadata {
         Self {
             name: name.to_string(),
             type_id: pg_type.pg_oid(),
             type_size: pg_type.pg_len(),
         }
+    }
+}
+
+impl<S: ToString> From<(S, PostgreSqlType)> for ColumnMetadata {
+    fn from(input: (S, PostgreSqlType)) -> ColumnMetadata {
+        let (name, pg_type) = input;
+        ColumnMetadata::new(name, pg_type)
     }
 }
 

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -133,11 +133,11 @@ impl QueryExecutor {
         match self.session.get_prepared_statement(name) {
             Some(stmt) => {
                 self.sender
-                    .send(Ok(QueryEvent::PreparedStatementDescribed(
-                        stmt.param_types().to_vec(),
-                        stmt.description().to_vec(),
-                    )))
-                    .expect("To Send ParametersDescribed Event");
+                    .send(Ok(QueryEvent::StatementParameters(stmt.param_types().to_vec())))
+                    .expect("To Send Statement Parameters to Client");
+                self.sender
+                    .send(Ok(QueryEvent::StatementDescription(stmt.description().to_vec())))
+                    .expect("To Send Statement Description to Client");
             }
             None => {
                 self.sender

--- a/src/sql_engine/src/lib.rs
+++ b/src/sql_engine/src/lib.rs
@@ -251,7 +251,13 @@ impl QueryExecutor {
 
         let statement = portal.stmt();
         let raw_sql_query = format!("{}", statement);
-        self.process_statement(&raw_sql_query, statement.clone())
+        self.process_statement(&raw_sql_query, statement.clone())?;
+
+        self.sender
+            .send(Ok(QueryEvent::QueryComplete))
+            .expect("To Send Query Complete Event to Client");
+
+        Ok(())
     }
 
     pub fn flush(&self) {

--- a/src/sql_engine/src/tests/delete.rs
+++ b/src/sql_engine/src/tests/delete.rs
@@ -22,49 +22,36 @@ use protocol::messages::ColumnMetadata;
 #[rstest::rstest]
 fn delete_from_nonexistent_table(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
     let (engine, collector) = sql_engine_with_schema;
+
     engine
         .execute("delete from schema_name.table_name;")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.table_name")),
-        Ok(QueryEvent::QueryComplete),
-    ]);
+    collector.assert_receive_single(Err(QueryError::table_does_not_exist("schema_name.table_name")));
 }
 
 #[rstest::rstest]
 fn delete_all_records(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
     let (engine, collector) = sql_engine_with_schema;
+
     engine
         .execute("create table schema_name.table_name (column_test smallint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
     engine
         .execute("insert into schema_name.table_name values (123);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
+
     engine
         .execute("insert into schema_name.table_name values (456);")
         .expect("no system errors");
-    engine
-        .execute("select * from schema_name.table_name;")
-        .expect("no system errors");
-    engine
-        .execute("delete from schema_name.table_name;")
-        .expect("no system errors");
-    engine
-        .execute("select * from schema_name.table_name;")
-        .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
 
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
+    engine
+        .execute("select * from schema_name.table_name;")
+        .expect("no system errors");
+    collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
             "column_test",
             PostgreSqlType::SmallInt,
@@ -72,14 +59,21 @@ fn delete_all_records(sql_engine_with_schema: (QueryExecutor, ResultCollector)) 
         Ok(QueryEvent::DataRow(vec!["123".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["456".to_owned()])),
         Ok(QueryEvent::RecordsSelected(2)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsDeleted(2)),
-        Ok(QueryEvent::QueryComplete),
+    ]);
+
+    engine
+        .execute("delete from schema_name.table_name;")
+        .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsDeleted(2)));
+
+    engine
+        .execute("select * from schema_name.table_name;")
+        .expect("no system errors");
+    collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
             "column_test",
             PostgreSqlType::SmallInt,
         )])),
         Ok(QueryEvent::RecordsSelected(0)),
-        Ok(QueryEvent::QueryComplete),
-    ])
+    ]);
 }

--- a/src/sql_engine/src/tests/delete.rs
+++ b/src/sql_engine/src/tests/delete.rs
@@ -17,6 +17,7 @@ use protocol::{pgsql_types::PostgreSqlType, results::QueryEvent};
 use crate::QueryExecutor;
 
 use super::*;
+use protocol::messages::ColumnMetadata;
 
 #[rstest::rstest]
 fn delete_from_nonexistent_table(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
@@ -64,17 +65,21 @@ fn delete_all_records(sql_engine_with_schema: (QueryExecutor, ResultCollector)) 
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
-            vec![vec!["123".to_owned()], vec!["456".to_owned()]],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+            "column_test",
+            PostgreSqlType::SmallInt,
+        )])),
+        Ok(QueryEvent::DataRow(vec!["123".to_owned()])),
+        Ok(QueryEvent::DataRow(vec!["456".to_owned()])),
+        Ok(QueryEvent::RecordsSelected(2)),
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsDeleted(2)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
-            vec![],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+            "column_test",
+            PostgreSqlType::SmallInt,
+        )])),
+        Ok(QueryEvent::RecordsSelected(0)),
         Ok(QueryEvent::QueryComplete),
     ])
 }

--- a/src/sql_engine/src/tests/describe_prepared_statement.rs
+++ b/src/sql_engine/src/tests/describe_prepared_statement.rs
@@ -38,13 +38,14 @@ fn describe_select_statement(sql_engine_with_schema: (QueryExecutor, ResultColle
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::ParseComplete),
-        Ok(QueryEvent::PreparedStatementDescribed(
-            vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
-            vec![
-                ("column_1".to_owned(), PostgreSqlType::SmallInt),
-                ("column_2".to_owned(), PostgreSqlType::SmallInt),
-            ],
-        )),
+        Ok(QueryEvent::StatementParameters(vec![
+            PostgreSqlType::SmallInt,
+            PostgreSqlType::SmallInt,
+        ])),
+        Ok(QueryEvent::StatementDescription(vec![
+            ("column_1".to_owned(), PostgreSqlType::SmallInt),
+            ("column_2".to_owned(), PostgreSqlType::SmallInt),
+        ])),
     ]);
 }
 
@@ -71,10 +72,11 @@ fn describe_update_statement(sql_engine_with_schema: (QueryExecutor, ResultColle
         Ok(QueryEvent::TableCreated),
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::ParseComplete),
-        Ok(QueryEvent::PreparedStatementDescribed(
-            vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
-            vec![],
-        )),
+        Ok(QueryEvent::StatementParameters(vec![
+            PostgreSqlType::SmallInt,
+            PostgreSqlType::SmallInt,
+        ])),
+        Ok(QueryEvent::StatementDescription(vec![])),
     ]);
 }
 

--- a/src/sql_engine/src/tests/describe_prepared_statement.rs
+++ b/src/sql_engine/src/tests/describe_prepared_statement.rs
@@ -19,9 +19,12 @@ use super::*;
 #[rstest::rstest]
 fn describe_select_statement(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
     let (mut engine, collector) = sql_engine_with_schema;
+
     engine
         .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
     engine
         .parse_prepared_statement(
             "statement_name",
@@ -29,32 +32,30 @@ fn describe_select_statement(sql_engine_with_schema: (QueryExecutor, ResultColle
             &[PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
         )
         .expect("no system errors");
+    collector.assert_receive_intermediate(Ok(QueryEvent::ParseComplete));
+
     engine
         .describe_prepared_statement("statement_name")
         .expect("no system errors");
-    collector.assert_content(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::ParseComplete),
-        Ok(QueryEvent::StatementParameters(vec![
-            PostgreSqlType::SmallInt,
-            PostgreSqlType::SmallInt,
-        ])),
-        Ok(QueryEvent::StatementDescription(vec![
-            ("column_1".to_owned(), PostgreSqlType::SmallInt),
-            ("column_2".to_owned(), PostgreSqlType::SmallInt),
-        ])),
-    ]);
+    collector.assert_receive_intermediate(Ok(QueryEvent::StatementDescription(vec![
+        ("column_1".to_owned(), PostgreSqlType::SmallInt),
+        ("column_2".to_owned(), PostgreSqlType::SmallInt),
+    ])));
+    collector.assert_receive_intermediate(Ok(QueryEvent::StatementParameters(vec![
+        PostgreSqlType::SmallInt,
+        PostgreSqlType::SmallInt,
+    ])));
 }
 
 #[rstest::rstest]
 fn describe_update_statement(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
     let (mut engine, collector) = sql_engine_with_schema;
+
     engine
         .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
     engine
         .parse_prepared_statement(
             "statement_name",
@@ -62,34 +63,24 @@ fn describe_update_statement(sql_engine_with_schema: (QueryExecutor, ResultColle
             &[PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
         )
         .expect("no system errors");
+    collector.assert_receive_intermediate(Ok(QueryEvent::ParseComplete));
+
     engine
         .describe_prepared_statement("statement_name")
         .expect("no system errors");
-
-    collector.assert_content(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::ParseComplete),
-        Ok(QueryEvent::StatementParameters(vec![
-            PostgreSqlType::SmallInt,
-            PostgreSqlType::SmallInt,
-        ])),
-        Ok(QueryEvent::StatementDescription(vec![])),
-    ]);
+    collector.assert_receive_intermediate(Ok(QueryEvent::StatementDescription(vec![])));
+    collector.assert_receive_intermediate(Ok(QueryEvent::StatementParameters(vec![
+        PostgreSqlType::SmallInt,
+        PostgreSqlType::SmallInt,
+    ])));
 }
 
 #[rstest::rstest]
 fn describe_not_existed_statement(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
     let (engine, collector) = sql_engine_with_schema;
+
     engine
         .describe_prepared_statement("non_existent")
         .expect("no system errors");
-
-    collector.assert_content(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Err(QueryError::prepared_statement_does_not_exist("non_existent")),
-    ]);
+    collector.assert_receive_intermediate(Err(QueryError::prepared_statement_does_not_exist("non_existent")));
 }

--- a/src/sql_engine/src/tests/error_responses.rs
+++ b/src/sql_engine/src/tests/error_responses.rs
@@ -21,10 +21,7 @@ fn parse_wrong_select_syntax(sql_engine: (QueryExecutor, ResultCollector)) {
         .execute("selec col from schema_name.table_name")
         .expect("no system errors");
 
-    collector.assert_content_for_single_queries(vec![
-        Err(QueryError::syntax_error(
-            "\"selec col from schema_name.table_name\" can\'t be parsed",
-        )),
-        Ok(QueryEvent::QueryComplete),
-    ]);
+    collector.assert_receive_single(Err(QueryError::syntax_error(
+        "\"selec col from schema_name.table_name\" can\'t be parsed",
+    )));
 }

--- a/src/sql_engine/src/tests/select.rs
+++ b/src/sql_engine/src/tests/select.rs
@@ -23,13 +23,7 @@ fn select_from_not_existed_table(sql_engine_with_schema: (QueryExecutor, ResultC
     engine
         .execute("select * from schema_name.non_existent;")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.non_existent")),
-        Ok(QueryEvent::QueryComplete),
-    ]);
+    collector.assert_receive_single(Err(QueryError::table_does_not_exist("schema_name.non_existent")));
 }
 
 #[rstest::rstest]
@@ -38,13 +32,7 @@ fn select_named_columns_from_non_existent_table(sql_engine_with_schema: (QueryEx
     engine
         .execute("select column_1 from schema_name.non_existent;")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Err(QueryError::table_does_not_exist("schema_name.non_existent")),
-        Ok(QueryEvent::QueryComplete),
-    ]);
+    collector.assert_receive_single(Err(QueryError::table_does_not_exist("schema_name.non_existent")));
 }
 
 #[rstest::rstest]
@@ -53,20 +41,17 @@ fn select_all_from_table_with_multiple_columns(sql_engine_with_schema: (QueryExe
     engine
         .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint, column_3 smallint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
     engine
         .execute("insert into schema_name.table_name values (123, 456, 789);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
+
     engine
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
+    collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
             ColumnMetadata::new("column_1", PostgreSqlType::SmallInt),
             ColumnMetadata::new("column_2", PostgreSqlType::SmallInt),
@@ -78,7 +63,6 @@ fn select_all_from_table_with_multiple_columns(sql_engine_with_schema: (QueryExe
             "789".to_owned(),
         ])),
         Ok(QueryEvent::RecordsSelected(1)),
-        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -88,20 +72,17 @@ fn select_not_all_columns(sql_engine_with_schema: (QueryExecutor, ResultCollecto
     engine
         .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint, column_3 smallint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
     engine
         .execute("insert into schema_name.table_name values (1, 4, 7), (2, 5, 8), (3, 6, 9);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(3)));
+
     engine
         .execute("select column_3, column_2 from schema_name.table_name;")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(3)),
-        Ok(QueryEvent::QueryComplete),
+    collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
             ColumnMetadata::new("column_3", PostgreSqlType::SmallInt),
             ColumnMetadata::new("column_2", PostgreSqlType::SmallInt),
@@ -110,7 +91,6 @@ fn select_not_all_columns(sql_engine_with_schema: (QueryExecutor, ResultCollecto
         Ok(QueryEvent::DataRow(vec!["8".to_owned(), "5".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["9".to_owned(), "6".to_owned()])),
         Ok(QueryEvent::RecordsSelected(3)),
-        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -120,18 +100,14 @@ fn select_non_existing_columns_from_table(sql_engine_with_schema: (QueryExecutor
     engine
         .execute("create table schema_name.table_name (column_in_table smallint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
     engine
         .execute("select column_not_in_table1, column_not_in_table2 from schema_name.table_name;")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
+    collector.assert_receive_many(vec![
         Err(QueryError::column_does_not_exist("column_not_in_table1")),
         Err(QueryError::column_does_not_exist("column_not_in_table2")),
-        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -143,31 +119,17 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(
     engine
         .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint, column_3 smallint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
     engine
-        .execute("insert into schema_name.table_name values (1, 2, 3);")
+        .execute("insert into schema_name.table_name values (1, 2, 3), (4, 5, 6), (7, 8, 9);")
         .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values (4, 5, 6);")
-        .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values (7, 8, 9);")
-        .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(3)));
 
     engine
         .execute("select column_3, column_1 from schema_name.table_name")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
+    collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
             ColumnMetadata::new("column_3", PostgreSqlType::SmallInt),
             ColumnMetadata::new("column_1", PostgreSqlType::SmallInt),
@@ -176,7 +138,6 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(
         Ok(QueryEvent::DataRow(vec!["6".to_owned(), "4".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["9".to_owned(), "7".to_owned()])),
         Ok(QueryEvent::RecordsSelected(3)),
-        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -188,32 +149,17 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(
     engine
         .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint, column_3 smallint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
 
     engine
-        .execute("insert into schema_name.table_name values (1, 2, 3);")
+        .execute("insert into schema_name.table_name values (1, 2, 3), (4, 5, 6), (7, 8, 9);")
         .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values (4, 5, 6);")
-        .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values (7, 8, 9);")
-        .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(3)));
 
     engine
         .execute("select column_3, column_1, column_2 from schema_name.table_name;")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
+    collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
             ColumnMetadata::new("column_3", PostgreSqlType::SmallInt),
             ColumnMetadata::new("column_1", PostgreSqlType::SmallInt),
@@ -235,7 +181,6 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(
             "8".to_owned(),
         ])),
         Ok(QueryEvent::RecordsSelected(3)),
-        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
@@ -245,31 +190,18 @@ fn select_with_column_name_duplication(sql_engine_with_schema: (QueryExecutor, R
     engine
         .execute("create table schema_name.table_name (column_1 smallint, column_2 smallint, column_3 smallint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
     engine
-        .execute("insert into schema_name.table_name values (1, 2, 3);")
+        .execute("insert into schema_name.table_name values (1, 2, 3), (4, 5, 6), (7, 8, 9);")
         .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values (4, 5, 6);")
-        .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values (7, 8, 9);")
-        .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(3)));
 
     engine
         .execute("select column_3, column_2, column_1, column_3, column_2 from schema_name.table_name;")
         .expect("no system errors");
 
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
+    collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
             ColumnMetadata::new("column_3", PostgreSqlType::SmallInt),
             ColumnMetadata::new("column_2", PostgreSqlType::SmallInt),
@@ -299,43 +231,26 @@ fn select_with_column_name_duplication(sql_engine_with_schema: (QueryExecutor, R
             "8".to_owned(),
         ])),
         Ok(QueryEvent::RecordsSelected(3)),
-        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
 #[rstest::rstest]
 fn select_different_integer_types(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
     let (engine, collector) = sql_engine_with_schema;
-
     engine
         .execute("create table schema_name.table_name (column_si smallint, column_i integer, column_bi bigint);")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
 
     engine
-        .execute("insert into schema_name.table_name values (1000, 2000000, 3000000000);")
+        .execute("insert into schema_name.table_name values (1000, 2000000, 3000000000), (4000, 5000000, 6000000000), (7000, 8000000, 9000000000);")
         .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values (4000, 5000000, 6000000000);")
-        .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values (7000, 8000000, 9000000000);")
-        .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(3)));
 
     engine
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
+    collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
             ColumnMetadata::new("column_si", PostgreSqlType::SmallInt),
             ColumnMetadata::new("column_i", PostgreSqlType::Integer),
@@ -357,43 +272,26 @@ fn select_different_integer_types(sql_engine_with_schema: (QueryExecutor, Result
             "9000000000".to_owned(),
         ])),
         Ok(QueryEvent::RecordsSelected(3)),
-        Ok(QueryEvent::QueryComplete),
     ]);
 }
 
 #[rstest::rstest]
 fn select_different_character_strings_types(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
     let (engine, collector) = sql_engine_with_schema;
-
     engine
         .execute("create table schema_name.table_name (char_10 char(10), var_char_20 varchar(20));")
         .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
 
     engine
-        .execute("insert into schema_name.table_name values ('1234567890', '12345678901234567890');")
+        .execute("insert into schema_name.table_name values ('1234567890', '12345678901234567890'), ('12345', '1234567890'), ('12345', '1234567890     ');")
         .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values ('12345', '1234567890');")
-        .expect("no system errors");
-    engine
-        .execute("insert into schema_name.table_name values ('12345', '1234567890     ');")
-        .expect("no system errors");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(3)));
 
     engine
         .execute("select * from schema_name.table_name;")
         .expect("no system errors");
-
-    collector.assert_content_for_single_queries(vec![
-        Ok(QueryEvent::SchemaCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::TableCreated),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsInserted(1)),
-        Ok(QueryEvent::QueryComplete),
+    collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
             ColumnMetadata::new("char_10", PostgreSqlType::Char),
             ColumnMetadata::new("var_char_20", PostgreSqlType::VarChar),
@@ -405,6 +303,5 @@ fn select_different_character_strings_types(sql_engine_with_schema: (QueryExecut
         Ok(QueryEvent::DataRow(vec!["12345".to_owned(), "1234567890".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["12345".to_owned(), "1234567890".to_owned()])),
         Ok(QueryEvent::RecordsSelected(3)),
-        Ok(QueryEvent::QueryComplete),
     ]);
 }

--- a/src/sql_engine/src/tests/type_constraints.rs
+++ b/src/sql_engine/src/tests/type_constraints.rs
@@ -22,6 +22,7 @@ fn int_table(sql_engine_with_schema: (QueryExecutor, ResultCollector)) -> (Query
     engine
         .execute("create table schema_name.table_name(col smallint);")
         .expect("no system errors");
+    collector.assert_receive_till_this_moment(vec![Ok(QueryEvent::TableCreated), Ok(QueryEvent::QueryComplete)]);
 
     (engine, collector)
 }
@@ -32,6 +33,7 @@ fn multiple_ints_table(sql_engine_with_schema: (QueryExecutor, ResultCollector))
     engine
         .execute("create table schema_name.table_name(column_si smallint, column_i integer, column_bi bigint);")
         .expect("no system errors");
+    collector.assert_receive_till_this_moment(vec![Ok(QueryEvent::TableCreated), Ok(QueryEvent::QueryComplete)]);
 
     (engine, collector)
 }
@@ -42,6 +44,7 @@ fn str_table(sql_engine_with_schema: (QueryExecutor, ResultCollector)) -> (Query
     engine
         .execute("create table schema_name.table_name(col varchar(5));")
         .expect("no system errors");
+    collector.assert_receive_till_this_moment(vec![Ok(QueryEvent::TableCreated), Ok(QueryEvent::QueryComplete)]);
 
     (engine, collector)
 }
@@ -57,19 +60,14 @@ mod insert {
         engine
             .execute("insert into schema_name.table_name values (32768);")
             .expect("no system errors");
-
-        collector.assert_content_for_single_queries(vec![
-            Ok(QueryEvent::SchemaCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::TableCreated),
-            Ok(QueryEvent::QueryComplete),
-            Err(QueryError::out_of_range(PostgreSqlType::SmallInt, "col".to_string(), 1)),
-            Ok(QueryEvent::QueryComplete),
-        ]);
+        collector.assert_receive_single(Err(QueryError::out_of_range(
+            PostgreSqlType::SmallInt,
+            "col".to_string(),
+            1,
+        )));
     }
 
     #[rstest::rstest]
-    #[ignore] // TODO constraints is going to be reworked
     fn type_mismatch(int_table: (QueryExecutor, ResultCollector)) {
         let (engine, collector) = int_table;
 
@@ -77,14 +75,10 @@ mod insert {
             .execute("insert into schema_name.table_name values ('str');")
             .expect("no system errors");
 
-        collector.assert_content_for_single_queries(vec![
-            Ok(QueryEvent::SchemaCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::TableCreated),
-            Ok(QueryEvent::QueryComplete),
-            Err(QueryError::type_mismatch("str", PostgreSqlType::SmallInt, "col", 1)),
-            Ok(QueryEvent::QueryComplete),
-        ]);
+        collector.assert_receive_single(Err(QueryError::invalid_text_representation(
+            PostgreSqlType::SmallInt,
+            "str",
+        )));
     }
 
     #[rstest::rstest]
@@ -93,15 +87,9 @@ mod insert {
         engine
             .execute("insert into schema_name.table_name values (-32769, -2147483649, 100), (100, -2147483649, -9223372036854775809);")
             .expect("no system errors");
-
-        collector.assert_content_for_single_queries(vec![
-            Ok(QueryEvent::SchemaCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::TableCreated),
-            Ok(QueryEvent::QueryComplete),
+        collector.assert_receive_many(vec![
             Err(QueryError::out_of_range(PostgreSqlType::SmallInt, "column_si", 1)),
             Err(QueryError::out_of_range(PostgreSqlType::Integer, "column_i", 1)),
-            Ok(QueryEvent::QueryComplete),
         ]);
     }
 
@@ -111,12 +99,7 @@ mod insert {
         engine
             .execute("insert into schema_name.table_name values (-32768, -2147483648, 100), (100, -2147483649, -9223372036854775809);")
             .expect("no system errors");
-
-        collector.assert_content_for_single_queries(vec![
-            Ok(QueryEvent::SchemaCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::TableCreated),
-            Ok(QueryEvent::QueryComplete),
+        collector.assert_receive_many(vec![
             Err(QueryError::out_of_range(
                 PostgreSqlType::Integer,
                 "column_i".to_owned(),
@@ -127,31 +110,22 @@ mod insert {
                 "column_bi".to_owned(),
                 2,
             )),
-            Ok(QueryEvent::QueryComplete),
         ]);
     }
 
     #[rstest::rstest]
-    #[ignore] // TODO constraints is going to be reworked
+    // #[ignore] // TODO constraints is going to be reworked
     fn value_too_long(str_table: (QueryExecutor, ResultCollector)) {
         let (engine, collector) = str_table;
         engine
             .execute("insert into schema_name.table_name values ('123457890');")
             .expect("no system errors");
-
-        collector.assert_content_for_single_queries(vec![
-            Ok(QueryEvent::SchemaCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::TableCreated),
-            Ok(QueryEvent::QueryComplete),
-            Err(QueryError::string_length_mismatch(
-                PostgreSqlType::VarChar,
-                5,
-                "col".to_string(),
-                1,
-            )),
-            Ok(QueryEvent::QueryComplete),
-        ]);
+        collector.assert_receive_single(Err(QueryError::string_length_mismatch(
+            PostgreSqlType::VarChar,
+            5,
+            "col".to_string(),
+            1,
+        )));
     }
 }
 
@@ -162,76 +136,58 @@ mod update {
     #[rstest::rstest]
     fn out_of_range(int_table: (QueryExecutor, ResultCollector)) {
         let (engine, collector) = int_table;
-
         engine
             .execute("insert into schema_name.table_name values (32767);")
             .expect("no system errors");
+        collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
+
         engine
             .execute("update schema_name.table_name set col = 32768;")
             .expect("no system errors");
 
-        collector.assert_content_for_single_queries(vec![
-            Ok(QueryEvent::SchemaCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::TableCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::RecordsInserted(1)),
-            Ok(QueryEvent::QueryComplete),
-            Err(QueryError::out_of_range(PostgreSqlType::SmallInt, "col".to_string(), 1)),
-            Ok(QueryEvent::QueryComplete),
-        ]);
+        collector.assert_receive_single(Err(QueryError::out_of_range(
+            PostgreSqlType::SmallInt,
+            "col".to_string(),
+            1,
+        )));
     }
 
     #[rstest::rstest]
-    #[ignore] // TODO constraints is going to be reworked
     fn type_mismatch(int_table: (QueryExecutor, ResultCollector)) {
         let (engine, collector) = int_table;
         engine
             .execute("insert into schema_name.table_name values (32767);")
             .expect("no system errors");
+        collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
+
         engine
             .execute("update schema_name.table_name set col = 'str';")
             .expect("no system errors");
 
-        collector.assert_content_for_single_queries(vec![
-            Ok(QueryEvent::SchemaCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::TableCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::RecordsInserted(1)),
-            Ok(QueryEvent::QueryComplete),
-            Err(QueryError::type_mismatch("str", PostgreSqlType::SmallInt, "col", 1)),
-            Ok(QueryEvent::QueryComplete),
-        ]);
+        collector.assert_receive_single(Err(QueryError::invalid_text_representation(
+            PostgreSqlType::SmallInt,
+            "str",
+        )));
     }
 
     #[rstest::rstest]
-    #[ignore] // TODO constraints is going to be reworked
     fn value_too_long(str_table: (QueryExecutor, ResultCollector)) {
         let (engine, collector) = str_table;
 
         engine
             .execute("insert into schema_name.table_name values ('str');")
             .expect("no system errors");
+        collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
+
         engine
             .execute("update schema_name.table_name set col = '123457890';")
             .expect("no system errors");
-
-        collector.assert_content_for_single_queries(vec![
-            Ok(QueryEvent::SchemaCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::TableCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::RecordsInserted(1)),
-            Ok(QueryEvent::QueryComplete),
-            Err(QueryError::string_length_mismatch(
-                PostgreSqlType::VarChar,
-                5,
-                "col".to_string(),
-                1,
-            )),
-            Ok(QueryEvent::QueryComplete),
-        ]);
+        collector.assert_receive_single(Err(QueryError::string_length_mismatch(
+            PostgreSqlType::VarChar,
+            5,
+            "col".to_string(),
+            1,
+        )));
     }
 
     #[rstest::rstest]
@@ -241,18 +197,12 @@ mod update {
         engine
             .execute("insert into schema_name.table_name values (100, 100, 100), (100, 100, 100);")
             .expect("no system errors");
+        collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(2)));
 
         engine
             .execute("update schema_name.table_name set column_si = -32769, column_i= -2147483649, column_bi=100;")
             .expect("no system errors");
-
-        collector.assert_content_for_single_queries(vec![
-            Ok(QueryEvent::SchemaCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::TableCreated),
-            Ok(QueryEvent::QueryComplete),
-            Ok(QueryEvent::RecordsInserted(2)),
-            Ok(QueryEvent::QueryComplete),
+        collector.assert_receive_many(vec![
             Err(QueryError::out_of_range(
                 PostgreSqlType::SmallInt,
                 "column_si".to_owned(),
@@ -263,7 +213,6 @@ mod update {
                 "column_i".to_owned(),
                 1,
             )),
-            Ok(QueryEvent::QueryComplete),
         ]);
     }
 }

--- a/src/sql_engine/src/tests/update.rs
+++ b/src/sql_engine/src/tests/update.rs
@@ -15,6 +15,7 @@
 use protocol::pgsql_types::PostgreSqlType;
 
 use super::*;
+use protocol::messages::ColumnMetadata;
 
 #[rstest::rstest]
 fn update_all_records(sql_engine_with_schema: (QueryExecutor, ResultCollector)) {
@@ -47,17 +48,23 @@ fn update_all_records(sql_engine_with_schema: (QueryExecutor, ResultCollector)) 
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
-            vec![vec!["123".to_owned()], vec!["456".to_owned()]],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+            "column_test",
+            PostgreSqlType::SmallInt,
+        )])),
+        Ok(QueryEvent::DataRow(vec!["123".to_owned()])),
+        Ok(QueryEvent::DataRow(vec!["456".to_owned()])),
+        Ok(QueryEvent::RecordsSelected(2)),
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsUpdated(2)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
-            vec![vec!["789".to_owned()], vec!["789".to_owned()]],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+            "column_test",
+            PostgreSqlType::SmallInt,
+        )])),
+        Ok(QueryEvent::DataRow(vec!["789".to_owned()])),
+        Ok(QueryEvent::DataRow(vec!["789".to_owned()])),
+        Ok(QueryEvent::RecordsSelected(2)),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -93,29 +100,23 @@ fn update_single_column_of_all_records(sql_engine_with_schema: (QueryExecutor, R
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![
-                ("col1".to_owned(), PostgreSqlType::SmallInt),
-                ("col2".to_owned(), PostgreSqlType::SmallInt),
-            ],
-            vec![
-                vec!["123".to_owned(), "789".to_owned()],
-                vec!["456".to_owned(), "789".to_owned()],
-            ],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("col1", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("col2", PostgreSqlType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec!["123".to_owned(), "789".to_owned()])),
+        Ok(QueryEvent::DataRow(vec!["456".to_owned(), "789".to_owned()])),
+        Ok(QueryEvent::RecordsSelected(2)),
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsUpdated(2)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![
-                ("col1".to_owned(), PostgreSqlType::SmallInt),
-                ("col2".to_owned(), PostgreSqlType::SmallInt),
-            ],
-            vec![
-                vec!["123".to_owned(), "357".to_owned()],
-                vec!["456".to_owned(), "357".to_owned()],
-            ],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("col1", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("col2", PostgreSqlType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec!["123".to_owned(), "357".to_owned()])),
+        Ok(QueryEvent::DataRow(vec!["456".to_owned(), "357".to_owned()])),
+        Ok(QueryEvent::RecordsSelected(2)),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -151,31 +152,41 @@ fn update_multiple_columns_of_all_records(sql_engine_with_schema: (QueryExecutor
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![
-                ("col1".to_owned(), PostgreSqlType::SmallInt),
-                ("col2".to_owned(), PostgreSqlType::SmallInt),
-                ("col3".to_owned(), PostgreSqlType::SmallInt),
-            ],
-            vec![
-                vec!["111".to_owned(), "222".to_owned(), "333".to_owned()],
-                vec!["444".to_owned(), "555".to_owned(), "666".to_owned()],
-            ],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("col1", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("col2", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("col3", PostgreSqlType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "111".to_owned(),
+            "222".to_owned(),
+            "333".to_owned(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "444".to_owned(),
+            "555".to_owned(),
+            "666".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(2)),
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsUpdated(2)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![
-                ("col1".to_owned(), PostgreSqlType::SmallInt),
-                ("col2".to_owned(), PostgreSqlType::SmallInt),
-                ("col3".to_owned(), PostgreSqlType::SmallInt),
-            ],
-            vec![
-                vec!["999".to_owned(), "222".to_owned(), "777".to_owned()],
-                vec!["999".to_owned(), "555".to_owned(), "777".to_owned()],
-            ],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("col1", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("col2", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("col3", PostgreSqlType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "999".to_owned(),
+            "222".to_owned(),
+            "777".to_owned(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "999".to_owned(),
+            "555".to_owned(),
+            "777".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(2)),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -206,33 +217,51 @@ fn update_all_records_in_multiple_columns(sql_engine_with_schema: (QueryExecutor
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(3)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![
-                ("column_1".to_owned(), PostgreSqlType::SmallInt),
-                ("column_2".to_owned(), PostgreSqlType::SmallInt),
-                ("column_3".to_owned(), PostgreSqlType::SmallInt),
-            ],
-            vec![
-                vec!["1".to_owned(), "2".to_owned(), "3".to_owned()],
-                vec!["4".to_owned(), "5".to_owned(), "6".to_owned()],
-                vec!["7".to_owned(), "8".to_owned(), "9".to_owned()],
-            ],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("column_1", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("column_2", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("column_3", PostgreSqlType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "1".to_owned(),
+            "2".to_owned(),
+            "3".to_owned(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "4".to_owned(),
+            "5".to_owned(),
+            "6".to_owned(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "7".to_owned(),
+            "8".to_owned(),
+            "9".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(3)),
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsUpdated(3)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![
-                ("column_1".to_owned(), PostgreSqlType::SmallInt),
-                ("column_2".to_owned(), PostgreSqlType::SmallInt),
-                ("column_3".to_owned(), PostgreSqlType::SmallInt),
-            ],
-            vec![
-                vec!["10".to_owned(), "-20".to_owned(), "30".to_owned()],
-                vec!["10".to_owned(), "-20".to_owned(), "30".to_owned()],
-                vec!["10".to_owned(), "-20".to_owned(), "30".to_owned()],
-            ],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("column_1", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("column_2", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("column_3", PostgreSqlType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "10".to_owned(),
+            "-20".to_owned(),
+            "30".to_owned(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "10".to_owned(),
+            "-20".to_owned(),
+            "30".to_owned(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "10".to_owned(),
+            "-20".to_owned(),
+            "30".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(3)),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -275,10 +304,12 @@ fn update_non_existent_columns_of_records(sql_engine_with_schema: (QueryExecutor
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(1)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![("column_test".to_owned(), PostgreSqlType::SmallInt)],
-            vec![vec!["123".to_owned()]],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+            "column_test",
+            PostgreSqlType::SmallInt,
+        )])),
+        Ok(QueryEvent::DataRow(vec!["123".to_owned()])),
+        Ok(QueryEvent::RecordsSelected(1)),
         Ok(QueryEvent::QueryComplete),
         Err(QueryError::column_does_not_exist("col1")),
         Err(QueryError::column_does_not_exist("col2")),
@@ -324,45 +355,51 @@ fn test_update_with_dynamic_expression(sql_engine_with_schema: (QueryExecutor, R
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsInserted(3)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![
-                ("si_column_1".to_owned(), PostgreSqlType::SmallInt),
-                ("si_column_2".to_owned(), PostgreSqlType::SmallInt),
-                ("si_column_3".to_owned(), PostgreSqlType::SmallInt),
-            ],
-            vec![
-                vec!["1".to_owned(), "2".to_owned(), "3".to_owned()],
-                vec!["4".to_owned(), "5".to_owned(), "6".to_owned()],
-                vec!["7".to_owned(), "8".to_owned(), "9".to_owned()],
-            ],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("si_column_1", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("si_column_2", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("si_column_3", PostgreSqlType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "1".to_owned(),
+            "2".to_owned(),
+            "3".to_owned(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "4".to_owned(),
+            "5".to_owned(),
+            "6".to_owned(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "7".to_owned(),
+            "8".to_owned(),
+            "9".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(3)),
         Ok(QueryEvent::QueryComplete),
         Ok(QueryEvent::RecordsUpdated(3)),
         Ok(QueryEvent::QueryComplete),
-        Ok(QueryEvent::RecordsSelected((
-            vec![
-                ("si_column_1".to_owned(), PostgreSqlType::SmallInt),
-                ("si_column_2".to_owned(), PostgreSqlType::SmallInt),
-                ("si_column_3".to_owned(), PostgreSqlType::SmallInt),
-            ],
-            vec![
-                vec![
-                    (2 * 1).to_string(),
-                    (2 * (1 + 2)).to_string(),
-                    (3 + (2 * (1 + 2))).to_string(),
-                ],
-                vec![
-                    (2 * 4).to_string(),
-                    (2 * (4 + 5)).to_string(),
-                    (6 + (2 * (4 + 5))).to_string(),
-                ],
-                vec![
-                    (2 * 7).to_string(),
-                    (2 * (7 + 8)).to_string(),
-                    (9 + (2 * (7 + 8))).to_string(),
-                ],
-            ],
-        ))),
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("si_column_1", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("si_column_2", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("si_column_3", PostgreSqlType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            (2 * 1).to_string(),
+            (2 * (1 + 2)).to_string(),
+            (3 + (2 * (1 + 2))).to_string(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            (2 * 4).to_string(),
+            (2 * (4 + 5)).to_string(),
+            (6 + (2 * (4 + 5))).to_string(),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            (2 * 7).to_string(),
+            (2 * (7 + 8)).to_string(),
+            (9 + (2 * (7 + 8))).to_string(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(3)),
         Ok(QueryEvent::QueryComplete),
     ]);
 }
@@ -414,10 +451,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["3".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["3".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -441,10 +480,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["-1".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["-1".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -468,10 +509,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["6".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["6".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -495,10 +538,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["4".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["4".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -522,10 +567,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["0".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["0".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -552,10 +599,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["64".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["64".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -581,10 +630,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["4".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["4".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -610,10 +661,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["2".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["2".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -639,10 +692,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["120".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["120".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -668,10 +723,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["120".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["120".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -697,10 +754,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["5".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["5".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -724,10 +783,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["1".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["1".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -751,10 +812,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["7".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["7".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -780,10 +843,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["-2".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["-2".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -809,10 +874,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["16".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["16".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -838,10 +905,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["2".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["2".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -865,10 +934,12 @@ mod operators {
                     Ok(QueryEvent::QueryComplete),
                     Ok(QueryEvent::RecordsUpdated(1)),
                     Ok(QueryEvent::QueryComplete),
-                    Ok(QueryEvent::RecordsSelected((
-                        vec![("column_si".to_owned(), PostgreSqlType::SmallInt)],
-                        vec![vec!["5".to_owned()]],
-                    ))),
+                    Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                        "column_si",
+                        PostgreSqlType::SmallInt,
+                    )])),
+                    Ok(QueryEvent::DataRow(vec!["5".to_owned()])),
+                    Ok(QueryEvent::RecordsSelected(1)),
                     Ok(QueryEvent::QueryComplete),
                 ]);
             }
@@ -912,10 +983,12 @@ mod operators {
                 Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsUpdated(1)),
                 Ok(QueryEvent::QueryComplete),
-                Ok(QueryEvent::RecordsSelected((
-                    vec![("strings".to_owned(), PostgreSqlType::Char)],
-                    vec![vec!["12345".to_owned()]],
-                ))),
+                Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                    "strings",
+                    PostgreSqlType::Char,
+                )])),
+                Ok(QueryEvent::DataRow(vec!["12345".to_owned()])),
+                Ok(QueryEvent::RecordsSelected(1)),
                 Ok(QueryEvent::QueryComplete),
             ]);
         }
@@ -945,17 +1018,21 @@ mod operators {
                 Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsUpdated(1)),
                 Ok(QueryEvent::QueryComplete),
-                Ok(QueryEvent::RecordsSelected((
-                    vec![("strings".to_owned(), PostgreSqlType::Char)],
-                    vec![vec!["145".to_owned()]],
-                ))),
+                Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                    "strings",
+                    PostgreSqlType::Char,
+                )])),
+                Ok(QueryEvent::DataRow(vec!["145".to_owned()])),
+                Ok(QueryEvent::RecordsSelected(1)),
                 Ok(QueryEvent::QueryComplete),
                 Ok(QueryEvent::RecordsUpdated(1)),
                 Ok(QueryEvent::QueryComplete),
-                Ok(QueryEvent::RecordsSelected((
-                    vec![("strings".to_owned(), PostgreSqlType::Char)],
-                    vec![vec!["451".to_owned()]],
-                ))),
+                Ok(QueryEvent::RowDescription(vec![ColumnMetadata::new(
+                    "strings",
+                    PostgreSqlType::Char,
+                )])),
+                Ok(QueryEvent::DataRow(vec!["451".to_owned()])),
+                Ok(QueryEvent::RecordsSelected(1)),
                 Ok(QueryEvent::QueryComplete),
             ]);
         }


### PR DESCRIPTION
no issue to close

#### Description
remove allocation in `QueryEvent` mapping to `BackendMessage`
change assertion on received query events

#### Is it a feature?
no

#### Client output
no changes

