### PR TITLE
Implement Parameter Bind on SQL Where clause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
  "gimli",
 ]
@@ -152,9 +152,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
+checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -357,11 +357,11 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -496,15 +496,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
+checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
 
 [[package]]
 name = "futures-io"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
+checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
 
 [[package]]
 name = "futures-lite"
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
+checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -535,18 +535,18 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
+checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
+checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "hermit-abi"
@@ -619,11 +619,11 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -650,9 +650,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "lock_api"
@@ -686,9 +686,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -802,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -831,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
@@ -952,18 +952,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1021,9 +1021,9 @@ checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -1181,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
+checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustc_version"
@@ -1339,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.45"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9c5432ff16d6152371f808fb5a871cd67368171b09bb21b43df8e4a47a3556"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/ast/src/predicates.rs
+++ b/src/ast/src/predicates.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use bigdecimal::BigDecimal;
-use sql_model::Id;
+use sql_model::{Id, ParameterName};
 
 #[derive(PartialEq, Clone, Debug)]
 pub enum PredicateOp {
@@ -24,4 +24,5 @@ pub enum PredicateOp {
 pub enum PredicateValue {
     Column(Id),
     Number(BigDecimal),
+    Parameter(ParameterName),
 }

--- a/src/binder/Cargo.toml
+++ b/src/binder/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 [dependencies]
 pg_wire = "0.1.0"
 
-bigdecimal = { version = "0.2.0", features = ["string-only"] }
 log = "0.4.11"
 sqlparser = { git = "https://github.com/ballista-compute/sqlparser-rs.git", branch = "main", features = ["bigdecimal"] }
 
 [dev-dependencies]
+bigdecimal = { version = "0.2.0", features = ["string-only"] }
 rstest = "0.6.4"

--- a/src/query_planner/src/select.rs
+++ b/src/query_planner/src/select.rs
@@ -112,6 +112,9 @@ impl Planner for SelectPlanner {
                                     };
                                     let r = match right.deref() {
                                         Expr::Value(Value::Number(num)) => PredicateValue::Number(num.clone()),
+                                        Expr::Identifier(Ident { value, .. }) if value.starts_with('$') => {
+                                            PredicateValue::Parameter(value[1..].to_string())
+                                        }
                                         _ => panic!(),
                                     };
                                     Some((l, o, r))

--- a/src/sql_model/src/lib.rs
+++ b/src/sql_model/src/lib.rs
@@ -20,6 +20,7 @@ pub type RecordId = Id;
 pub type CatalogId = Id;
 pub type SchemaId = Id;
 pub type TableId = (Id, Id);
+pub type ParameterName = String;
 
 pub const DEFAULT_CATALOG: &str = "public";
 pub const SYSTEM_CATALOG: &str = "system";

--- a/tests/compatibility/src/test/groovy/io/database/extended/SelectiveAttributesQueryOperationsSpec.groovy
+++ b/tests/compatibility/src/test/groovy/io/database/extended/SelectiveAttributesQueryOperationsSpec.groovy
@@ -17,6 +17,51 @@ class SelectiveAttributesQueryOperationsSpec extends ThreeSmallIntColumnTable {
     db.executeUpdate INSERT_QUERY
   }
 
+  @Ignore('Failed to Parse prepared statement with parameter type of OID zero, needs to analyze the SQL to inspect the real parameter type.')
+  def 'select{where specified column > ?}'() {
+    given:
+      String selectQuery = 'select * from SCHEMA_NAME.TABLE_NAME where COL1 > ?'
+
+    when:
+      List<GroovyRowResult> pgSelect = pg.rows selectQuery, [6]
+      List<GroovyRowResult> dbSelect = db.rows selectQuery, [6]
+
+    then:
+      println "SELECTION: ${pgSelect.inspect()}"
+    and:
+      pgSelect == dbSelect
+  }
+
+  @Ignore('Failed to Parse prepared statement with parameter type of OID zero, needs to analyze the SQL to inspect the real parameter type.')
+  def 'select{where specified ? > column}'() {
+    given:
+      String selectQuery = 'select * from SCHEMA_NAME.TABLE_NAME where ? > COL1'
+
+    when:
+      List<GroovyRowResult> pgSelect = pg.rows selectQuery, [4]
+      List<GroovyRowResult> dbSelect = db.rows selectQuery, [4]
+
+    then:
+      println "SELECTION: ${pgSelect.inspect()}"
+    and:
+      pgSelect == dbSelect
+  }
+
+  @Ignore('Failed to Parse prepared statement with parameter type of OID zero, needs to analyze the SQL to inspect the real parameter type.')
+  def 'select{where specified ? > ?}'() {
+    given:
+      String selectQuery = 'select * from SCHEMA_NAME.TABLE_NAME where ? > ?'
+
+    when:
+      List<GroovyRowResult> pgSelect = pg.rows selectQuery, [1, 0]
+      List<GroovyRowResult> dbSelect = db.rows selectQuery, [1, 0]
+
+    then:
+      println "SELECTION: ${pgSelect.inspect()}"
+    and:
+      pgSelect == dbSelect
+  }
+
   @Ignore("[Failed to execute: insert into SCHEMA_NAME.TABLE_NAME values (?, ?, ?), (?, ?, ?), (?, ?, ?) because: This connection has been closed.] happens when database executes insert")
   def 'update {specified column}'() {
     given:


### PR DESCRIPTION
Closes #275 

#### Description

Implements Parameter Bind for simple expression on SQL Where clause as below.

```
prepare fooplan (smallint) as select * from schema_name.table_name where col1 = $1
```

#### Is it a feature that change user experience?

Yes. Some database drivers could directly use Extended Protocol. And this PR updates the Bind logic for `Select` queries. 

#### Client output

```
psql (12.1, server 0.0.0)
Type "help" for help.

xxx=> create schema schema_name;
CREATE SCHEMA
xxx=> create table schema_name.table_name (col1 smallint, col2 smallint, col3 smallint);
CREATE TABLE
xxx=> insert into schema_name.table_name values (1, 2, 3);
INSERT 0 1
xxx=> prepare fooplan (smallint) as select * from schema_name.table_name where col1 = $1;
PREPARE
xxx=> execute fooplan(1);
 col1 | col2 | col3
------+------+------
    1 |    2 |    3
(1 row)
```