### PR TITLE
Fix to combine async_dup Arc and Mutex to avoid thread issue in test

### DIFF
--- a/src/protocol/src/tests/accept_client_request.rs
+++ b/src/protocol/src/tests/accept_client_request.rs
@@ -80,7 +80,6 @@ fn trying_read_only_length_of_ssl_message() {
 }
 
 #[test]
-#[ignore]
 fn sending_reject_notification_for_none_secure() {
     block_on(async {
         let test_case = TestCase::with_content(vec![pg_frontend::Message::SslRequired.as_vec().as_slice(), &[]]);
@@ -106,7 +105,6 @@ fn sending_reject_notification_for_none_secure() {
 }
 
 #[test]
-#[ignore]
 fn sending_accept_notification_for_ssl_only_secure() {
     block_on(async {
         let test_case = TestCase::with_content(vec![pg_frontend::Message::SslRequired.as_vec().as_slice(), &[]]);


### PR DESCRIPTION
Closes #370 

#### Description

Fixes the field `request` and `response` of `TestCase` to type `Arc<Mutex<Unblock<File>>>`.
And clones them directly in function `clone`.

#### Is it a feature that change user experience?

No

#### Client output

No