### PR TITLE
experimental filter dataflow element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "ast",
  "constraints",
  "data_manager",
+ "protocol",
  "sql_model",
  "sqlparser",
 ]
@@ -1033,6 +1034,7 @@ name = "query_planner"
 version = "0.1.0"
 dependencies = [
  "ast",
+ "bigdecimal",
  "constraints",
  "data_manager",
  "kernel",

--- a/src/ast/src/lib.rs
+++ b/src/ast/src/lib.rs
@@ -25,6 +25,7 @@ use std::{
 };
 
 pub mod operations;
+pub mod predicates;
 pub mod values;
 
 #[derive(Debug, PartialEq)]

--- a/src/ast/src/predicates.rs
+++ b/src/ast/src/predicates.rs
@@ -1,0 +1,27 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bigdecimal::BigDecimal;
+use sql_model::Id;
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum PredicateOp {
+    Eq,
+}
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum PredicateValue {
+    Column(Id),
+    Number(BigDecimal),
+}

--- a/src/node/src/query_engine/mod.rs
+++ b/src/node/src/query_engine/mod.rs
@@ -281,40 +281,12 @@ impl QueryEngine {
     }
 
     pub(crate) fn describe(&self, select_input: SelectInput) -> Result<Description, ()> {
-        // let all_columns = self.data_manager.table_columns(&select_input.table_id)?;
-        // let mut column_definitions = vec![];
-        // let mut has_error = false;
-        // for column_name in &select_input.selected_columns {
-        //     let mut found = None;
-        //     for column_definition in &all_columns {
-        //         if column_definition.has_name(&column_name) {
-        //             found = Some(column_definition);
-        //             break;
-        //         }
-        //     }
-        //
-        //     if let Some(column_definition) = found {
-        //         column_definitions.push(column_definition);
-        //     } else {
-        //         self.sender
-        //             .send(Err(QueryError::column_does_not_exist(column_name)))
-        //             .expect("To Send Result to Client");
-        //         has_error = true;
-        //     }
-        // }
-        //
-        // if has_error {
-        //     return Err(());
-        // }
-
-        let description = self
+        Ok(self
             .data_manager
             .column_defs(&select_input.table_id, &select_input.selected_columns)
             .into_iter()
             .map(|column_definition| (column_definition.name(), (&column_definition.sql_type()).into()))
-            .collect();
-
-        Ok(description)
+            .collect())
     }
 }
 

--- a/src/node/src/query_engine/tests/mod.rs
+++ b/src/node/src/query_engine/tests/mod.rs
@@ -28,6 +28,8 @@ mod table;
 mod type_constraints;
 #[cfg(test)]
 mod update;
+#[cfg(test)]
+mod where_clause;
 
 use std::{
     io,

--- a/src/node/src/query_engine/tests/where_clause.rs
+++ b/src/node/src/query_engine/tests/where_clause.rs
@@ -1,0 +1,56 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use protocol::pgsql_types::PostgreSqlType;
+
+use protocol::{messages::ColumnMetadata, results::QueryEvent};
+
+#[rstest::rstest]
+fn select_row_by_column_equality_predicate(database_with_schema: (QueryEngine, ResultCollector)) {
+    let (mut engine, collector) = database_with_schema;
+    engine
+        .execute(Command::Query {
+            sql: "create table schema_name.table_name (column_1 smallint, column_2 smallint, column_3 smallint);"
+                .to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::TableCreated));
+
+    engine
+        .execute(Command::Query {
+            sql: "insert into schema_name.table_name values (1, 4, 7), (2, 5, 8), (3, 6, 9);".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(3)));
+
+    engine
+        .execute(Command::Query {
+            sql: "select * from schema_name.table_name where column_1 = 1;".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_many(vec![
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("column_1", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("column_2", PostgreSqlType::SmallInt),
+            ColumnMetadata::new("column_3", PostgreSqlType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "1".to_owned(),
+            "4".to_owned(),
+            "7".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(1)),
+    ]);
+}

--- a/src/plan/Cargo.toml
+++ b/src/plan/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 ast = { path = "../ast" }
 constraints = { path = "../constraints" }
 data_manager = { path = "../data_manager" }
+protocol = { path = "../protocol" }
 sql_model = { path = "../sql_model" }
 
 sqlparser = { version = "0.6.1", features = ["bigdecimal"] }

--- a/src/plan/src/lib.rs
+++ b/src/plan/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use ast::operations::ScalarOp;
+use ast::predicates::{PredicateOp, PredicateValue};
 use constraints::TypeConstraint;
 use data_manager::ColumnDefinition;
 use sql_model::{sql_types::SqlType, Id};
@@ -205,6 +206,7 @@ pub struct TableDeletes {
 pub struct SelectInput {
     pub table_id: TableId,
     pub selected_columns: Vec<Id>,
+    pub predicate: Option<(PredicateValue, PredicateOp, PredicateValue)>,
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/src/query_planner/Cargo.toml
+++ b/src/query_planner/Cargo.toml
@@ -14,6 +14,7 @@ plan = { path = "../plan" }
 protocol = { path = "../protocol" }
 sql_model = { path = "../sql_model" }
 
+bigdecimal = "0.1.2"
 sqlparser = { version = "0.6.1", features = ["bigdecimal"] }
 
 [dev-dependencies]

--- a/src/query_planner/src/tests/mod.rs
+++ b/src/query_planner/src/tests/mod.rs
@@ -39,6 +39,8 @@ mod insert;
 mod select;
 #[cfg(test)]
 mod update;
+#[cfg(test)]
+mod where_clause;
 
 struct Collector(Mutex<Vec<QueryResult>>);
 

--- a/src/query_planner/src/tests/select.rs
+++ b/src/query_planner/src/tests/select.rs
@@ -195,7 +195,8 @@ fn select_from_table(planner_and_sender_with_no_column_table: (QueryPlanner, Res
         }))),
         Ok(Plan::Select(SelectInput {
             table_id: TableId::from((0, 0)),
-            selected_columns: vec![]
+            selected_columns: vec![],
+            predicate: None
         }))
     );
 

--- a/src/query_planner/src/tests/where_clause.rs
+++ b/src/query_planner/src/tests/where_clause.rs
@@ -1,0 +1,67 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use ast::predicates::{PredicateOp, PredicateValue};
+use bigdecimal::BigDecimal;
+use plan::{SelectInput, TableId};
+use sqlparser::ast::{
+    BinaryOperator, Expr, ObjectName, Query, Select, SelectItem, SetExpr, Statement, TableFactor, TableWithJoins, Value,
+};
+
+#[rstest::rstest]
+fn select_from_table(planner_and_sender_with_table: (QueryPlanner, ResultCollector)) {
+    let (query_planner, collector) = planner_and_sender_with_table;
+    assert_eq!(
+        query_planner.plan(&Statement::Query(Box::new(Query {
+            ctes: vec![],
+            body: SetExpr::Select(Box::new(Select {
+                distinct: false,
+                top: None,
+                projection: vec![SelectItem::Wildcard],
+                from: vec![TableWithJoins {
+                    relation: TableFactor::Table {
+                        name: ObjectName(vec![ident(SCHEMA), ident(TABLE)]),
+                        alias: None,
+                        args: vec![],
+                        with_hints: vec![]
+                    },
+                    joins: vec![],
+                }],
+                selection: Some(Expr::BinaryOp {
+                    left: Box::new(Expr::Identifier(ident("small_int"))),
+                    op: BinaryOperator::Eq,
+                    right: Box::new(Expr::Value(Value::Number(BigDecimal::from(0))))
+                }),
+                group_by: vec![],
+                having: None,
+            })),
+            order_by: vec![],
+            limit: None,
+            offset: None,
+            fetch: None,
+        }))),
+        Ok(Plan::Select(SelectInput {
+            table_id: TableId::from((0, 0)),
+            selected_columns: vec![0, 1, 2],
+            predicate: Some((
+                PredicateValue::Column(0),
+                PredicateOp::Eq,
+                PredicateValue::Number(BigDecimal::from(0))
+            ))
+        }))
+    );
+
+    collector.assert_content(vec![])
+}


### PR DESCRIPTION
Related to #290 

#### Description
added `Filter` dataflow element to experiment with `where` predicate inside `select` queries

#### Is it a feature that change user experience?
yes, but experimental

#### Client output

e.g. for `psql`

```
alex-dukhno=> create schema s;
CREATE SCHEMA
alex-dukhno=> create table t (c1 smallint, c2 smallint, c3 smallint);
ERROR:  syntax error: unsupported table name 't'. All table names must be qualified
alex-dukhno=> create table s.t (c1 smallint, c2 smallint, c3 smallint);
CREATE TABLE
alex-dukhno=> insert into s.t values (1, 2, 3), (4, 5, 6), (7, 8, 9);
INSERT 0 3
alex-dukhno=> select * from s.t where c1 = 1;
 c1 | c2 | c3
----+----+----
  1 |  2 |  3
(1 row)

alex-dukhno=> select * from s.t where c1 = 2;
 c1 | c2 | c3
----+----+----
(0 rows)

alex-dukhno=> select * from s.t where c1 = 4;
 c1 | c2 | c3
----+----+----
  4 |  5 |  6
(1 row)
```

