### PR TITLE
remove protocol dependency from query planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "native-tls"
 version = "0.2.4"
-source = "git+https://github.com/sfackler/rust-native-tls.git#9a9e79825cde4705bad1b2192962066e29d365b5"
+source = "git+https://github.com/sfackler/rust-native-tls.git#?branch=master9a9e79825cde4705bad1b2192962066e29d365b5"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "native-tls"
 version = "0.2.4"
-source = "git+https://github.com/sfackler/rust-native-tls.git#?branch=master9a9e79825cde4705bad1b2192962066e29d365b5"
+source = "git+https://github.com/sfackler/rust-native-tls.git?branch=master#9a9e79825cde4705bad1b2192962066e29d365b5"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "native-tls"
 version = "0.2.4"
-source = "git+https://github.com/sfackler/rust-native-tls.git?branch=master#9a9e79825cde4705bad1b2192962066e29d365b5"
+source = "git+https://github.com/sfackler/rust-native-tls.git#9a9e79825cde4705bad1b2192962066e29d365b5"
 dependencies = [
  "lazy_static",
  "libc",
@@ -931,7 +931,6 @@ name = "parser"
 version = "0.1.0"
 dependencies = [
  "log",
- "protocol",
  "sqlparser",
 ]
 
@@ -1089,11 +1088,9 @@ dependencies = [
  "ast",
  "bigdecimal",
  "constraints",
- "kernel",
  "meta_def",
  "metadata",
  "plan",
- "protocol",
  "rstest",
  "sql_model",
  "sqlparser",

--- a/src/parser/Cargo.toml
+++ b/src/parser/Cargo.toml
@@ -6,7 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-protocol = { path = "../protocol" }
-
 log = "0.4.11"
 sqlparser = { git = "https://github.com/ballista-compute/sqlparser-rs.git", branch = "main", features = ["bigdecimal"] }

--- a/src/plan/src/lib.rs
+++ b/src/plan/src/lib.rs
@@ -224,5 +224,6 @@ pub enum Plan {
     Update(TableUpdates),
     Delete(TableDeletes),
     Insert(TableInserts),
+    NothingToExecute,
     NotProcessed(Box<Statement>),
 }

--- a/src/protocol/src/lib.rs
+++ b/src/protocol/src/lib.rs
@@ -547,17 +547,9 @@ pub trait Receiver: Send + Sync {
 }
 
 struct ResponseSender<RW: AsyncRead + AsyncWrite + Unpin> {
+    #[allow(dead_code)]
     properties: (Version, Params),
     channel: Arc<AsyncMutex<Channel<RW>>>,
-}
-
-impl<RW: AsyncRead + AsyncWrite + Unpin> Clone for ResponseSender<RW> {
-    fn clone(&self) -> Self {
-        Self {
-            properties: (self.properties.0, self.properties.1.clone()),
-            channel: self.channel.clone(),
-        }
-    }
 }
 
 impl<RW: AsyncRead + AsyncWrite + Unpin> ResponseSender<RW> {

--- a/src/query_executor/src/lib.rs
+++ b/src/query_executor/src/lib.rs
@@ -43,6 +43,10 @@ impl QueryExecutor {
 
     pub fn execute(&self, plan: Plan) {
         match plan {
+            Plan::NothingToExecute => self
+                .sender
+                .send(Ok(QueryEvent::QueryComplete))
+                .expect("To Send Query Result to Client"),
             Plan::CreateSchema(creation_info) => {
                 CreateSchemaCommand::new(creation_info, self.data_manager.clone(), self.sender.clone()).execute()
             }
@@ -94,8 +98,5 @@ impl QueryExecutor {
                 }
             },
         }
-        // self.sender
-        //     .send(Ok(QueryEvent::QueryComplete))
-        //     .expect("To Send Query Complete Event to Client");
     }
 }

--- a/src/query_planner/Cargo.toml
+++ b/src/query_planner/Cargo.toml
@@ -8,11 +8,9 @@ publish = false
 [dependencies]
 ast = { path = "../ast" }
 constraints = { path = "../constraints" }
-kernel = { path = "../kernel" }
 meta_def = { path = "../meta_def" }
 metadata = { path = "../metadata" }
 plan = { path = "../plan" }
-protocol = { path = "../protocol" }
 sql_model = { path = "../sql_model" }
 
 bigdecimal = "0.2.0"

--- a/src/query_planner/src/tests/delete.rs
+++ b/src/query_planner/src/tests/delete.rs
@@ -14,61 +14,50 @@
 
 use super::*;
 use plan::{TableDeletes, TableId};
-use protocol::results::QueryError;
 use sqlparser::ast::{ObjectName, Statement};
 
 #[rstest::rstest]
-fn delete_from_table_that_in_nonexistent_schema(planner_and_sender: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender;
+fn delete_from_table_that_in_nonexistent_schema(planner: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Delete {
+        planner.plan(&Statement::Delete {
             table_name: ObjectName(vec![ident("non_existent_schema"), ident(TABLE)]),
             selection: None
         }),
-        Err(())
+        Err(vec![PlanError::schema_does_not_exist(&"non_existent_schema")])
     );
-
-    collector.assert_content(vec![Err(QueryError::schema_does_not_exist("non_existent_schema"))])
 }
 
 #[rstest::rstest]
-fn delete_from_nonexistent_table(planner_and_sender_with_schema: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender_with_schema;
+fn delete_from_nonexistent_table(planner_with_schema: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Delete {
+        planner_with_schema.plan(&Statement::Delete {
             table_name: ObjectName(vec![ident(SCHEMA), ident("non_existent_table")]),
             selection: None
         }),
-        Err(())
+        Err(vec![PlanError::table_does_not_exist(&format!(
+            "{}.{}",
+            SCHEMA, "non_existent_table"
+        ))])
     );
-
-    collector.assert_content(vec![Err(QueryError::table_does_not_exist(format!(
-        "{}.{}",
-        SCHEMA, "non_existent_table"
-    )))])
 }
 
 #[rstest::rstest]
-fn delete_from_table_with_unqualified_name(planner_and_sender_with_schema: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender_with_schema;
+fn delete_from_table_with_unqualified_name(planner_with_schema: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Delete {
+        planner_with_schema.plan(&Statement::Delete {
             table_name: ObjectName(vec![ident("only_schema_in_the_name")]),
             selection: None
         }),
-        Err(())
+        Err(vec![PlanError::syntax_error(
+            &"unsupported table name 'only_schema_in_the_name'. All table names must be qualified",
+        )])
     );
-
-    collector.assert_content(vec![Err(QueryError::syntax_error(
-        "unsupported table name 'only_schema_in_the_name'. All table names must be qualified",
-    ))])
 }
 
 #[rstest::rstest]
-fn c_table_with_unsupported_name(planner_and_sender_with_schema: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender_with_schema;
+fn c_table_with_unsupported_name(planner_with_schema: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Delete {
+        planner_with_schema.plan(&Statement::Delete {
             table_name: ObjectName(vec![
                 ident("first_part"),
                 ident("second_part"),
@@ -77,19 +66,16 @@ fn c_table_with_unsupported_name(planner_and_sender_with_schema: (InMemory, Resu
             ]),
             selection: None
         }),
-        Err(())
+        Err(vec![PlanError::syntax_error(
+            &"unable to process table name 'first_part.second_part.third_part.fourth_part'",
+        )])
     );
-
-    collector.assert_content(vec![Err(QueryError::syntax_error(
-        "unable to process table name 'first_part.second_part.third_part.fourth_part'",
-    ))])
 }
 
 #[rstest::rstest]
-fn delete_from_table(planner_and_sender_with_table: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender_with_table;
+fn delete_from_table(planner_with_table: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Delete {
+        planner_with_table.plan(&Statement::Delete {
             table_name: ObjectName(vec![ident(SCHEMA), ident(TABLE)]),
             selection: None
         }),
@@ -97,6 +83,4 @@ fn delete_from_table(planner_and_sender_with_table: (InMemory, ResultCollector))
             table_id: TableId::from((0, 0))
         }))
     );
-
-    collector.assert_content(vec![])
 }

--- a/src/query_planner/src/tests/update.rs
+++ b/src/query_planner/src/tests/update.rs
@@ -16,48 +16,40 @@ use super::*;
 use ast::{operations::ScalarOp, values::ScalarValue};
 use constraints::TypeConstraint;
 use plan::{Plan, TableId, TableUpdates};
-use protocol::results::QueryError;
 use sql_model::sql_types::SqlType;
 use sqlparser::ast::{Assignment, Expr, ObjectName, Statement, Value};
 
 #[rstest::rstest]
-fn update_table_that_in_nonexistent_schema(planner_and_sender: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender;
+fn update_table_that_in_nonexistent_schema(planner: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Update {
+        planner.plan(&Statement::Update {
             table_name: ObjectName(vec![ident("non_existent_schema"), ident(TABLE)]),
             assignments: vec![],
             selection: None
         }),
-        Err(())
+        Err(vec![PlanError::schema_does_not_exist(&"non_existent_schema")])
     );
-
-    collector.assert_content(vec![Err(QueryError::schema_does_not_exist("non_existent_schema"))])
 }
 
 #[rstest::rstest]
-fn update_nonexistent_table(planner_and_sender_with_schema: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender_with_schema;
+fn update_nonexistent_table(planner_with_schema: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Update {
+        planner_with_schema.plan(&Statement::Update {
             table_name: ObjectName(vec![ident(SCHEMA), ident("non_existent_table")]),
             assignments: vec![],
             selection: None
         }),
-        Err(())
+        Err(vec![PlanError::table_does_not_exist(&format!(
+            "{}.{}",
+            SCHEMA, "non_existent_table"
+        ))])
     );
-
-    collector.assert_content(vec![Err(QueryError::table_does_not_exist(format!(
-        "{}.{}",
-        SCHEMA, "non_existent_table"
-    )))])
 }
 
 #[rstest::rstest]
-fn update_table_with_unqualified_name(planner_and_sender_with_schema: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender_with_schema;
+fn update_table_with_unqualified_name(planner_with_schema: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Update {
+        planner_with_schema.plan(&Statement::Update {
             table_name: ObjectName(vec![ident("only_schema_in_the_name")]),
             assignments: vec![Assignment {
                 id: ident(""),
@@ -65,19 +57,16 @@ fn update_table_with_unqualified_name(planner_and_sender_with_schema: (InMemory,
             }],
             selection: None
         }),
-        Err(())
+        Err(vec![PlanError::syntax_error(
+            &"unsupported table name 'only_schema_in_the_name'. All table names must be qualified",
+        )])
     );
-
-    collector.assert_content(vec![Err(QueryError::syntax_error(
-        "unsupported table name 'only_schema_in_the_name'. All table names must be qualified",
-    ))])
 }
 
 #[rstest::rstest]
-fn update_table_with_unsupported_name(planner_and_sender_with_schema: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender_with_schema;
+fn update_table_with_unsupported_name(planner_with_schema: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Update {
+        planner_with_schema.plan(&Statement::Update {
             table_name: ObjectName(vec![
                 ident("first_part"),
                 ident("second_part"),
@@ -90,19 +79,16 @@ fn update_table_with_unsupported_name(planner_and_sender_with_schema: (InMemory,
             }],
             selection: None
         }),
-        Err(())
+        Err(vec![PlanError::syntax_error(
+            &"unable to process table name 'first_part.second_part.third_part.fourth_part'",
+        )])
     );
-
-    collector.assert_content(vec![Err(QueryError::syntax_error(
-        "unable to process table name 'first_part.second_part.third_part.fourth_part'",
-    ))])
 }
 
 #[rstest::rstest]
-fn update_table(planner_and_sender_with_table: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender_with_table;
+fn update_table(planner_with_table: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Update {
+        planner_with_table.plan(&Statement::Update {
             table_name: ObjectName(vec![ident(SCHEMA), ident(TABLE)]),
             assignments: vec![Assignment {
                 id: ident("small_int"),
@@ -121,6 +107,4 @@ fn update_table(planner_and_sender_with_table: (InMemory, ResultCollector)) {
             input: vec![ScalarOp::Value(ScalarValue::String("".to_string()))],
         }))
     );
-
-    collector.assert_content(vec![])
 }

--- a/src/query_planner/src/tests/where_clause.rs
+++ b/src/query_planner/src/tests/where_clause.rs
@@ -22,10 +22,9 @@ use sqlparser::ast::{
 use std::convert::TryFrom;
 
 #[rstest::rstest]
-fn select_from_table(planner_and_sender_with_table: (InMemory, ResultCollector)) {
-    let (query_planner, collector) = planner_and_sender_with_table;
+fn select_from_table(planner_with_table: QueryPlanner) {
     assert_eq!(
-        query_planner.plan(&Statement::Query(Box::new(Query {
+        planner_with_table.plan(&Statement::Query(Box::new(Query {
             ctes: vec![],
             body: SetExpr::Select(Box::new(Select {
                 distinct: false,
@@ -63,6 +62,4 @@ fn select_from_table(planner_and_sender_with_table: (InMemory, ResultCollector))
             ))
         }))
     );
-
-    collector.assert_content(vec![])
 }

--- a/src/sql_model/src/sql_types.rs
+++ b/src/sql_model/src/sql_types.rs
@@ -99,8 +99,6 @@ mod tests {
 
     #[cfg(test)]
     mod to_postgresql_type_conversion {
-        use protocol::pgsql_types::PostgreSqlType;
-
         use super::*;
 
         #[test]


### PR DESCRIPTION
no issue to close

#### Description
remove `protocol`, `kernel` dependency from `query_planner` module

#### Is it a feature that change user experience?
no

#### Client output
no

