### PR TITLE
Implement query cancellation for PostgreSQL wire protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
  "futures-lite",
  "itertools",
  "log",
- "rand",
+ "rand 0.7.3",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "async-native-tls"
 version = "0.3.3"
-source = "git+https://github.com/alex-dukhno/async-native-tls.git?branch=new-native-tls#9251f254a0e8cc6585269d272cd72c2bca1c1fc7"
+source = "git+https://github.com/alex-dukhno/async-native-tls.git?branch=new-native-tls#a959a677b3f052f587cff1c51d103ba3334d0f7a"
 dependencies = [
  "futures-util",
  "native-tls",
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "native-tls"
 version = "0.2.4"
-source = "git+https://github.com/sfackler/rust-native-tls.git#9a9e79825cde4705bad1b2192962066e29d365b5"
+source = "git+https://github.com/alex-dukhno/rust-native-tls.git?branch=update-dependecies#04ccdf311f7705d3aee0ad8082f3541bad7d89fd"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,6 +1010,7 @@ dependencies = [
  "futures-lite",
  "itertools",
  "log",
+ "rand",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "async-native-tls"
 version = "0.3.3"
-source = "git+https://github.com/alex-dukhno/async-native-tls.git?branch=new-native-tls#a959a677b3f052f587cff1c51d103ba3334d0f7a"
+source = "git+https://github.com/alex-dukhno/async-native-tls.git?branch=new-native-tls#9251f254a0e8cc6585269d272cd72c2bca1c1fc7"
 dependencies = [
  "futures-util",
  "native-tls",
@@ -192,9 +192,9 @@ checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
 
 [[package]]
 name = "async-trait"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "native-tls"
 version = "0.2.4"
-source = "git+https://github.com/alex-dukhno/rust-native-tls.git?branch=update-dependecies#04ccdf311f7705d3aee0ad8082f3541bad7d89fd"
+source = "git+https://github.com/sfackler/rust-native-tls.git#9a9e79825cde4705bad1b2192962066e29d365b5"
 dependencies = [
  "lazy_static",
  "libc",
@@ -910,18 +910,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48fad7cfbff853437be7cf54d7b993af21f53be7f0988cbfe4a51535aa77205"
+checksum = "2b9e280448854bd91559252582173b3bd1f8e094a0e644791c0628ca9b1f144f"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c6d293bdd3ca5a1697997854c6cf7855e43fb6a0ba1c47af57a5bcafd158ae"
+checksum = "c8c8b352676bc6a4c3d71970560b913cea444a7a921cc2e2d920225e4b91edaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe74897791e156a0cd8cce0db31b9b2198e67877316bf3086c3acd187f719f0"
+checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-utils"
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a53ed2efd04911c8280f2da7bf9abd350c931b86bc7f9f2386fbafbf525ff9"
+checksum = "b36ca4371e647131759047d7a0ac5e41e11fd540e0a49c9e158b1b94193081a1"
 dependencies = [
  "atty",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "async-native-tls"
 version = "0.3.3"
-source = "git+https://github.com/alex-dukhno/async-native-tls.git?branch=new-native-tls#a959a677b3f052f587cff1c51d103ba3334d0f7a"
+source = "git+https://github.com/alex-dukhno/async-native-tls.git?branch=new-native-tls#6ea553c9d9e741934d422a7faf5c7a44c612f587"
 dependencies = [
  "futures-util",
  "native-tls",
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "native-tls"
 version = "0.2.4"
-source = "git+https://github.com/alex-dukhno/rust-native-tls.git?branch=update-dependecies#04ccdf311f7705d3aee0ad8082f3541bad7d89fd"
+source = "git+https://github.com/sfackler/rust-native-tls.git#9a9e79825cde4705bad1b2192962066e29d365b5"
 dependencies = [
  "lazy_static",
  "libc",

--- a/deny.toml
+++ b/deny.toml
@@ -28,5 +28,5 @@ unknown-git = "deny"
 unknown-registry = "deny"
 allow-git = [
     "https://github.com/alex-dukhno/async-native-tls.git",
-    "https://github.com/alex-dukhno/rust-native-tls.git"
+    "https://github.com/sfackler/rust-native-tls.git"
 ]

--- a/src/protocol/Cargo.toml
+++ b/src/protocol/Cargo.toml
@@ -16,6 +16,7 @@ byteorder = "1.3.4"
 futures-lite = "1.7.0"
 itertools = "0.9.0"
 log = "0.4.11"
+rand = "0.7"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/protocol/src/messages.rs
+++ b/src/protocol/src/messages.rs
@@ -18,7 +18,7 @@ use byteorder::{ByteOrder, NetworkEndian};
 
 use crate::{
     pgsql_types::{Oid, PostgreSqlFormat, PostgreSqlType},
-    Error, Result,
+    ConnId, ConnSecretKey, Error, Result,
 };
 
 const COMMAND_COMPLETE: u8 = b'C';
@@ -217,7 +217,7 @@ pub enum BackendMessage {
     AuthenticationOk,
     /// Identifies as cancellation key data. The frontend must save these values
     /// if it wishes to be able to issue CancelRequest messages later.
-    BackendKeyData(i32, i32),
+    BackendKeyData(ConnId, ConnSecretKey),
     /// Start-up is completed. The frontend can now issue commands.
     ReadyForQuery,
     /// One of the set of rows returned by a SELECT, FETCH, etc query.

--- a/src/protocol/src/messages.rs
+++ b/src/protocol/src/messages.rs
@@ -762,7 +762,7 @@ mod serializing_backend_messages {
     }
 
     #[test]
-    fn backend_ket_data() {
+    fn backend_key_data() {
         assert_eq!(
             BackendMessage::BackendKeyData(1, 2).as_vec(),
             vec![BACKEND_KEY_DATA, 0, 0, 0, 12, 0, 0, 0, 1, 0, 0, 0, 2]

--- a/src/protocol/src/tests/mod.rs
+++ b/src/protocol/src/tests/mod.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(test)]
+mod accept_client_request;
 mod async_io;
 #[cfg(test)]
 mod connection;
-#[cfg(test)]
-mod hand_shake;
 #[cfg(test)]
 mod pg_frontend;
 

--- a/src/protocol/src/tests/pg_frontend.rs
+++ b/src/protocol/src/tests/pg_frontend.rs
@@ -22,6 +22,7 @@ pub enum Message {
     SslDisabled,
     SslRequired,
     Password(&'static str),
+    CancelRequest(i32, i32),
 }
 
 impl Message {
@@ -70,6 +71,14 @@ impl Message {
                 with_len.extend_from_slice(&(buff.len() as u32 + 4).to_be_bytes());
                 with_len.extend_from_slice(&buff);
                 with_len
+            }
+            Message::CancelRequest(conn_id, secret_key) => {
+                let mut buff = Vec::new();
+                buff.extend_from_slice(&16u32.to_be_bytes());
+                buff.extend_from_slice(&80_877_102u32.to_be_bytes());
+                buff.extend_from_slice(&conn_id.to_be_bytes());
+                buff.extend_from_slice(&secret_key.to_be_bytes());
+                buff
             }
         }
     }


### PR DESCRIPTION
Implements the Protocol part of #207.

#### Description

This PR only implements the Protocol of `CancelRequest`. In-progress query cancellation hasn't been implemented yet.

1. Adds struct `ConnSupervisor` to save the all current active connection pairs - `conn_id` and `secret_key`. The `secret_key` needs to be verified when invoking `CancelRequest` from another new connection.

2. Returns `conn_id` and `secret_key` in backend message `BackendKeyData` (before `ReadyForQuery`) when startup.

#### Client output

Since the in-progress query cancellation hasn't been supported, the Empty cancellation could only been tested via `psycopg2` (in `python` command line).

```
ipython

In [1]: from psycopg2 import connect

In [2]: conn = connect(host="localhost", password="check_this_out", database="postgres")

In [3]: conn.cancel()
```

The Debug log outputs as below.

```
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/database`

DEBUG [protocol] address V4(127.0.0.1:62276)
DEBUG [protocol] client is trying to connect with SSL
DEBUG [protocol] client is trying to connect with version 3
DEBUG [protocol] client message response tag Ok(112)
DEBUG [protocol] waiting for authentication response
DEBUG [protocol] start service on connection-1
DEBUG [protocol] send ready_for_query message
DEBUG [node::node] ready to handle query
DEBUG [protocol] address V4(127.0.0.1:62277)
DEBUG [protocol] client is trying to connect cancel request
DEBUG [node::node] cancel request of connection-1
```
