### PR TITLE
remove serial types support

### DIFF
--- a/src/ast/src/values.rs
+++ b/src/ast/src/values.rs
@@ -102,9 +102,9 @@ impl ScalarValue {
             (ScalarValue::String(str), SqlType::Bool) => Bool::from_str(str)
                 .map(ScalarValue::Bool)
                 .map_err(|_err| OperationError(NotSupportedOperation::ImplicitCast(self.clone(), *to_type))),
-            (ScalarValue::String(str), SqlType::SmallInt(_))
-            | (ScalarValue::String(str), SqlType::Integer(_))
-            | (ScalarValue::String(str), SqlType::BigInt(_))
+            (ScalarValue::String(str), SqlType::SmallInt)
+            | (ScalarValue::String(str), SqlType::Integer)
+            | (ScalarValue::String(str), SqlType::BigInt)
             | (ScalarValue::String(str), SqlType::Real)
             | (ScalarValue::String(str), SqlType::DoublePrecision) => BigDecimal::from_str(str)
                 .map(ScalarValue::Number)
@@ -113,9 +113,9 @@ impl ScalarValue {
             | (ScalarValue::Bool(Bool(boolean)), SqlType::VarChar(len)) => Ok(ScalarValue::String(
                 boolean.to_string().chars().take(*len as usize).collect(),
             )),
-            (ScalarValue::Bool(Bool(boolean)), SqlType::SmallInt(_))
-            | (ScalarValue::Bool(Bool(boolean)), SqlType::Integer(_))
-            | (ScalarValue::Bool(Bool(boolean)), SqlType::BigInt(_))
+            (ScalarValue::Bool(Bool(boolean)), SqlType::SmallInt)
+            | (ScalarValue::Bool(Bool(boolean)), SqlType::Integer)
+            | (ScalarValue::Bool(Bool(boolean)), SqlType::BigInt)
             | (ScalarValue::Bool(Bool(boolean)), SqlType::Real)
             | (ScalarValue::Bool(Bool(boolean)), SqlType::DoublePrecision) => {
                 if *boolean {
@@ -128,9 +128,9 @@ impl ScalarValue {
             (ScalarValue::String(str), SqlType::Char(_)) | (ScalarValue::String(str), SqlType::VarChar(_)) => {
                 Ok(ScalarValue::String(str.trim().to_owned()))
             }
-            (ScalarValue::Number(number), SqlType::SmallInt(_))
-            | (ScalarValue::Number(number), SqlType::Integer(_))
-            | (ScalarValue::Number(number), SqlType::BigInt(_))
+            (ScalarValue::Number(number), SqlType::SmallInt)
+            | (ScalarValue::Number(number), SqlType::Integer)
+            | (ScalarValue::Number(number), SqlType::BigInt)
             | (ScalarValue::Number(number), SqlType::Real)
             | (ScalarValue::Number(number), SqlType::DoublePrecision) => Ok(ScalarValue::Number(number.clone())),
             (ScalarValue::Bool(Bool(boolean)), SqlType::Bool) => Ok(ScalarValue::Bool(Bool(*boolean))),
@@ -326,15 +326,15 @@ mod tests {
         #[test]
         fn string_to_number() {
             assert_eq!(
-                ScalarValue::String("123".to_owned()).cast(&SqlType::SmallInt(i16::min_value())),
+                ScalarValue::String("123".to_owned()).cast(&SqlType::SmallInt),
                 Ok(ScalarValue::Number(BigDecimal::from(123i32)))
             );
             assert_eq!(
-                ScalarValue::String("123".to_owned()).cast(&SqlType::Integer(i32::min_value())),
+                ScalarValue::String("123".to_owned()).cast(&SqlType::Integer),
                 Ok(ScalarValue::Number(BigDecimal::from(123i32)))
             );
             assert_eq!(
-                ScalarValue::String("123".to_owned()).cast(&SqlType::BigInt(i64::min_value())),
+                ScalarValue::String("123".to_owned()).cast(&SqlType::BigInt),
                 Ok(ScalarValue::Number(BigDecimal::from(123i32)))
             );
             assert_eq!(
@@ -350,10 +350,10 @@ mod tests {
         #[test]
         fn not_supported_string_to_number() {
             assert_eq!(
-                ScalarValue::String("not a number".to_owned()).cast(&SqlType::Integer(i32::min_value())),
+                ScalarValue::String("not a number".to_owned()).cast(&SqlType::Integer),
                 Err(OperationError(NotSupportedOperation::ImplicitCast(
                     ScalarValue::String("not a number".to_owned()),
-                    SqlType::Integer(i32::min_value())
+                    SqlType::Integer
                 )))
             );
         }
@@ -385,15 +385,15 @@ mod tests {
         #[test]
         fn bool_to_number() {
             assert_eq!(
-                ScalarValue::Bool(Bool(true)).cast(&SqlType::SmallInt(i16::min_value())),
+                ScalarValue::Bool(Bool(true)).cast(&SqlType::SmallInt),
                 Ok(ScalarValue::Number(BigDecimal::from(1)))
             );
             assert_eq!(
-                ScalarValue::Bool(Bool(false)).cast(&SqlType::Integer(i32::min_value())),
+                ScalarValue::Bool(Bool(false)).cast(&SqlType::Integer),
                 Ok(ScalarValue::Number(BigDecimal::from(0)))
             );
             assert_eq!(
-                ScalarValue::Bool(Bool(true)).cast(&SqlType::BigInt(i64::min_value())),
+                ScalarValue::Bool(Bool(true)).cast(&SqlType::BigInt),
                 Ok(ScalarValue::Number(BigDecimal::from(1)))
             );
             assert_eq!(
@@ -408,18 +408,9 @@ mod tests {
 
         #[test]
         fn null_is_always_null() {
-            assert_eq!(
-                ScalarValue::Null.cast(&SqlType::SmallInt(i16::min_value())),
-                Ok(ScalarValue::Null)
-            );
-            assert_eq!(
-                ScalarValue::Null.cast(&SqlType::Integer(i32::min_value())),
-                Ok(ScalarValue::Null)
-            );
-            assert_eq!(
-                ScalarValue::Null.cast(&SqlType::BigInt(i64::min_value())),
-                Ok(ScalarValue::Null)
-            );
+            assert_eq!(ScalarValue::Null.cast(&SqlType::SmallInt), Ok(ScalarValue::Null));
+            assert_eq!(ScalarValue::Null.cast(&SqlType::Integer), Ok(ScalarValue::Null));
+            assert_eq!(ScalarValue::Null.cast(&SqlType::BigInt), Ok(ScalarValue::Null));
             assert_eq!(ScalarValue::Null.cast(&SqlType::Real), Ok(ScalarValue::Null));
             assert_eq!(ScalarValue::Null.cast(&SqlType::DoublePrecision), Ok(ScalarValue::Null));
             assert_eq!(ScalarValue::Null.cast(&SqlType::Char(1)), Ok(ScalarValue::Null));
@@ -450,7 +441,7 @@ mod tests {
         #[test]
         fn number_to_number() {
             assert_eq!(
-                ScalarValue::Number(BigDecimal::from_str("123").unwrap()).cast(&SqlType::SmallInt(i16::min_value())),
+                ScalarValue::Number(BigDecimal::from_str("123").unwrap()).cast(&SqlType::SmallInt),
                 Ok(ScalarValue::Number(BigDecimal::from(123)))
             );
             assert_eq!(
@@ -460,7 +451,7 @@ mod tests {
                     )
                     .unwrap()
                 )
-                .cast(&SqlType::SmallInt(i16::min_value())),
+                .cast(&SqlType::SmallInt),
                 Ok(ScalarValue::Number(
                     BigDecimal::from_str(
                         "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
@@ -469,7 +460,7 @@ mod tests {
                 ))
             );
             assert_eq!(
-                ScalarValue::Number(BigDecimal::from_str("123").unwrap()).cast(&SqlType::Integer(i32::min_value())),
+                ScalarValue::Number(BigDecimal::from_str("123").unwrap()).cast(&SqlType::Integer),
                 Ok(ScalarValue::Number(BigDecimal::from(123)))
             );
             assert_eq!(
@@ -479,7 +470,7 @@ mod tests {
                     )
                     .unwrap()
                 )
-                .cast(&SqlType::Integer(i32::min_value())),
+                .cast(&SqlType::Integer),
                 Ok(ScalarValue::Number(
                     BigDecimal::from_str(
                         "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
@@ -488,7 +479,7 @@ mod tests {
                 ))
             );
             assert_eq!(
-                ScalarValue::Number(BigDecimal::from_str("123").unwrap()).cast(&SqlType::BigInt(i64::min_value())),
+                ScalarValue::Number(BigDecimal::from_str("123").unwrap()).cast(&SqlType::BigInt),
                 Ok(ScalarValue::Number(BigDecimal::from(123)))
             );
             assert_eq!(
@@ -498,7 +489,7 @@ mod tests {
                     )
                     .unwrap()
                 )
-                .cast(&SqlType::BigInt(i64::min_value())),
+                .cast(&SqlType::BigInt),
                 Ok(ScalarValue::Number(
                     BigDecimal::from_str(
                         "12345678901234567890123456789012345678901234567890123456789012345678901234567890"

--- a/src/binary/src/lib.rs
+++ b/src/binary/src/lib.rs
@@ -84,8 +84,8 @@ fn read_tag(data: &[u8], idx: &mut usize) -> TypeTag {
 pub struct Binary(Vec<u8>);
 
 impl Binary {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new() -> Binary {
+        Binary::default()
     }
 
     #[allow(clippy::wrong_self_convention)]
@@ -93,15 +93,14 @@ impl Binary {
         self.0.as_slice()
     }
 
-    pub fn with_data(data: Vec<u8>) -> Self {
-        Self(data)
+    pub fn with_data(data: Vec<u8>) -> Binary {
+        Binary(data)
     }
 
-    pub fn pack<'a>(other: &[Datum<'a>]) -> Self {
+    pub fn pack<'a>(other: &[Datum<'a>]) -> Binary {
         use std::ops::Deref;
-        let size = other.iter().fold(0usize, |acc, datum| acc + datum.size());
+        let size = other.iter().map(Datum::size).sum();
         let mut data = Vec::with_capacity(size);
-        // this is not a very smart way of doing this, this just to get it working.
         for datum in other {
             match datum {
                 Datum::<'a>::True => {

--- a/src/data_manager/src/tests/queries.rs
+++ b/src/data_manager/src/tests/queries.rs
@@ -24,10 +24,7 @@ fn delete_all_from_table(data_manager_with_schema: InMemory) {
         .create_table(
             schema_id,
             "table_name",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value()),
-            )],
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)],
         )
         .expect("table is created");
 
@@ -87,9 +84,9 @@ fn with_small_ints_table(data_manager_with_schema: InMemory) -> InMemory {
             schema_id,
             "table_name",
             &[
-                ColumnDefinition::new("column_1", SqlType::SmallInt(i16::min_value())),
-                ColumnDefinition::new("column_2", SqlType::SmallInt(i16::min_value())),
-                ColumnDefinition::new("column_3", SqlType::SmallInt(i16::min_value())),
+                ColumnDefinition::new("column_1", SqlType::SmallInt),
+                ColumnDefinition::new("column_2", SqlType::SmallInt),
+                ColumnDefinition::new("column_3", SqlType::SmallInt),
             ],
         )
         .expect("table is created");

--- a/src/data_manager/src/tests/schema.rs
+++ b/src/data_manager/src/tests/schema.rs
@@ -30,10 +30,7 @@ fn same_table_names_with_different_columns_in_different_schemas(data_manager: In
         .create_table(
             schema_1_id,
             "table_name",
-            &[ColumnDefinition::new(
-                "sn_1_column",
-                SqlType::SmallInt(i16::min_value()),
-            )],
+            &[ColumnDefinition::new("sn_1_column", SqlType::SmallInt)],
         )
         .expect("table is created");
 
@@ -41,23 +38,17 @@ fn same_table_names_with_different_columns_in_different_schemas(data_manager: In
         .create_table(
             schema_2_id,
             "table_name",
-            &[ColumnDefinition::new("sn_2_column", SqlType::BigInt(i64::min_value()))],
+            &[ColumnDefinition::new("sn_2_column", SqlType::BigInt)],
         )
         .expect("table is created");
 
     assert_eq!(
         data_manager.table_columns(&Box::new((schema_1_id, table_1_id))),
-        Ok(vec![ColumnDefinition::new(
-            "sn_1_column",
-            SqlType::SmallInt(i16::min_value()),
-        )])
+        Ok(vec![ColumnDefinition::new("sn_1_column", SqlType::SmallInt,)])
     );
     assert_eq!(
         data_manager.table_columns(&Box::new((schema_2_id, table_2_id))),
-        Ok(vec![ColumnDefinition::new(
-            "sn_2_column",
-            SqlType::BigInt(i64::min_value()),
-        )])
+        Ok(vec![ColumnDefinition::new("sn_2_column", SqlType::BigInt,)])
     );
 }
 
@@ -95,20 +86,14 @@ fn cascade_drop_schema_drops_tables_in_it(data_manager_with_schema: InMemory) {
         .create_table(
             schema_id,
             "table_name_1",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value()),
-            )],
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)],
         )
         .expect("table is created");
     data_manager_with_schema
         .create_table(
             schema_id,
             "table_name_2",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value()),
-            )],
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)],
         )
         .expect("table is created");
 
@@ -123,10 +108,7 @@ fn cascade_drop_schema_drops_tables_in_it(data_manager_with_schema: InMemory) {
         data_manager_with_schema.create_table(
             schema_id,
             "table_name_1",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value())
-            )]
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)]
         ),
         Ok(_)
     ));
@@ -134,10 +116,7 @@ fn cascade_drop_schema_drops_tables_in_it(data_manager_with_schema: InMemory) {
         data_manager_with_schema.create_table(
             schema_id,
             "table_name_2",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value())
-            )]
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)]
         ),
         Ok(_)
     ));

--- a/src/data_manager/src/tests/table.rs
+++ b/src/data_manager/src/tests/table.rs
@@ -22,10 +22,7 @@ fn create_tables_with_different_names(data_manager_with_schema: InMemory) {
         data_manager_with_schema.create_table(
             schema_id,
             "table_name_1",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value())
-            )]
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)]
         ),
         Ok(_)
     ));
@@ -33,10 +30,7 @@ fn create_tables_with_different_names(data_manager_with_schema: InMemory) {
         data_manager_with_schema.create_table(
             schema_id,
             "table_name_2",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value())
-            )]
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)]
         ),
         Ok(_)
     ));
@@ -51,10 +45,7 @@ fn create_table_with_the_same_name_in_different_schemas(data_manager: InMemory) 
         data_manager.create_table(
             schema_1_id,
             "table_name",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value())
-            )]
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)]
         ),
         Ok(_)
     ));
@@ -63,10 +54,7 @@ fn create_table_with_the_same_name_in_different_schemas(data_manager: InMemory) 
         data_manager.create_table(
             schema_2_id,
             "table_name",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value())
-            )]
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)]
         ),
         Ok(_)
     ));
@@ -79,10 +67,7 @@ fn drop_table(data_manager_with_schema: InMemory) {
         .create_table(
             schema_id,
             "table_name",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value()),
-            )],
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)],
         )
         .expect("table is created");
 
@@ -94,10 +79,7 @@ fn drop_table(data_manager_with_schema: InMemory) {
         data_manager_with_schema.create_table(
             schema_id,
             "table_name",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value())
-            )]
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)]
         ),
         Ok(_)
     ));
@@ -126,10 +108,7 @@ fn table_ids_for_existing_columns(data_manager_with_schema: InMemory) {
         .create_table(
             schema_id,
             "table_name",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value()),
-            )],
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)],
         )
         .expect("table is created");
 
@@ -146,10 +125,7 @@ fn table_ids_for_non_existing_columns(data_manager_with_schema: InMemory) {
         .create_table(
             schema_id,
             "table_name",
-            &[ColumnDefinition::new(
-                "column_test",
-                SqlType::SmallInt(i16::min_value()),
-            )],
+            &[ColumnDefinition::new("column_test", SqlType::SmallInt)],
         )
         .expect("table is created");
 

--- a/src/metadata/src/lib.rs
+++ b/src/metadata/src/lib.rs
@@ -337,7 +337,7 @@ fn tables_table_types() -> [ColumnDefinition; 3] {
 /// TABLE_SCHEMA        varchar(255)
 /// TABLE_NAME          varchar(255)
 /// COLUMN_NAME         varchar(255)
-/// ORDINAL_POSITION    integer > 0
+/// ORDINAL_POSITION    integer check (ORDINAL_POSITION > 0)
 #[allow(dead_code)]
 fn columns_table_types() -> [ColumnDefinition; 5] {
     [
@@ -345,7 +345,7 @@ fn columns_table_types() -> [ColumnDefinition; 5] {
         ColumnDefinition::new("TABLE_SCHEMA", SqlType::VarChar(255)),
         ColumnDefinition::new("TABLE_NAME", SqlType::VarChar(255)),
         ColumnDefinition::new("COLUMN_NAME", SqlType::VarChar(255)),
-        ColumnDefinition::new("ORDINAL_POSITION", SqlType::Integer(1)),
+        ColumnDefinition::new("ORDINAL_POSITION", SqlType::Integer),
     ]
 }
 
@@ -1333,11 +1333,11 @@ mod tests {
                 DEFAULT_CATALOG,
                 "schema_name",
                 "table_name",
-                &[ColumnDefinition::new("col1", SqlType::Integer(0))],
+                &[ColumnDefinition::new("col1", SqlType::Integer)],
             ) {
                 Some((_, Some((schema_id, Some(table_id))))) => assert_eq!(
                     data_definition.table_columns(&Box::new((schema_id, table_id))),
-                    Ok(vec![ColumnDefinition::new("col1", SqlType::Integer(0))])
+                    Ok(vec![ColumnDefinition::new("col1", SqlType::Integer)])
                 ),
                 _ => panic!(),
             }
@@ -1377,7 +1377,7 @@ mod tests {
                 DEFAULT_CATALOG,
                 "schema_name",
                 "table_name",
-                &[ColumnDefinition::new("col1", SqlType::Integer(0))],
+                &[ColumnDefinition::new("col1", SqlType::Integer)],
             ) {
                 Some((_, Some((schema_id, Some(table_id))))) => assert_eq!(
                     data_definition.column_ids(&Box::new((schema_id, table_id)), &["col1".to_owned()]),
@@ -1421,11 +1421,11 @@ mod tests {
                 DEFAULT_CATALOG,
                 "schema_name",
                 "table_name",
-                &[ColumnDefinition::new("col1", SqlType::Integer(0))],
+                &[ColumnDefinition::new("col1", SqlType::Integer)],
             ) {
                 Some((_, Some((schema_id, Some(table_id))))) => assert_eq!(
                     data_definition.column_defs(&Box::new((schema_id, table_id)), &[0]),
-                    vec![ColumnDefinition::new("col1", SqlType::Integer(0))]
+                    vec![ColumnDefinition::new("col1", SqlType::Integer)]
                 ),
                 _ => panic!(),
             }
@@ -1441,7 +1441,7 @@ mod tests {
                 DEFAULT_CATALOG,
                 "schema_name",
                 "table_name",
-                &[ColumnDefinition::new("col1", SqlType::Integer(0))],
+                &[ColumnDefinition::new("col1", SqlType::Integer)],
             ) {
                 Some((_, Some((schema_id, Some(table_id))))) => assert_eq!(
                     data_definition.column_defs(&Box::new((schema_id, table_id)), &[1]),
@@ -1783,7 +1783,7 @@ mod tests {
                     DEFAULT_CATALOG,
                     "schema_name",
                     "table_name",
-                    &[ColumnDefinition::new("col_1", SqlType::Integer(0))],
+                    &[ColumnDefinition::new("col_1", SqlType::Integer)],
                 );
                 drop(data_definition);
 
@@ -1807,7 +1807,7 @@ mod tests {
                     DEFAULT_CATALOG,
                     "schema_name_1",
                     "table_name",
-                    &[ColumnDefinition::new("col_1", SqlType::Integer(0))],
+                    &[ColumnDefinition::new("col_1", SqlType::Integer)],
                 ) {
                     Some((_, Some((schema_id, Some(table_id))))) => Box::new((schema_id, table_id)),
                     _ => panic!(),
@@ -1817,18 +1817,18 @@ mod tests {
                     DEFAULT_CATALOG,
                     "schema_name_2",
                     "table_name",
-                    &[ColumnDefinition::new("col_1", SqlType::SmallInt(0))],
+                    &[ColumnDefinition::new("col_1", SqlType::SmallInt)],
                 ) {
                     Some((_, Some((schema_id, Some(table_id))))) => Box::new((schema_id, table_id)),
                     _ => panic!(),
                 };
                 assert_eq!(
                     data_definition.table_columns(&full_table_1_id),
-                    Ok(vec![ColumnDefinition::new("col_1", SqlType::Integer(0))])
+                    Ok(vec![ColumnDefinition::new("col_1", SqlType::Integer)])
                 );
                 assert_eq!(
                     data_definition.table_columns(&full_table_2_id),
-                    Ok(vec![ColumnDefinition::new("col_1", SqlType::SmallInt(0))])
+                    Ok(vec![ColumnDefinition::new("col_1", SqlType::SmallInt)])
                 );
                 drop(data_definition);
 
@@ -1838,11 +1838,11 @@ mod tests {
 
                 assert_eq!(
                     data_definition.table_columns(&full_table_1_id),
-                    Ok(vec![ColumnDefinition::new("col_1", SqlType::Integer(0))])
+                    Ok(vec![ColumnDefinition::new("col_1", SqlType::Integer)])
                 );
                 assert_eq!(
                     data_definition.table_columns(&full_table_2_id),
-                    Ok(vec![ColumnDefinition::new("col_1", SqlType::SmallInt(0))])
+                    Ok(vec![ColumnDefinition::new("col_1", SqlType::SmallInt)])
                 );
             }
 
@@ -1855,7 +1855,7 @@ mod tests {
                     DEFAULT_CATALOG,
                     "schema_name",
                     "table_name",
-                    &[ColumnDefinition::new("col_1", SqlType::Integer(0))],
+                    &[ColumnDefinition::new("col_1", SqlType::Integer)],
                 );
                 assert!(matches!(
                     data_definition.table_exists(&"schema_name", &"table_name"),
@@ -1887,9 +1887,9 @@ mod tests {
                     "schema_name",
                     "table_name",
                     &[
-                        ColumnDefinition::new("col_1", SqlType::SmallInt(0)),
-                        ColumnDefinition::new("col_2", SqlType::Integer(0)),
-                        ColumnDefinition::new("col_3", SqlType::BigInt(0)),
+                        ColumnDefinition::new("col_1", SqlType::SmallInt),
+                        ColumnDefinition::new("col_2", SqlType::Integer),
+                        ColumnDefinition::new("col_3", SqlType::BigInt),
                     ],
                 ) {
                     Some((_, Some((schema_id, Some(table_id))))) => Box::new((schema_id, table_id)),
@@ -1898,9 +1898,9 @@ mod tests {
                 assert_eq!(
                     data_definition.table_columns(&full_table_id),
                     Ok(vec![
-                        ColumnDefinition::new("col_1", SqlType::SmallInt(0)),
-                        ColumnDefinition::new("col_2", SqlType::Integer(0)),
-                        ColumnDefinition::new("col_3", SqlType::BigInt(0))
+                        ColumnDefinition::new("col_1", SqlType::SmallInt),
+                        ColumnDefinition::new("col_2", SqlType::Integer),
+                        ColumnDefinition::new("col_3", SqlType::BigInt)
                     ])
                 );
                 drop(data_definition);
@@ -1911,9 +1911,9 @@ mod tests {
                 assert_eq!(
                     data_definition.table_columns(&full_table_id),
                     Ok(vec![
-                        ColumnDefinition::new("col_1", SqlType::SmallInt(0)),
-                        ColumnDefinition::new("col_2", SqlType::Integer(0)),
-                        ColumnDefinition::new("col_3", SqlType::BigInt(0))
+                        ColumnDefinition::new("col_1", SqlType::SmallInt),
+                        ColumnDefinition::new("col_2", SqlType::Integer),
+                        ColumnDefinition::new("col_3", SqlType::BigInt)
                     ])
                 );
             }
@@ -1927,7 +1927,7 @@ mod tests {
                     DEFAULT_CATALOG,
                     "schema_name",
                     "table_name",
-                    &[ColumnDefinition::new("col_1", SqlType::SmallInt(0))],
+                    &[ColumnDefinition::new("col_1", SqlType::SmallInt)],
                 ) {
                     Some((_, Some((schema_id, Some(table_id))))) => Box::new((schema_id, table_id)),
                     _ => panic!(),
@@ -1977,7 +1977,7 @@ mod tests {
                     DEFAULT_CATALOG,
                     "schema_name",
                     "table_name",
-                    &[ColumnDefinition::new("col_1", SqlType::SmallInt(0))],
+                    &[ColumnDefinition::new("col_1", SqlType::SmallInt)],
                 ) {
                     Some((_, Some((schema_id, Some(table_id))))) => Box::new((schema_id, table_id)),
                     _ => panic!(),

--- a/src/node/src/query_engine/tests/insert.rs
+++ b/src/node/src/query_engine/tests/insert.rs
@@ -221,20 +221,22 @@ fn insert_and_select_different_integer_types(database_with_schema: (InMemory, Re
     let (mut engine, collector) = database_with_schema;
     engine
         .execute(Command::Query {
-    sql: "create table schema_name.table_name (column_si smallint, column_i integer, column_bi bigint, column_serial serial);".to_owned()
-        }).expect("query executed");
+            sql: "create table schema_name.table_name (column_si smallint, column_i integer, column_bi bigint);"
+                .to_owned(),
+        })
+        .expect("query executed");
     collector.assert_receive_single(Ok(QueryEvent::TableCreated));
 
     engine
         .execute(Command::Query {
-            sql: "insert into schema_name.table_name values(-32768, -2147483648, -9223372036854775808, 1);".to_owned(),
+            sql: "insert into schema_name.table_name values(-32768, -2147483648, -9223372036854775808);".to_owned(),
         })
         .expect("query executed");
     collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
 
     engine
         .execute(Command::Query {
-            sql: "insert into schema_name.table_name values(32767, 2147483647, 9223372036854775807, 1);".to_owned(),
+            sql: "insert into schema_name.table_name values(32767, 2147483647, 9223372036854775807);".to_owned(),
         })
         .expect("query executed");
     collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
@@ -249,19 +251,16 @@ fn insert_and_select_different_integer_types(database_with_schema: (InMemory, Re
             PostgreSqlType::SmallInt.as_column_metadata("column_si"),
             PostgreSqlType::Integer.as_column_metadata("column_i"),
             PostgreSqlType::BigInt.as_column_metadata("column_bi"),
-            PostgreSqlType::Integer.as_column_metadata("column_serial"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "-32768".to_owned(),
             "-2147483648".to_owned(),
             "-9223372036854775808".to_owned(),
-            "1".to_owned(),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "32767".to_owned(),
             "2147483647".to_owned(),
             "9223372036854775807".to_owned(),
-            "1".to_owned(),
         ])),
         Ok(QueryEvent::RecordsSelected(2)),
     ]);

--- a/src/node/src/query_engine/tests/table.rs
+++ b/src/node/src/query_engine/tests/table.rs
@@ -173,21 +173,4 @@ mod different_types {
 
         collector.assert_receive_single(Ok(QueryEvent::TableCreated));
     }
-
-    #[rstest::rstest]
-    fn serials(database_with_schema: (InMemory, ResultCollector)) {
-        let (mut engine, collector) = database_with_schema;
-        engine
-            .execute(Command::Query {
-                sql: "create table schema_name.table_name (\
-            column_smalls smallserial,\
-            column_s serial,\
-            column_bigs bigserial\
-            );"
-                .to_owned(),
-            })
-            .expect("query executed");
-
-        collector.assert_receive_single(Ok(QueryEvent::TableCreated));
-    }
 }

--- a/src/pg_model/Cargo.toml
+++ b/src/pg_model/Cargo.toml
@@ -6,12 +6,11 @@ edition = "2018"
 publish = false
 
 [dependencies]
-pg_wire = "0.1.0"
-
 bigdecimal = { version = "0.2.0", features = ["string-only"] }
 byteorder = "1.3.4"
 # TODO get rid off dependency
 sqlparser = { git = "https://github.com/ballista-compute/sqlparser-rs.git", branch = "main", features = ["bigdecimal"] }
+pg_wire = "0.1.0"
 rand = "0.7"
 
 [dev-dependencies]

--- a/src/query_analyzer/src/lib.rs
+++ b/src/query_analyzer/src/lib.rs
@@ -153,7 +153,7 @@ mod tests {
             DEFAULT_CATALOG,
             SCHEMA,
             TABLE,
-            &[ColumnDefinition::new("col", SqlType::SmallInt(i16::min_value()))],
+            &[ColumnDefinition::new("col", SqlType::SmallInt)],
         ) {
             Some((_, Some((_, Some(table_id))))) => table_id,
             _ => panic!(),
@@ -165,7 +165,7 @@ mod tests {
             description,
             Ok(Description::Insert(InsertStatement {
                 table_id: FullTableId::from((schema_id, table_id)),
-                sql_types: vec![SqlType::SmallInt(i16::min_value())]
+                sql_types: vec![SqlType::SmallInt]
             }))
         );
     }

--- a/src/query_planner/src/tests/create_table.rs
+++ b/src/query_planner/src/tests/create_table.rs
@@ -111,10 +111,7 @@ fn create_table(planner_with_schema: QueryPlanner) {
         Ok(Plan::CreateTable(TableCreationInfo::new(
             0,
             TABLE,
-            vec![ColumnDefinition::new(
-                "column_name",
-                SqlType::SmallInt(i16::min_value())
-            )]
+            vec![ColumnDefinition::new("column_name", SqlType::SmallInt)]
         )))
     );
 }

--- a/src/query_planner/src/tests/insert.rs
+++ b/src/query_planner/src/tests/insert.rs
@@ -124,14 +124,9 @@ fn insert_into_table(planner_with_table: QueryPlanner) {
         Ok(Plan::Insert(TableInserts {
             table_id: FullTableId::from((0, 0)),
             column_indices: vec![
-                (
-                    0,
-                    "small_int".to_owned(),
-                    SqlType::SmallInt(0),
-                    TypeConstraint::SmallInt(0)
-                ),
-                (1, "integer".to_owned(), SqlType::Integer(0), TypeConstraint::Integer(0)),
-                (2, "big_int".to_owned(), SqlType::BigInt(0), TypeConstraint::BigInt(0))
+                (0, "small_int".to_owned(), SqlType::SmallInt, TypeConstraint::SmallInt),
+                (1, "integer".to_owned(), SqlType::Integer, TypeConstraint::Integer),
+                (2, "big_int".to_owned(), SqlType::BigInt, TypeConstraint::BigInt)
             ],
             input: vec![]
         }))
@@ -156,14 +151,9 @@ fn insert_into_table_without_columns(planner_with_table: QueryPlanner) {
         Ok(Plan::Insert(TableInserts {
             table_id: FullTableId::from((0, 0)),
             column_indices: vec![
-                (
-                    0,
-                    "small_int".to_owned(),
-                    SqlType::SmallInt(0),
-                    TypeConstraint::SmallInt(0)
-                ),
-                (1, "integer".to_owned(), SqlType::Integer(0), TypeConstraint::Integer(0)),
-                (2, "big_int".to_owned(), SqlType::BigInt(0), TypeConstraint::BigInt(0))
+                (0, "small_int".to_owned(), SqlType::SmallInt, TypeConstraint::SmallInt),
+                (1, "integer".to_owned(), SqlType::Integer, TypeConstraint::Integer),
+                (2, "big_int".to_owned(), SqlType::BigInt, TypeConstraint::BigInt)
             ],
             input: vec![]
         }))

--- a/src/query_planner/src/tests/mod.rs
+++ b/src/query_planner/src/tests/mod.rs
@@ -66,9 +66,9 @@ fn planner_with_table() -> QueryPlanner {
             SCHEMA,
             TABLE,
             &[
-                ColumnDefinition::new("small_int", SqlType::SmallInt(0)),
-                ColumnDefinition::new("integer", SqlType::Integer(0)),
-                ColumnDefinition::new("big_int", SqlType::BigInt(0)),
+                ColumnDefinition::new("small_int", SqlType::SmallInt),
+                ColumnDefinition::new("integer", SqlType::Integer),
+                ColumnDefinition::new("big_int", SqlType::BigInt),
             ],
         )
         .expect("table created");

--- a/src/query_planner/src/tests/update.rs
+++ b/src/query_planner/src/tests/update.rs
@@ -98,12 +98,7 @@ fn update_table(planner_with_table: QueryPlanner) {
         }),
         Ok(Plan::Update(TableUpdates {
             table_id: FullTableId::from((0, 0)),
-            column_indices: vec![(
-                0,
-                "small_int".to_owned(),
-                SqlType::SmallInt(0),
-                TypeConstraint::SmallInt(0)
-            )],
+            column_indices: vec![(0, "small_int".to_owned(), SqlType::SmallInt, TypeConstraint::SmallInt)],
             input: vec![ScalarOp::Value(ScalarValue::String("".to_string()))],
         }))
     );

--- a/src/sql_model/src/sql_types.rs
+++ b/src/sql_model/src/sql_types.rs
@@ -24,9 +24,9 @@ pub enum SqlType {
     Bool,
     Char(u64),
     VarChar(u64),
-    SmallInt(i16),
-    Integer(i32),
-    BigInt(i64),
+    SmallInt,
+    Integer,
+    BigInt,
     Real,
     DoublePrecision,
 }
@@ -36,21 +36,12 @@ impl TryFrom<&DataType> for SqlType {
 
     fn try_from(data_type: &DataType) -> Result<Self, Self::Error> {
         match data_type {
-            DataType::SmallInt => Ok(SqlType::SmallInt(i16::min_value())),
-            DataType::Int => Ok(SqlType::Integer(i32::min_value())),
-            DataType::BigInt => Ok(SqlType::BigInt(i64::min_value())),
+            DataType::SmallInt => Ok(SqlType::SmallInt),
+            DataType::Int => Ok(SqlType::Integer),
+            DataType::BigInt => Ok(SqlType::BigInt),
             DataType::Char(len) => Ok(SqlType::Char(len.unwrap_or(255))),
             DataType::Varchar(len) => Ok(SqlType::VarChar(len.unwrap_or(255))),
             DataType::Boolean => Ok(SqlType::Bool),
-            DataType::Custom(name) => {
-                let name = name.to_string();
-                match name.as_str() {
-                    "serial" => Ok(SqlType::Integer(1)),
-                    "smallserial" => Ok(SqlType::SmallInt(1)),
-                    "bigserial" => Ok(SqlType::BigInt(1)),
-                    _other_type => Err(NotSupportedType(data_type.clone())),
-                }
-            }
             other_type => Err(NotSupportedType(other_type.clone())),
         }
     }
@@ -70,9 +61,9 @@ impl Display for SqlType {
             SqlType::Bool => write!(f, "bool"),
             SqlType::Char(len) => write!(f, "char({})", len),
             SqlType::VarChar(len) => write!(f, "varchar({})", len),
-            SqlType::SmallInt(_) => write!(f, "smallint"),
-            SqlType::Integer(_) => write!(f, "integer"),
-            SqlType::BigInt(_) => write!(f, "bigint"),
+            SqlType::SmallInt => write!(f, "smallint"),
+            SqlType::Integer => write!(f, "integer"),
+            SqlType::BigInt => write!(f, "bigint"),
             SqlType::Real => write!(f, "real"),
             SqlType::DoublePrecision => write!(f, "double precision"),
         }
@@ -85,9 +76,9 @@ impl Into<PostgreSqlType> for &SqlType {
             SqlType::Bool => PostgreSqlType::Bool,
             SqlType::Char(_) => PostgreSqlType::Char,
             SqlType::VarChar(_) => PostgreSqlType::VarChar,
-            SqlType::SmallInt(_) => PostgreSqlType::SmallInt,
-            SqlType::Integer(_) => PostgreSqlType::Integer,
-            SqlType::BigInt(_) => PostgreSqlType::BigInt,
+            SqlType::SmallInt => PostgreSqlType::SmallInt,
+            SqlType::Integer => PostgreSqlType::Integer,
+            SqlType::BigInt => PostgreSqlType::BigInt,
             SqlType::Real => PostgreSqlType::Real,
             SqlType::DoublePrecision => PostgreSqlType::DoublePrecision,
         }
@@ -110,19 +101,19 @@ mod tests {
 
         #[test]
         fn small_int() {
-            let pg_type: PostgreSqlType = (&SqlType::SmallInt(i16::min_value())).into();
+            let pg_type: PostgreSqlType = (&SqlType::SmallInt).into();
             assert_eq!(pg_type, PostgreSqlType::SmallInt);
         }
 
         #[test]
         fn integer() {
-            let pg_type: PostgreSqlType = (&SqlType::Integer(i32::min_value())).into();
+            let pg_type: PostgreSqlType = (&SqlType::Integer).into();
             assert_eq!(pg_type, PostgreSqlType::Integer);
         }
 
         #[test]
         fn big_int() {
-            let pg_type: PostgreSqlType = (&SqlType::BigInt(i64::min_value())).into();
+            let pg_type: PostgreSqlType = (&SqlType::BigInt).into();
             assert_eq!(pg_type, PostgreSqlType::BigInt);
         }
 


### PR DESCRIPTION
No issue to close

#### Description
`smallserial`, `serial` and `bigserial` support are removed as they were not implemented correctly

#### Is it a feature that change user experience?
no

#### Client output
yes, user can't create table with above three types

