### PR TITLE
Fix the issue of reporting UnexpectedEof when client disconnected immediately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
 [[package]]
 name = "native-tls"
 version = "0.2.4"
-source = "git+https://github.com/sfackler/rust-native-tls.git#9a9e79825cde4705bad1b2192962066e29d365b5"
+source = "git+https://github.com/sfackler/rust-native-tls.git?branch=master#9a9e79825cde4705bad1b2192962066e29d365b5"
 dependencies = [
  "lazy_static",
  "libc",


### PR DESCRIPTION
Closes #354 

#### Description

This issue occurred when client disconnected immediately without sending a `Terminate` message.
As client closed the socket directly, the server side could only receive a zero byte for client close.

#### Is it a feature that change user experience?

no

#### Client output

This issue could be reproduced as @alex-dukhno 's comment in #354 when running compatibility tests, or run the below `groovy` script.

```
groovysh
groovy:000>

:grab org.postgresql:postgresql:9.4-1205-jdbc42
import groovy.sql.Sql

dbConf = [
  url: "jdbc:postgresql://localhost:5432/test?gssEncMode=disable&sslmode=disable&preferQueryMode=extendedForPrepared",
  user: "postgres",
  password: "postgres",
  driver: "org.postgresql.Driver",
]

db = Sql.newInstance(dbConf)
```

Then exit directly as below (or `CTRL + C`) without calling `db.close()`.

```
groovy:000>:exit
```

The log message `[protocol] client disconnected immediately` should be displayed with this fix.