### PR TITLE
storing types in SYSTEM.DEFINITION_SCHEMA.DATA_TYPE_DESCROPTOR table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,6 @@ name = "binary"
 version = "0.1.0"
 dependencies = [
  "repr",
- "sql_model",
 ]
 
 [[package]]
@@ -716,6 +715,7 @@ dependencies = [
  "dashmap",
  "log",
  "meta_def",
+ "pg_model",
  "repr",
  "rstest",
  "sql_model",
@@ -1164,7 +1164,6 @@ name = "repr"
 version = "0.1.0"
 dependencies = [
  "ordered-float",
- "sql_model",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
 name = "description"
 version = "0.1.0"
 dependencies = [
+ "pg_model",
  "sql_model",
  "sqlparser",
 ]

--- a/src/ast/src/lib.rs
+++ b/src/ast/src/lib.rs
@@ -80,12 +80,10 @@ impl<'a> TryInto<ScalarValue> for &Datum<'a> {
             Datum::Int16(num) => Ok(ScalarValue::Number(BigDecimal::from(*num))),
             Datum::Int32(num) => Ok(ScalarValue::Number(BigDecimal::from(*num))),
             Datum::Int64(num) => Ok(ScalarValue::Number(BigDecimal::from(*num))),
-            Datum::UInt64(num) => Ok(ScalarValue::Number(BigDecimal::from(*num))),
             Datum::Float32(num) => Ok(ScalarValue::Number(BigDecimal::try_from(**num).unwrap())),
             Datum::Float64(num) => Ok(ScalarValue::Number(BigDecimal::try_from(**num).unwrap())),
             Datum::String(str) => Ok(ScalarValue::String(str.to_string())),
             Datum::OwnedString(str) => Ok(ScalarValue::String(str.to_owned())),
-            Datum::SqlType(_) => Err(()),
         }
     }
 }

--- a/src/binary/Cargo.toml
+++ b/src/binary/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 
 [dependencies]
 repr = { path = "../repr" }
-sql_model = { path = "../sql_model" }

--- a/src/connection/src/lib.rs
+++ b/src/connection/src/lib.rs
@@ -18,7 +18,7 @@ use blocking::Unblock;
 use byteorder::{ByteOrder, NetworkEndian};
 use futures_lite::{future::block_on, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use pg_model::{
-    pg_types::{PostgreSqlFormat, PostgreSqlType},
+    pg_types::{PgType, PostgreSqlFormat},
     results::QueryResult,
     Command, ConnId, ConnSupervisor, Encryption, ProtocolConfiguration,
 };
@@ -282,7 +282,7 @@ impl<RW: AsyncRead + AsyncWrite + Unpin> Receiver for RequestReceiver<RW> {
             } => {
                 let mut parameter_types = vec![];
                 for param_type in param_types {
-                    match PostgreSqlType::try_from(param_type) {
+                    match PgType::try_from(param_type) {
                         Ok(pg_type) => parameter_types.push(pg_type),
                         Err(_error) => return Ok(Err(Error::VerificationFailed)),
                     }

--- a/src/description/Cargo.toml
+++ b/src/description/Cargo.toml
@@ -7,5 +7,6 @@ publish = false
 
 [dependencies]
 sql_model = { path = "../sql_model" }
+pg_model = { path = "../pg_model" }
 
 sqlparser = { git = "https://github.com/ballista-compute/sqlparser-rs.git", branch = "main", features = ["bigdecimal"] }

--- a/src/metadata/Cargo.toml
+++ b/src/metadata/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 binary = { path = "../binary" }
 meta_def = { path = "../meta_def" }
+pg_model = { path = "../pg_model" }
 repr = { path = "../repr" }
 sql_model = { path = "../sql_model" }
 storage = { path = "../storage" }

--- a/src/metadata/src/lib.rs
+++ b/src/metadata/src/lib.rs
@@ -66,249 +66,21 @@ pub trait MetadataView {
 }
 
 const SYSTEM_CATALOG: &'_ str = "system";
-// CREATE SCHEMA DEFINITION_SCHEMA
-//      AUTHORIZATION DEFINITION_SCHEMA
+
 const DEFINITION_SCHEMA: &'_ str = "DEFINITION_SCHEMA";
-//CREATE TABLE CATALOG_NAMES (
-//     CATALOG_NAME    INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//                     CONSTRAINT CATALOG_NAMES_PRIMARY_KEY
-//                         PRIMARY KEY (CATALOG_NAME)
-// )
+
 const CATALOG_NAMES_TABLE: &'_ str = "CATALOG_NAMES";
-// CREATE TABLE SCHEMATA (
-//     CATALOG_NAME                    INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     SCHEMA_NAME                     INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     SCHEMA_OWNER                    INFORMATION_SCHEMA.SQL_IDENTIFIER
-//                                     CONSTRAINT
-//                                         SCHEMA_OWNER_NOT_NULL NOT NULL,
-//     DEFAULT_CHARACTER_SET_CATALOG   INFORMATION_SCHEMA.SQL_IDENTIFIER
-//                                     CONSTRAINT
-//                                         DEFAULT_CHARACTER_SET_CATALOG_NOT_NULL NOT NULL,
-//     DEFAULT_CHARACTER_SET_SCHEMA    INFORMATION_SCHEMA.SQL_IDENTIFIER
-//                                     CONSTRAINT
-//                                         DEFAULT_CHARACTER_SET_SCHEMA_NOT_NULL NOT NULL,
-//     DEFAULT_CHARACTER_SET_NAME      INFORMATION_SCHEMA.SQL_IDENTIFIER
-//                                     CONSTRAINT
-//                                         DEFAULT_CHARACTER_SET_NAME_NOT_NULL NOT NULL,
-//     SQL_PATH                        INFORMATION_SCHEMA.CHARACTER_DATA,
-//
-//     CONSTRAINT SCHEMATA_PRIMARY_KEY
-//         PRIMARY KEY (CATALOG_NAME, SCHEMA_NAME),
-//
-//     CONSTRAINT SCHEMATA_FOREIGN_KEY_AUTHORIZATIONS
-//         FOREIGN KEY (SCHEMA_OWNER)
-//         REFERENCES AUTHORIZATIONS,
-//
-//     CONSTRAINT SCHEMATA_FOREIGN_KEY_CATALOG_NAMES
-//         FOREIGN KEY (CATALOG_NAME)
-//         REFERENCES CATALOG_NAMES
-// )
 const SCHEMATA_TABLE: &'_ str = "SCHEMATA";
-// CREATE TABLE TABLES (
-//     TABLE_CATALOG                               INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     TABLE_SCHEMA                                INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     TABLE_NAME                                  INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     TABLE_TYPE                                  INFORMATION_SCHEMA.CHARACTER_DATA
-//                                                 CONSTRAINT
-//                                                     TABLE_TYPE_NOT_NULL NOT NULL
-//                                                 CONSTRAINT
-//                                                     TABLE_TYPE_CHECK CHECK (
-//                                                         TABLE_TYPE IN ('BASE TABLE', 'VIEW', 'GLOBAL TEMPORARY', 'LOCAL TEMPORARY')
-//                                                     ),
-//     SELF_REFERENCING_COLUMN_NAME                INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     REFERENCE_GENERATION                        INFORMATION_SCHEMA.CHARACTER_DATA
-//                                                 CONSTRAINT
-//                                                     REFERENCE_GENERATION_CHECK CHECK (
-//                                                         REFERENCE_GENERATION IN ('SYSTEM GENERATED', 'USER GENERATED', 'DERIVED')
-//                                                     ),
-//     USER_DEFINED_TYPE_CATALOG                   INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     USER_DEFINED_TYPE_SCHEMA                    INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     USER_DEFINED_TYPE_NAME                      INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     IS_INSERTABLE_INTO                          INFORMATION_SCHEMA.CHARACTER_DATA
-//                                                 CONSTRAINT
-//                                                     IS_INSERTABLE_INTO_NOT_NULL NOT NULL
-//                                                 CONSTRAINT
-//                                                     IS_INSERTABLE_INTO_CHECK CHECK (
-//                                                         IS_INSERTABLE_INTO IN ('YES', 'NO')
-//                                                     )
-//     IS_TYPED                                    INFORMATION_SCHEMA.CHARACTER_DATA
-//                                                 CONSTRAINT
-//                                                     IS_TYPED_NOT_NULL NOT NULL
-//                                                 CONSTRAINT
-//                                                     IS_TYPED_CHECK CHECK (IS_TYPED IN ('YES', 'NO'))
-//     COMMIT_ACTION                               INFORMATION_SCHEMA.CHARACTER_DATA
-//                                                 CONSTRAINT
-//                                                     COMMIT_ACTIONCHECK CHECK (
-//                                                         COMMIT_ACTION IN ('DELETE', 'PRESERVE')
-//                                                     ),
-//
-//     CONSTRAINT TABLES_PRIMARY_KEY
-//         PRIMARY KEY (TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME),
-//
-//     CONSTRAINT TABLES_FOREIGN_KEY_SCHEMATA
-//         FOREIGN KEY (TABLE_CATALOG, TABLE_SCHEMA)
-//         REFERENCES SCHEMATA,
-//
-//     CONSTRAINT TABLES_CHECK_TABLE_IN_COLUMNS
-//         CHECK (
-//             (TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME) IN (SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME FROM COLUMNS)
-//         ),
-//
-//     CONSTRAINT TABLES_FOREIGN_KEY_USER_DEFINED_TYPES
-//         FOREIGN KEY (USER_DEFINED_TYPE_CATALOG, USER_DEFINED_TYPE_SCHEMA, USER_DEFINED_TYPE_NAME)
-//         REFERENCES USER_DEFINED_TYPES MATCH FULL,
-//
-//     CONSTRAINT TABLES_TYPED_TABLE_CHECK CHECK (
-//         (
-//             IS_TYPED = 'YES'
-//             AND (
-//                 (USER_DEFINED_TYPE_CATALOG,
-//                     USER_DEFINED_TYPE_SCHEMA,
-//                     USER_DEFINED_TYPE_NAME,
-//                     SELF_REFERENCING_COLUMN_NAME,
-//                     REFERENCE_GENERATION) IS NOT NULL
-//                 AND
-//                 (TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, SELF_REFERENCING_COLUMN_NAME) IN
-//                     (SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME FROM COLUMNS WHERE IS_SELF_REFERENCING = 'YES')
-//             )
-//         ) OR (
-//             IS_TYPED = 'NO'
-//             AND (
-//                 USER_DEFINED_TYPE_CATALOG,
-//                 USER_DEFINED_TYPE_SCHEMA,
-//                 USER_DEFINED_TYPE_NAME,
-//                 SELF_REFERENCING_COLUMN_NAME,
-//                 REFERENCE_GENERATION ) IS NULL
-//         )
-//     ),
-//
-//     CONSTRAINT TABLES_SELF_REFERENCING_COLUMN_CHECK
-//         CHECK (
-//             (SELF_REFERENCING_COLUMN_NAME, REFERENCE_GENERATION) IS NULL
-//             OR (SELF_REFERENCING_COLUMN_NAME, REFERENCE_GENERATION) IS NOT NULL
-//         ),
-//
-//     CONSTRAINT TABLES_TEMPORARY_TABLE_CHECK
-//         CHECK (
-//             (TABLE_TYPE IN ('GLOBAL TEMPORARY', 'LOCAL TEMPORARY')) = (COMMIT_ACTION IS NOT NULL)
-//         ),
-//
-//     CONSTRAINT TABLES_CHECK_NOT_VIEW
-//         CHECK (
-//             NOT EXISTS (
-//                 SELECT  TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
-//                 FROM    TABLES
-//                 WHERE   TABLE_TYPE = 'VIEW'
-//                 EXCEPT
-//                 SELECT  TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
-//                 FROM    VIEWS
-//             )
-//         )
-// )
 const TABLES_TABLE: &'_ str = "TABLES";
-// CREATE TABLE COLUMNS (
-//     TABLE_CATALOG           INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     TABLE_SCHEMA            INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     TABLE_NAME              INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     COLUMN_NAME             INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     ORDINAL_POSITION        INFORMATION_SCHEMA.CARDINAL_NUMBER
-//                             CONSTRAINT
-//                                 COLUMNS_ORDINAL_POSITION_NOT_NULL NOT NULL
-//                             CONSTRAINT
-//                                 COLUMNS_ORDINAL_POSITION_GREATER_THAN_ZERO_CHECK
-//                                 CHECK (ORDINAL_POSITION > 0)
-//                             CONSTRAINT COLUMNS_ORDINAL_POSITION_CONTIGUOUS_CHECK
-//                                 CHECK (0 = ALL(
-//                                     SELECT      MAX(ORDINAL_POSITION) - COUNT(*)
-//                                     FROM        COLUMNS
-//                                     GROUP BY    TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME
-//                                     )),
-//     DTD_IDENTIFIER          INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     DOMAIN_CATALOG          INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     DOMAIN_SCHEMA           INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     DOMAIN_NAME             INFORMATION_SCHEMA.SQL_IDENTIFIER,
-//     COLUMN_DEFAULT          INFORMATION_SCHEMA.CHARACTER_DATA,
-//     IS_NULLABLE             INFORMATION_SCHEMA.CHARACTER_DATA
-//                             CONSTRAINT
-//                                 COLUMNS_IS_NULLABLE_NOT_NULL NOT NULL
-//                             CONSTRAINT
-//                                 COLUMNS_IS_NULLABLE_CHECK
-//                                 CHECK (IS_NULLABLE IN ('YES', 'NO')),
-//     IS_SELF_REFERENCING     INFORMATION_SCHEMA.CHARACTER_DATA
-//                             CONSTRAINT
-//                                 COLUMNS_IS_SELF_REFERENCING_NOT_NULL NOT NULL
-//                             CONSTRAINT
-//                                 COLUMNS_IS_SELF_REFERENCING_CHECK
-//                                 CHECK (IS_SELF_REFERENCING IN ('YES', 'NO')),
-//     IS_IDENTITY             INFORMATION_SCHEMA.CHARACTER_DATA
-//                             CONSTRAINT COLUMNS_IS_IDENTITY_NOT_NULL NOT NULL
-//                             CONSTRAINT COLUMNS_IS_IDENTITY_CHECK
-//                                 CHECK (IS_IDENTITY IN ('YES', 'NO')),
-//     IDENTITY_GENERATION     INFORMATION_SCHEMA.CHARACTER_DATA,
-//     IDENTITY_START          INFORMATION_SCHEMA.CHARACTER_DATA,
-//     IDENTITY_INCREMENT      INFORMATION_SCHEMA.CHARACTER_DATA,
-//     IDENTITY_MAXIMUM        INFORMATION_SCHEMA.CHARACTER_DATA,
-//     IDENTITY_MINIMUM        INFORMATION_SCHEMA.CHARACTER_DATA,
-//     IDENTITY_CYCLE          INFORMATION_SCHEMA.CHARACTER_DATA
-//                             CONSTRAINT
-//                                 COLUMNS_IDENTITY_CYCLE_CHECK
-//                                 CHECK (IDENTITY_CYCLE IN ('YES', 'NO')),
-//     IS_GENERATED            INFORMATION_SCHEMA.CHARACTER_DATA,
-//     GENERATION_EXPRESSION   INFORMATION_SCHEMA.CHARACTER_DATA,
-//     IS_UPDATABLE            INFORMATION_SCHEMA.CHARACTER_DATA
-//                             CONSTRAINT COLUMNS_IS_UPDATABLE_NOT_NULL NOT NULL
-//                             CONSTRAINT COLUMNS_IS_UPDATABLE_CHECK
-//                                 CHECK (IS_UPDATABLE IN ('YES', 'NO')),
-//
-//     CONSTRAINT COLUMNS_PRIMARY_KEY
-//         PRIMARY KEY (TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME),
-//
-//     CONSTRAINT COLUMNS_UNIQUE
-//         UNIQUE (TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION),
-//
-//     CONSTRAINT COLUMNS_FOREIGN_KEY_TABLES
-//         FOREIGN KEY (TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME)
-//         REFERENCES TABLES,
-//
-//     CONSTRAINT COLUMNS_CHECK_REFERENCES_DOMAIN
-//         CHECK (
-//             DOMAIN_CATALOG NOT IN (SELECT CATALOG_NAME FROM SCHEMATA)
-//             OR (DOMAIN_CATALOG, DOMAIN_SCHEMA, DOMAIN_NAME)
-//                 IN (SELECT DOMAIN_CATALOG, DOMAIN_SCHEMA, DOMAIN_NAME FROM DOMAINS)
-//         ),
-//
-//     CONSTRAINT COLUMNS_CHECK_IDENTITY_COMBINATIONS
-//         CHECK (
-//             (IS_IDENTITY = 'NO') =
-//             ((IDENTITY_GENERATION, IDENTITY_START, IDENTITY_INCREMENT, IDENTITY_MAXIMUM, IDENTITY_MINIMUM, IDENTITY_CYCLE) IS NULL)
-//         ),
-//
-//     CONSTRAINT COLUMNS_CHECK_DATA_TYPE
-//         CHECK (
-//             DOMAIN_CATALOG NOT IN (SELECT CATALOG_NAME FROM SCHEMATA)
-//             OR (
-//                 (DOMAIN_CATALOG, DOMAIN_SCHEMA, DOMAIN_NAME) IS NOT NULL
-//                 AND
-//                 (TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, 'TABLE', DTD_IDENTIFIER)
-//                     NOT IN (SELECT OBJECT_CATALOG, OBJECT_SCHEMA, OBJECT_NAME, OBJECT_TYPE, DTD_IDENTIFIER FROM DATA_TYPE_DESCRIPTOR))
-//             OR (
-//                 (
-//                     (DOMAIN_CATALOG, DOMAIN_SCHEMA, DOMAIN_NAME) IS NULL
-//                     AND
-//                     (TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, 'TABLE', DTD_IDENTIFIER)
-//                         IN (SELECT OBJECT_CATALOG, OBJECT_SCHEMA, OBJECT_NAME, OBJECT_TYPE, DTD_IDENTIFIER FROM DATA_TYPE_DESCRIPTOR)
-//                 )
-//             )
-//         )
-// )
 const COLUMNS_TABLE: &'_ str = "COLUMNS";
+const DATA_TYPE_DESCRIPTOR_TABLE: &'_ str = "DATA_TYPE_DESCRIPTOR";
 
 #[allow(dead_code)]
 fn catalog_names_types() -> [ColumnDefinition; 1] {
     [ColumnDefinition::new("CATALOG_NAME", SqlType::VarChar(255))]
 }
 
-/// **SCHEMATA_TABLE** sql types definition
+/// **SCHEMATA** sql types definition
 /// CATALOG_NAME    varchar(255)
 /// SCHEMA_NAME     varchar(255)
 #[allow(dead_code)]
@@ -319,7 +91,7 @@ fn schemata_table_types() -> [ColumnDefinition; 2] {
     ]
 }
 
-/// **TABLES_TABLE** sql types definition
+/// **TABLES** sql types definition
 /// TABLE_CATALOG   varchar(255)
 /// TABLE_SCHEMA    varchar(255)
 /// TABLE_NAME      varchar(255)
@@ -332,7 +104,7 @@ fn tables_table_types() -> [ColumnDefinition; 3] {
     ]
 }
 
-/// **COLUMNS_TABLE** sql type definition
+/// **COLUMNS** sql type definition
 /// TABLE_CATALOG       varchar(255)
 /// TABLE_SCHEMA        varchar(255)
 /// TABLE_NAME          varchar(255)
@@ -346,6 +118,27 @@ fn columns_table_types() -> [ColumnDefinition; 5] {
         ColumnDefinition::new("TABLE_NAME", SqlType::VarChar(255)),
         ColumnDefinition::new("COLUMN_NAME", SqlType::VarChar(255)),
         ColumnDefinition::new("ORDINAL_POSITION", SqlType::Integer),
+    ]
+}
+
+/// **DATA_TYPE_DESCRIPTOR** sql type definition
+/// OBJECT_CATALOG              varchar(255)
+/// OBJECT_SCHEMA               varchar(255)
+/// OBJECT_NAME                 varchar(255)
+/// OBJECT_TYPE                 varchar(255)
+/// DATA_TYPE                   varchar(255)
+/// CHARACTER_MAXIMUM_LENGTH    integer CHECK (VALUE >= 0),
+/// NUMERIC_PRECISION           integer CHECK (VALUE >= 0),
+#[allow(dead_code)]
+fn data_type_descriptor() -> [ColumnDefinition; 7] {
+    [
+        ColumnDefinition::new("OBJECT_CATALOG", SqlType::VarChar(255)),
+        ColumnDefinition::new("OBJECT_SCHEMA", SqlType::VarChar(255)),
+        ColumnDefinition::new("OBJECT_NAME", SqlType::VarChar(255)),
+        ColumnDefinition::new("OBJECT_TYPE", SqlType::VarChar(255)),
+        ColumnDefinition::new("DATA_TYPE", SqlType::VarChar(255)),
+        ColumnDefinition::new("CHARACTER_MAXIMUM_LENGTH", SqlType::Integer),
+        ColumnDefinition::new("NUMERIC_PRECISION", SqlType::Integer),
     ]
 }
 
@@ -556,6 +349,11 @@ impl DataDefinition {
             .expect("no io error")
             .expect("no platform error")
             .expect("table COLUMNS is created");
+        system_catalog
+            .create_object(DEFINITION_SCHEMA, DATA_TYPE_DESCRIPTOR_TABLE)
+            .expect("no io error")
+            .expect("no platform error")
+            .expect("table DATA_TYPE_DESCRIPTOR created");
         DataDefinition {
             catalog_ids: AtomicU64::default(),
             catalogs: DashMap::default(),
@@ -605,6 +403,11 @@ impl DataDefinition {
                     .expect("no io error")
                     .expect("no platform error")
                     .expect("table COLUMNS is created");
+                system_catalog
+                    .create_object(DEFINITION_SCHEMA, DATA_TYPE_DESCRIPTOR_TABLE)
+                    .expect("no io error")
+                    .expect("no platform error")
+                    .expect("table DATA_TYPE_DESCRIPTOR created");
                 (DashMap::new(), 0)
             }
             Err(storage_error) => return Ok(Err(storage_error)),

--- a/src/node/src/query_engine/mod.rs
+++ b/src/node/src/query_engine/mod.rs
@@ -20,7 +20,7 @@ use itertools::izip;
 use metadata::{DataDefinition, MetadataView};
 use parser::QueryParser;
 use pg_model::{
-    pg_types::{PostgreSqlFormat, PostgreSqlType},
+    pg_types::{PgType, PostgreSqlFormat},
     results::{QueryError, QueryEvent},
     session::Session,
     statement::PreparedStatement,
@@ -309,7 +309,7 @@ impl QueryEngine {
         &mut self,
         statement_name: String,
         statement: Statement,
-        param_types: Vec<PostgreSqlType>,
+        param_types: Vec<PgType>,
     ) -> Result<(), Vec<QueryError>> {
         match self.query_planner.plan(&statement) {
             Ok(plan) => match plan {
@@ -331,6 +331,7 @@ impl QueryEngine {
                     Err(DescriptionError::SchemaDoesNotExist(schema_name)) => {
                         Err(vec![QueryError::table_does_not_exist(schema_name)])
                     }
+                    _ => unreachable!("this should not be reached during insertions"),
                 },
                 Plan::Update(_table_updates) => {
                     let statement = PreparedStatement::new(statement, param_types.to_vec(), vec![]);
@@ -389,7 +390,7 @@ impl QueryEngine {
                 let Ident { value: name, .. } = name;
                 let mut pg_types = vec![];
                 for t in data_types {
-                    match PostgreSqlType::try_from(t) {
+                    match PgType::try_from(t) {
                         Ok(pg_type) => pg_types.push(pg_type),
                         Err(_) => {
                             self.sender

--- a/src/node/src/query_engine/tests/delete.rs
+++ b/src/node/src/query_engine/tests/delete.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use pg_model::{
-    pg_types::PostgreSqlType,
+    pg_types::PgType,
     results::{QueryError, QueryEvent},
     Command,
 };
@@ -63,7 +63,7 @@ fn delete_all_records(database_with_schema: (InMemory, ResultCollector)) {
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_test")
+            PgType::SmallInt.as_column_metadata("column_test")
         ])),
         Ok(QueryEvent::DataRow(vec!["123".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["456".to_owned()])),
@@ -84,7 +84,7 @@ fn delete_all_records(database_with_schema: (InMemory, ResultCollector)) {
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_test")
+            PgType::SmallInt.as_column_metadata("column_test")
         ])),
         Ok(QueryEvent::RecordsSelected(0)),
     ]);

--- a/src/node/src/query_engine/tests/extended_query_flow.rs
+++ b/src/node/src/query_engine/tests/extended_query_flow.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use pg_model::{
-    pg_types::{PostgreSqlFormat, PostgreSqlType},
+    pg_types::{PgType, PostgreSqlFormat},
     results::QueryEvent,
     Command,
 };
@@ -57,8 +57,8 @@ mod statement_description {
             })
             .expect("statement described");
         collector.assert_receive_intermediate(Ok(QueryEvent::StatementDescription(vec![
-            ("column_1".to_owned(), PostgreSqlType::SmallInt),
-            ("column_2".to_owned(), PostgreSqlType::SmallInt),
+            ("column_1".to_owned(), PgType::SmallInt),
+            ("column_2".to_owned(), PgType::SmallInt),
         ])));
         collector.assert_receive_intermediate(Ok(QueryEvent::StatementParameters(vec![])));
     }
@@ -71,7 +71,7 @@ mod statement_description {
             .execute(Command::Parse {
                 statement_name: "statement_name".to_owned(),
                 sql: "update schema_name.table_name set column_1 = $1 where column_2 = $2;".to_owned(),
-                param_types: vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
+                param_types: vec![PgType::SmallInt, PgType::SmallInt],
             })
             .expect("statement parsed");
         collector.assert_receive_intermediate(Ok(QueryEvent::ParseComplete));
@@ -83,8 +83,8 @@ mod statement_description {
             .expect("statement described");
         collector.assert_receive_intermediate(Ok(QueryEvent::StatementDescription(vec![])));
         collector.assert_receive_intermediate(Ok(QueryEvent::StatementParameters(vec![
-            PostgreSqlType::SmallInt,
-            PostgreSqlType::SmallInt,
+            PgType::SmallInt,
+            PgType::SmallInt,
         ])));
     }
 
@@ -117,7 +117,7 @@ mod parse_bind_execute {
                 .execute(Command::Parse {
                     statement_name: "statement_name".to_owned(),
                     sql: "insert into schema_name.table_name values ($1, $2);".to_owned(),
-                    param_types: vec![PostgreSqlType::SmallInt, PostgreSqlType::SmallInt],
+                    param_types: vec![PgType::SmallInt, PgType::SmallInt],
                 })
                 .expect("statement parsed");
             collector.assert_receive_intermediate(Ok(QueryEvent::ParseComplete));
@@ -157,7 +157,7 @@ mod parse_bind_execute {
                 .execute(Command::Parse {
                     statement_name: "statement_name".to_owned(),
                     sql: "update schema_name.table_name set column_1 = $1, column_2 = $2".to_owned(),
-                    param_types: vec![PostgreSqlType::Integer, PostgreSqlType::VarChar],
+                    param_types: vec![PgType::Integer, PgType::VarChar],
                 })
                 .expect("query parsed");
             collector.assert_receive_intermediate(Ok(QueryEvent::ParseComplete));

--- a/src/node/src/query_engine/tests/insert.rs
+++ b/src/node/src/query_engine/tests/insert.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use pg_model::{
-    pg_types::PostgreSqlType,
+    pg_types::PgType,
     results::{QueryError, QueryEvent},
     Command,
 };
@@ -76,7 +76,7 @@ fn insert_and_select_single_row(database_with_schema: (InMemory, ResultCollector
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_test")
+            PgType::SmallInt.as_column_metadata("column_test")
         ])),
         Ok(QueryEvent::DataRow(vec!["123".to_owned()])),
         Ok(QueryEvent::RecordsSelected(1)),
@@ -115,7 +115,7 @@ fn insert_and_select_multiple_rows(database_with_schema: (InMemory, ResultCollec
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_test")
+            PgType::SmallInt.as_column_metadata("column_test")
         ])),
         Ok(QueryEvent::DataRow(vec!["123".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["456".to_owned()])),
@@ -148,9 +148,9 @@ fn insert_and_select_named_columns(database_with_schema: (InMemory, ResultCollec
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("col1"),
-            PostgreSqlType::SmallInt.as_column_metadata("col2"),
-            PostgreSqlType::SmallInt.as_column_metadata("col3"),
+            PgType::SmallInt.as_column_metadata("col1"),
+            PgType::SmallInt.as_column_metadata("col2"),
+            PgType::SmallInt.as_column_metadata("col3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "3".to_owned(),
@@ -193,9 +193,9 @@ fn insert_multiple_rows(database_with_schema: (InMemory, ResultCollector)) {
 
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_1"),
+            PgType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "1".to_owned(),
@@ -248,9 +248,9 @@ fn insert_and_select_different_integer_types(database_with_schema: (InMemory, Re
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_si"),
-            PostgreSqlType::Integer.as_column_metadata("column_i"),
-            PostgreSqlType::BigInt.as_column_metadata("column_bi"),
+            PgType::SmallInt.as_column_metadata("column_si"),
+            PgType::Integer.as_column_metadata("column_i"),
+            PgType::BigInt.as_column_metadata("column_bi"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "-32768".to_owned(),
@@ -297,8 +297,8 @@ fn insert_and_select_different_character_types(database_with_schema: (InMemory, 
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::Char.as_column_metadata("column_c"),
-            PostgreSqlType::VarChar.as_column_metadata("column_vc"),
+            PgType::Char.as_column_metadata("column_c"),
+            PgType::VarChar.as_column_metadata("column_vc"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "12345abcde".to_owned(),
@@ -386,7 +386,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["3".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -411,7 +411,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["-1".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -436,7 +436,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["6".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -461,7 +461,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["4".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -486,7 +486,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["0".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -514,7 +514,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["64".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -541,7 +541,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["4".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -568,7 +568,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["2".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -595,7 +595,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["120".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -622,7 +622,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["120".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -649,7 +649,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["5".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -674,7 +674,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["1".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -699,7 +699,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["7".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -726,7 +726,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["-2".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -753,7 +753,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["16".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -780,7 +780,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["2".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -805,7 +805,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["5".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -851,7 +851,7 @@ mod operators {
                 .expect("query executed");
             collector.assert_receive_many(vec![
                 Ok(QueryEvent::RowDescription(vec![
-                    PostgreSqlType::Char.as_column_metadata("strings")
+                    PgType::Char.as_column_metadata("strings")
                 ])),
                 Ok(QueryEvent::DataRow(vec!["12345".to_owned()])),
                 Ok(QueryEvent::RecordsSelected(1)),
@@ -883,7 +883,7 @@ mod operators {
                 .expect("query executed");
             collector.assert_receive_many(vec![
                 Ok(QueryEvent::RowDescription(vec![
-                    PostgreSqlType::Char.as_column_metadata("strings")
+                    PgType::Char.as_column_metadata("strings")
                 ])),
                 Ok(QueryEvent::DataRow(vec!["145".to_owned()])),
                 Ok(QueryEvent::DataRow(vec!["451".to_owned()])),

--- a/src/node/src/query_engine/tests/select.rs
+++ b/src/node/src/query_engine/tests/select.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use pg_model::{
-    pg_types::PostgreSqlType,
+    pg_types::PgType,
     results::{QueryError, QueryEvent},
     Command,
 };
@@ -66,9 +66,9 @@ fn select_all_from_table_with_multiple_columns(database_with_schema: (InMemory, 
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_1"),
+            PgType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "123".to_owned(),
@@ -104,8 +104,8 @@ fn select_not_all_columns(database_with_schema: (InMemory, ResultCollector)) {
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_2"),
         ])),
         Ok(QueryEvent::DataRow(vec!["7".to_owned(), "4".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["8".to_owned(), "5".to_owned()])),
@@ -160,8 +160,8 @@ fn select_first_and_last_columns_from_table_with_multiple_columns(database_with_
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_1"),
+            PgType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_1"),
         ])),
         Ok(QueryEvent::DataRow(vec!["3".to_owned(), "1".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["6".to_owned(), "4".to_owned()])),
@@ -195,9 +195,9 @@ fn select_all_columns_reordered_from_table_with_multiple_columns(database_with_s
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_1"),
+            PgType::SmallInt.as_column_metadata("column_2"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "3".to_owned(),
@@ -243,11 +243,11 @@ fn select_with_column_name_duplication(database_with_schema: (InMemory, ResultCo
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_1"),
+            PgType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_2"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "3".to_owned(),
@@ -296,9 +296,9 @@ fn select_different_integer_types(database_with_schema: (InMemory, ResultCollect
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_si"),
-            PostgreSqlType::Integer.as_column_metadata("column_i"),
-            PostgreSqlType::BigInt.as_column_metadata("column_bi"),
+            PgType::SmallInt.as_column_metadata("column_si"),
+            PgType::Integer.as_column_metadata("column_i"),
+            PgType::BigInt.as_column_metadata("column_bi"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "1000".to_owned(),
@@ -340,8 +340,8 @@ fn select_different_character_strings_types(database_with_schema: (InMemory, Res
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::Char.as_column_metadata("char_10"),
-            PostgreSqlType::VarChar.as_column_metadata("var_char_20"),
+            PgType::Char.as_column_metadata("char_10"),
+            PgType::VarChar.as_column_metadata("var_char_20"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "1234567890".to_owned(),

--- a/src/node/src/query_engine/tests/simple_prepared_statement.rs
+++ b/src/node/src/query_engine/tests/simple_prepared_statement.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use pg_model::{
-    pg_types::PostgreSqlType,
+    pg_types::PgType,
     results::{QueryError, QueryEvent},
     Command,
 };
@@ -59,9 +59,9 @@ fn prepare_execute_and_deallocate(database_with_schema: (InMemory, ResultCollect
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_1"),
+            PgType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "123".to_owned(),

--- a/src/node/src/query_engine/tests/type_constraints.rs
+++ b/src/node/src/query_engine/tests/type_constraints.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use pg_model::{
-    pg_types::PostgreSqlType,
+    pg_types::PgType,
     results::{QueryError, QueryEvent},
     Command,
 };
@@ -72,11 +72,7 @@ mod insert {
                 sql: "insert into schema_name.table_name values (32768);".to_owned(),
             })
             .expect("query executed");
-        collector.assert_receive_single(Err(QueryError::out_of_range(
-            PostgreSqlType::SmallInt,
-            "col".to_string(),
-            1,
-        )));
+        collector.assert_receive_single(Err(QueryError::out_of_range(PgType::SmallInt, "col".to_string(), 1)));
     }
 
     #[rstest::rstest]
@@ -88,10 +84,7 @@ mod insert {
                 sql: "insert into schema_name.table_name values ('str');".to_owned(),
             })
             .expect("query executed");
-        collector.assert_receive_single(Err(QueryError::invalid_text_representation(
-            PostgreSqlType::SmallInt,
-            "str",
-        )));
+        collector.assert_receive_single(Err(QueryError::invalid_text_representation(PgType::SmallInt, "str")));
     }
 
     #[rstest::rstest]
@@ -100,8 +93,8 @@ mod insert {
         engine
             .execute(Command::Query { sql: "insert into schema_name.table_name values (-32769, -2147483649, 100), (100, -2147483649, -9223372036854775809);".to_owned()}).expect("query executed");
         collector.assert_receive_many(vec![
-            Err(QueryError::out_of_range(PostgreSqlType::SmallInt, "column_si", 1)),
-            Err(QueryError::out_of_range(PostgreSqlType::Integer, "column_i", 1)),
+            Err(QueryError::out_of_range(PgType::SmallInt, "column_si", 1)),
+            Err(QueryError::out_of_range(PgType::Integer, "column_i", 1)),
         ]);
     }
 
@@ -111,16 +104,8 @@ mod insert {
         engine
             .execute(Command::Query { sql: "insert into schema_name.table_name values (-32768, -2147483648, 100), (100, -2147483649, -9223372036854775809);".to_owned()}).expect("query executed");
         collector.assert_receive_many(vec![
-            Err(QueryError::out_of_range(
-                PostgreSqlType::Integer,
-                "column_i".to_owned(),
-                2,
-            )),
-            Err(QueryError::out_of_range(
-                PostgreSqlType::BigInt,
-                "column_bi".to_owned(),
-                2,
-            )),
+            Err(QueryError::out_of_range(PgType::Integer, "column_i".to_owned(), 2)),
+            Err(QueryError::out_of_range(PgType::BigInt, "column_bi".to_owned(), 2)),
         ]);
     }
 
@@ -134,7 +119,7 @@ mod insert {
             })
             .expect("query executed");
         collector.assert_receive_single(Err(QueryError::string_length_mismatch(
-            PostgreSqlType::VarChar,
+            PgType::VarChar,
             5,
             "col".to_string(),
             1,
@@ -162,11 +147,7 @@ mod update {
             })
             .expect("query executed");
 
-        collector.assert_receive_single(Err(QueryError::out_of_range(
-            PostgreSqlType::SmallInt,
-            "col".to_string(),
-            1,
-        )));
+        collector.assert_receive_single(Err(QueryError::out_of_range(PgType::SmallInt, "col".to_string(), 1)));
     }
 
     #[rstest::rstest]
@@ -185,10 +166,7 @@ mod update {
             })
             .expect("query executed");
 
-        collector.assert_receive_single(Err(QueryError::invalid_text_representation(
-            PostgreSqlType::SmallInt,
-            "str",
-        )));
+        collector.assert_receive_single(Err(QueryError::invalid_text_representation(PgType::SmallInt, "str")));
     }
 
     #[rstest::rstest]
@@ -208,7 +186,7 @@ mod update {
             })
             .expect("query executed");
         collector.assert_receive_single(Err(QueryError::string_length_mismatch(
-            PostgreSqlType::VarChar,
+            PgType::VarChar,
             5,
             "col".to_string(),
             1,
@@ -233,16 +211,8 @@ mod update {
             })
             .expect("query executed");
         collector.assert_receive_many(vec![
-            Err(QueryError::out_of_range(
-                PostgreSqlType::SmallInt,
-                "column_si".to_owned(),
-                1,
-            )),
-            Err(QueryError::out_of_range(
-                PostgreSqlType::Integer,
-                "column_i".to_owned(),
-                1,
-            )),
+            Err(QueryError::out_of_range(PgType::SmallInt, "column_si".to_owned(), 1)),
+            Err(QueryError::out_of_range(PgType::Integer, "column_i".to_owned(), 1)),
         ]);
     }
 }

--- a/src/node/src/query_engine/tests/update.rs
+++ b/src/node/src/query_engine/tests/update.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use pg_model::{
-    pg_types::PostgreSqlType,
+    pg_types::PgType,
     results::{QueryError, QueryEvent},
     Command,
 };
@@ -43,7 +43,7 @@ fn update_all_records(database_with_schema: (InMemory, ResultCollector)) {
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_test")
+            PgType::SmallInt.as_column_metadata("column_test")
         ])),
         Ok(QueryEvent::DataRow(vec!["123".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["456".to_owned()])),
@@ -64,7 +64,7 @@ fn update_all_records(database_with_schema: (InMemory, ResultCollector)) {
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_test")
+            PgType::SmallInt.as_column_metadata("column_test")
         ])),
         Ok(QueryEvent::DataRow(vec!["789".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["789".to_owned()])),
@@ -96,8 +96,8 @@ fn update_single_column_of_all_records(database_with_schema: (InMemory, ResultCo
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("col1"),
-            PostgreSqlType::SmallInt.as_column_metadata("col2"),
+            PgType::SmallInt.as_column_metadata("col1"),
+            PgType::SmallInt.as_column_metadata("col2"),
         ])),
         Ok(QueryEvent::DataRow(vec!["123".to_owned(), "789".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["456".to_owned(), "789".to_owned()])),
@@ -118,8 +118,8 @@ fn update_single_column_of_all_records(database_with_schema: (InMemory, ResultCo
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("col1"),
-            PostgreSqlType::SmallInt.as_column_metadata("col2"),
+            PgType::SmallInt.as_column_metadata("col1"),
+            PgType::SmallInt.as_column_metadata("col2"),
         ])),
         Ok(QueryEvent::DataRow(vec!["123".to_owned(), "357".to_owned()])),
         Ok(QueryEvent::DataRow(vec!["456".to_owned(), "357".to_owned()])),
@@ -151,9 +151,9 @@ fn update_multiple_columns_of_all_records(database_with_schema: (InMemory, Resul
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("col1"),
-            PostgreSqlType::SmallInt.as_column_metadata("col2"),
-            PostgreSqlType::SmallInt.as_column_metadata("col3"),
+            PgType::SmallInt.as_column_metadata("col1"),
+            PgType::SmallInt.as_column_metadata("col2"),
+            PgType::SmallInt.as_column_metadata("col3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "111".to_owned(),
@@ -183,9 +183,9 @@ fn update_multiple_columns_of_all_records(database_with_schema: (InMemory, Resul
 
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("col1"),
-            PostgreSqlType::SmallInt.as_column_metadata("col2"),
-            PostgreSqlType::SmallInt.as_column_metadata("col3"),
+            PgType::SmallInt.as_column_metadata("col1"),
+            PgType::SmallInt.as_column_metadata("col2"),
+            PgType::SmallInt.as_column_metadata("col3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "999".to_owned(),
@@ -226,9 +226,9 @@ fn update_all_records_in_multiple_columns(database_with_schema: (InMemory, Resul
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_1"),
+            PgType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "1".to_owned(),
@@ -263,9 +263,9 @@ fn update_all_records_in_multiple_columns(database_with_schema: (InMemory, Resul
 
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_1"),
+            PgType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "10".to_owned(),
@@ -321,7 +321,7 @@ fn update_non_existent_columns_of_records(database_with_schema: (InMemory, Resul
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_test")
+            PgType::SmallInt.as_column_metadata("column_test")
         ])),
         Ok(QueryEvent::DataRow(vec!["123".to_owned()])),
         Ok(QueryEvent::RecordsSelected(1)),
@@ -367,9 +367,9 @@ fn test_update_with_dynamic_expression(database_with_schema: (InMemory, ResultCo
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("si_column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("si_column_2"),
-            PostgreSqlType::SmallInt.as_column_metadata("si_column_3"),
+            PgType::SmallInt.as_column_metadata("si_column_1"),
+            PgType::SmallInt.as_column_metadata("si_column_2"),
+            PgType::SmallInt.as_column_metadata("si_column_3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "1".to_owned(),
@@ -408,9 +408,9 @@ fn test_update_with_dynamic_expression(database_with_schema: (InMemory, ResultCo
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("si_column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("si_column_2"),
-            PostgreSqlType::SmallInt.as_column_metadata("si_column_3"),
+            PgType::SmallInt.as_column_metadata("si_column_1"),
+            PgType::SmallInt.as_column_metadata("si_column_2"),
+            PgType::SmallInt.as_column_metadata("si_column_3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             (2 * 1).to_string(),
@@ -483,7 +483,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["3".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -508,7 +508,7 @@ mod operators {
 
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["-1".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -533,7 +533,7 @@ mod operators {
 
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["6".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -557,7 +557,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["4".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -581,7 +581,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["0".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -608,7 +608,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["64".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -634,7 +634,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["4".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -660,7 +660,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["2".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -686,7 +686,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["120".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -712,7 +712,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["120".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -738,7 +738,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["5".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -762,7 +762,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["1".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -786,7 +786,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["7".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -812,7 +812,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["-2".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -838,7 +838,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["16".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -864,7 +864,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["2".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -888,7 +888,7 @@ mod operators {
                     .expect("query executed");
                 collector.assert_receive_many(vec![
                     Ok(QueryEvent::RowDescription(vec![
-                        PostgreSqlType::SmallInt.as_column_metadata("column_si")
+                        PgType::SmallInt.as_column_metadata("column_si")
                     ])),
                     Ok(QueryEvent::DataRow(vec!["5".to_owned()])),
                     Ok(QueryEvent::RecordsSelected(1)),
@@ -941,7 +941,7 @@ mod operators {
                 .expect("query executed");
             collector.assert_receive_many(vec![
                 Ok(QueryEvent::RowDescription(vec![
-                    PostgreSqlType::Char.as_column_metadata("strings")
+                    PgType::Char.as_column_metadata("strings")
                 ])),
                 Ok(QueryEvent::DataRow(vec!["12345".to_owned()])),
                 Ok(QueryEvent::RecordsSelected(1)),
@@ -965,7 +965,7 @@ mod operators {
                 .expect("query executed");
             collector.assert_receive_many(vec![
                 Ok(QueryEvent::RowDescription(vec![
-                    PostgreSqlType::Char.as_column_metadata("strings")
+                    PgType::Char.as_column_metadata("strings")
                 ])),
                 Ok(QueryEvent::DataRow(vec!["145".to_owned()])),
                 Ok(QueryEvent::RecordsSelected(1)),
@@ -985,7 +985,7 @@ mod operators {
                 .expect("query executed");
             collector.assert_receive_many(vec![
                 Ok(QueryEvent::RowDescription(vec![
-                    PostgreSqlType::Char.as_column_metadata("strings")
+                    PgType::Char.as_column_metadata("strings")
                 ])),
                 Ok(QueryEvent::DataRow(vec!["451".to_owned()])),
                 Ok(QueryEvent::RecordsSelected(1)),

--- a/src/node/src/query_engine/tests/where_clause.rs
+++ b/src/node/src/query_engine/tests/where_clause.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::*;
-use pg_model::{pg_types::PostgreSqlType, results::QueryEvent, Command};
+use pg_model::{pg_types::PgType, results::QueryEvent, Command};
 
 #[rstest::rstest]
 fn select_row_by_column_equality_predicate(database_with_schema: (InMemory, ResultCollector)) {
@@ -40,9 +40,9 @@ fn select_row_by_column_equality_predicate(database_with_schema: (InMemory, Resu
         .expect("query executed");
     collector.assert_receive_many(vec![
         Ok(QueryEvent::RowDescription(vec![
-            PostgreSqlType::SmallInt.as_column_metadata("column_1"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_2"),
-            PostgreSqlType::SmallInt.as_column_metadata("column_3"),
+            PgType::SmallInt.as_column_metadata("column_1"),
+            PgType::SmallInt.as_column_metadata("column_2"),
+            PgType::SmallInt.as_column_metadata("column_3"),
         ])),
         Ok(QueryEvent::DataRow(vec![
             "1".to_owned(),

--- a/src/pg_model/src/lib.rs
+++ b/src/pg_model/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::pg_types::{PostgreSqlFormat, PostgreSqlType};
+use crate::pg_types::{PgType, PostgreSqlFormat};
 use pg_wire::{Error, Result};
 use rand::Rng;
 use std::{
@@ -137,7 +137,7 @@ pub enum Command {
         sql: String,
         /// The number of specified parameter data types can be less than the
         /// number of parameters specified in the query.
-        param_types: Vec<PostgreSqlType>,
+        param_types: Vec<PgType>,
     },
     /// Client commands to execute a `Query`
     Query {

--- a/src/pg_model/src/statement.rs
+++ b/src/pg_model/src/statement.rs
@@ -35,7 +35,7 @@
 //!    that portal to actually start scanning and returning results.
 
 use crate::{
-    pg_types::{PostgreSqlFormat, PostgreSqlType},
+    pg_types::{PgType, PostgreSqlFormat},
     results::Description,
 };
 
@@ -45,14 +45,14 @@ pub struct PreparedStatement<S> {
     /// The raw prepared SQL statement will be bound to a portal.
     stmt: S,
     /// The types of any bound parameters.
-    param_types: Vec<PostgreSqlType>,
+    param_types: Vec<PgType>,
     /// The type of the rows that will be returned.
     description: Description,
 }
 
 impl<S> PreparedStatement<S> {
     /// Constructs a new `PreparedStatement`.
-    pub fn new(stmt: S, param_types: Vec<PostgreSqlType>, description: Description) -> PreparedStatement<S> {
+    pub fn new(stmt: S, param_types: Vec<PgType>, description: Description) -> PreparedStatement<S> {
         PreparedStatement {
             stmt,
             param_types,
@@ -66,12 +66,12 @@ impl<S> PreparedStatement<S> {
     }
 
     /// Returns the types of any bound parameters.
-    pub fn param_types(&self) -> &[PostgreSqlType] {
+    pub fn param_types(&self) -> &[PgType] {
         &self.param_types
     }
 
     /// Returns the type of the rows that will be returned.
-    pub fn description(&self) -> &[(String, PostgreSqlType)] {
+    pub fn description(&self) -> &[(String, PgType)] {
         self.description.as_ref()
     }
 }

--- a/src/query_analyzer/src/lib.rs
+++ b/src/query_analyzer/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use description::{Description, DescriptionError, FullTableId, FullTableName, InsertStatement};
+use description::{Description, DescriptionError, FullTableId, FullTableName, InsertStatement, TableNamingError};
 use metadata::{DataDefinition, MetadataView};
 use sql_model::sql_errors::NotFoundError;
 use sqlparser::ast::Statement;
@@ -29,9 +29,8 @@ impl Analyzer {
 
     pub fn describe(&self, statement: &Statement) -> Result<Description, DescriptionError> {
         match statement {
-            Statement::Insert { table_name, .. } => {
-                let full_table_name = FullTableName::try_from(table_name).unwrap();
-                match self.metadata.table_desc((&full_table_name).into()) {
+            Statement::Insert { table_name, .. } => match FullTableName::try_from(table_name) {
+                Ok(full_table_name) => match self.metadata.table_desc((&full_table_name).into()) {
                     Ok(table_def) => Ok(Description::Insert(InsertStatement {
                         table_id: FullTableId::from(table_def.full_table_id()),
                         sql_types: table_def.column_types(),
@@ -40,133 +39,14 @@ impl Analyzer {
                     Err(NotFoundError::Schema) => {
                         Err(DescriptionError::schema_does_not_exist(full_table_name.schema()))
                     }
-                }
-            }
+                },
+                Err(error) => Err(DescriptionError::syntax_error(&error)),
+            },
+            Statement::CreateTable { name, .. } => Err(DescriptionError::schema_does_not_exist(&name.0[0])),
             _ => unimplemented!(),
         }
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use meta_def::ColumnDefinition;
-    use sql_model::{sql_types::SqlType, DEFAULT_CATALOG};
-    use sqlparser::ast::{Expr, Ident, ObjectName, Query, SetExpr, Value, Values};
-    use std::sync::Arc;
-
-    const SCHEMA: &str = "schema_name";
-    const TABLE: &str = "table_name";
-
-    fn ident<S: ToString>(name: S) -> Ident {
-        Ident {
-            value: name.to_string(),
-            quote_style: None,
-        }
-    }
-
-    fn insert_stmt_with_values<S: ToString>(schema: S, table: S, values: Vec<&'static str>) -> Statement {
-        Statement::Insert {
-            table_name: ObjectName(vec![ident(schema), ident(table)]),
-            columns: vec![],
-            source: Box::new(Query {
-                with: None,
-                body: SetExpr::Values(Values(vec![values
-                    .into_iter()
-                    .map(|s| Expr::Value(Value::Number(s.parse().unwrap())))
-                    .collect()])),
-                order_by: vec![],
-                limit: None,
-                offset: None,
-                fetch: None,
-            }),
-        }
-    }
-
-    fn insert_statement<S: ToString>(schema: S, table: S) -> Statement {
-        insert_stmt_with_values(schema, table, vec![])
-    }
-
-    #[test]
-    fn insert_into_table_under_non_existing_schema() {
-        let metadata = Arc::new(DataDefinition::in_memory());
-        metadata.create_catalog(DEFAULT_CATALOG);
-        let analyzer = Analyzer::new(metadata);
-        let description = analyzer.describe(&insert_statement("non_existent_schema", "non_existent_table"));
-
-        assert_eq!(
-            description,
-            Err(DescriptionError::schema_does_not_exist(&"non_existent_schema"))
-        )
-    }
-
-    #[test]
-    fn insert_into_non_existing_table() {
-        let metadata = Arc::new(DataDefinition::in_memory());
-        metadata.create_catalog(DEFAULT_CATALOG);
-        metadata.create_schema(DEFAULT_CATALOG, SCHEMA);
-        let analyzer = Analyzer::new(metadata);
-        let description = analyzer.describe(&insert_statement(SCHEMA, "non_existent"));
-
-        assert_eq!(
-            description,
-            Err(DescriptionError::table_does_not_exist(&format!(
-                "{}.{}",
-                SCHEMA, "non_existent"
-            )))
-        );
-    }
-
-    #[test]
-    fn insert_into_existing_table_without_columns() {
-        let metadata = Arc::new(DataDefinition::in_memory());
-        metadata.create_catalog(DEFAULT_CATALOG);
-        let schema_id = match metadata.create_schema(DEFAULT_CATALOG, SCHEMA) {
-            Some((_, Some(schema_id))) => schema_id,
-            _ => panic!(),
-        };
-        let table_id = match metadata.create_table(DEFAULT_CATALOG, SCHEMA, TABLE, &[]) {
-            Some((_, Some((_, Some(table_id))))) => table_id,
-            _ => panic!(),
-        };
-        let analyzer = Analyzer::new(metadata);
-        let description = analyzer.describe(&insert_statement(SCHEMA, TABLE));
-
-        assert_eq!(
-            description,
-            Ok(Description::Insert(InsertStatement {
-                table_id: FullTableId::from((schema_id, table_id)),
-                sql_types: vec![]
-            }))
-        );
-    }
-
-    #[test]
-    fn insert_into_existing_table_with_column() {
-        let metadata = Arc::new(DataDefinition::in_memory());
-        metadata.create_catalog(DEFAULT_CATALOG);
-        let schema_id = match metadata.create_schema(DEFAULT_CATALOG, SCHEMA) {
-            Some((_, Some(schema_id))) => schema_id,
-            _ => panic!(),
-        };
-        let table_id = match metadata.create_table(
-            DEFAULT_CATALOG,
-            SCHEMA,
-            TABLE,
-            &[ColumnDefinition::new("col", SqlType::SmallInt)],
-        ) {
-            Some((_, Some((_, Some(table_id))))) => table_id,
-            _ => panic!(),
-        };
-        let analyzer = Analyzer::new(metadata);
-        let description = analyzer.describe(&insert_stmt_with_values(SCHEMA, TABLE, vec!["1"]));
-
-        assert_eq!(
-            description,
-            Ok(Description::Insert(InsertStatement {
-                table_id: FullTableId::from((schema_id, table_id)),
-                sql_types: vec![SqlType::SmallInt]
-            }))
-        );
-    }
-}
+mod tests;

--- a/src/query_analyzer/src/lib.rs
+++ b/src/query_analyzer/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use description::{Description, DescriptionError, FullTableId, FullTableName, InsertStatement, TableNamingError};
+use description::{Description, DescriptionError, FullTableId, FullTableName, InsertStatement};
 use metadata::{DataDefinition, MetadataView};
 use sql_model::sql_errors::NotFoundError;
 use sqlparser::ast::Statement;

--- a/src/query_analyzer/src/tests/create_table.rs
+++ b/src/query_analyzer/src/tests/create_table.rs
@@ -1,0 +1,70 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use sqlparser::ast::{ColumnDef, DataType};
+
+fn column(name: &str, data_type: DataType) -> ColumnDef {
+    ColumnDef {
+        name: ident(name),
+        data_type,
+        collation: None,
+        options: vec![],
+    }
+}
+
+fn create_table(schema_name: &str, table_name: &str, columns: Vec<ColumnDef>) -> Statement {
+    Statement::CreateTable {
+        or_replace: false,
+        name: ObjectName(vec![schema_name, table_name].into_iter().map(ident).collect()),
+        columns,
+        constraints: vec![],
+        with_options: vec![],
+        if_not_exists: false,
+        external: false,
+        file_format: None,
+        location: None,
+        query: None,
+        without_rowid: false,
+    }
+}
+
+#[test]
+fn create_table_with_nonexistent_schema() {
+    let metadata = Arc::new(DataDefinition::in_memory());
+    metadata.create_catalog(DEFAULT_CATALOG);
+    let analyzer = Analyzer::new(metadata);
+    let description = analyzer.describe(&create_table("non_existent_schema", "non_existent_table", vec![]));
+
+    assert_eq!(
+        description,
+        Err(DescriptionError::schema_does_not_exist(&"non_existent_schema"))
+    );
+}
+
+#[ignore]
+#[test]
+fn create_table_with_the_same_name() {
+    let metadata = Arc::new(DataDefinition::in_memory());
+    metadata.create_catalog(DEFAULT_CATALOG);
+    metadata.create_schema(DEFAULT_CATALOG, SCHEMA);
+    metadata.create_table(DEFAULT_CATALOG, SCHEMA, TABLE, &[]);
+    let analyzer = Analyzer::new(metadata);
+    let description = analyzer.describe(&create_table(SCHEMA, TABLE, vec![]));
+
+    assert_eq!(
+        description,
+        Err(DescriptionError::table_already_exists(&format!("{}.{}", SCHEMA, TABLE)))
+    );
+}

--- a/src/query_analyzer/src/tests/create_table.rs
+++ b/src/query_analyzer/src/tests/create_table.rs
@@ -15,6 +15,7 @@
 use super::*;
 use sqlparser::ast::{ColumnDef, DataType};
 
+#[allow(dead_code)]
 fn column(name: &str, data_type: DataType) -> ColumnDef {
     ColumnDef {
         name: ident(name),

--- a/src/query_analyzer/src/tests/insert.rs
+++ b/src/query_analyzer/src/tests/insert.rs
@@ -1,0 +1,120 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+fn insert_stmt_with_values<S: ToString>(schema: S, table: S, values: Vec<&'static str>) -> Statement {
+    Statement::Insert {
+        table_name: ObjectName(vec![ident(schema), ident(table)]),
+        columns: vec![],
+        source: Box::new(Query {
+            with: None,
+            body: SetExpr::Values(Values(vec![values
+                .into_iter()
+                .map(|s| Expr::Value(Value::Number(s.parse().unwrap())))
+                .collect()])),
+            order_by: vec![],
+            limit: None,
+            offset: None,
+            fetch: None,
+        }),
+    }
+}
+
+fn insert_statement<S: ToString>(schema: S, table: S) -> Statement {
+    insert_stmt_with_values(schema, table, vec![])
+}
+
+#[test]
+fn insert_into_table_under_non_existing_schema() {
+    let metadata = Arc::new(DataDefinition::in_memory());
+    metadata.create_catalog(DEFAULT_CATALOG);
+    let analyzer = Analyzer::new(metadata);
+    let description = analyzer.describe(&insert_statement("non_existent_schema", "non_existent_table"));
+
+    assert_eq!(
+        description,
+        Err(DescriptionError::schema_does_not_exist(&"non_existent_schema"))
+    )
+}
+
+#[test]
+fn insert_into_non_existing_table() {
+    let metadata = Arc::new(DataDefinition::in_memory());
+    metadata.create_catalog(DEFAULT_CATALOG);
+    metadata.create_schema(DEFAULT_CATALOG, SCHEMA);
+    let analyzer = Analyzer::new(metadata);
+    let description = analyzer.describe(&insert_statement(SCHEMA, "non_existent"));
+
+    assert_eq!(
+        description,
+        Err(DescriptionError::table_does_not_exist(&format!(
+            "{}.{}",
+            SCHEMA, "non_existent"
+        )))
+    );
+}
+
+#[test]
+fn insert_into_existing_table_without_columns() {
+    let metadata = Arc::new(DataDefinition::in_memory());
+    metadata.create_catalog(DEFAULT_CATALOG);
+    let schema_id = match metadata.create_schema(DEFAULT_CATALOG, SCHEMA) {
+        Some((_, Some(schema_id))) => schema_id,
+        _ => panic!(),
+    };
+    let table_id = match metadata.create_table(DEFAULT_CATALOG, SCHEMA, TABLE, &[]) {
+        Some((_, Some((_, Some(table_id))))) => table_id,
+        _ => panic!(),
+    };
+    let analyzer = Analyzer::new(metadata);
+    let description = analyzer.describe(&insert_statement(SCHEMA, TABLE));
+
+    assert_eq!(
+        description,
+        Ok(Description::Insert(InsertStatement {
+            table_id: FullTableId::from((schema_id, table_id)),
+            sql_types: vec![]
+        }))
+    );
+}
+
+#[test]
+fn insert_into_existing_table_with_column() {
+    let metadata = Arc::new(DataDefinition::in_memory());
+    metadata.create_catalog(DEFAULT_CATALOG);
+    let schema_id = match metadata.create_schema(DEFAULT_CATALOG, SCHEMA) {
+        Some((_, Some(schema_id))) => schema_id,
+        _ => panic!(),
+    };
+    let table_id = match metadata.create_table(
+        DEFAULT_CATALOG,
+        SCHEMA,
+        TABLE,
+        &[ColumnDefinition::new("col", SqlType::SmallInt)],
+    ) {
+        Some((_, Some((_, Some(table_id))))) => table_id,
+        _ => panic!(),
+    };
+    let analyzer = Analyzer::new(metadata);
+    let description = analyzer.describe(&insert_stmt_with_values(SCHEMA, TABLE, vec!["1"]));
+
+    assert_eq!(
+        description,
+        Ok(Description::Insert(InsertStatement {
+            table_id: FullTableId::from((schema_id, table_id)),
+            sql_types: vec![SqlType::SmallInt]
+        }))
+    );
+}

--- a/src/query_analyzer/src/tests/mod.rs
+++ b/src/query_analyzer/src/tests/mod.rs
@@ -1,0 +1,32 @@
+// Copyright 2020 Alex Dukhno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod create_table;
+mod insert;
+
+use super::*;
+use meta_def::ColumnDefinition;
+use sql_model::{sql_types::SqlType, DEFAULT_CATALOG};
+use sqlparser::ast::{Expr, Ident, ObjectName, Query, SetExpr, Value, Values};
+use std::sync::Arc;
+
+const SCHEMA: &str = "schema_name";
+const TABLE: &str = "table_name";
+
+fn ident<S: ToString>(name: S) -> Ident {
+    Ident {
+        value: name.to_string(),
+        quote_style: None,
+    }
+}

--- a/src/query_executor/src/dml/select.rs
+++ b/src/query_executor/src/dml/select.rs
@@ -20,7 +20,7 @@ use binary::ReadCursor;
 use connection::Sender;
 use data_manager::DataManager;
 use metadata::MetadataView;
-use pg_model::{pg_types::PostgreSqlType, results::QueryEvent};
+use pg_model::{pg_types::PgType, results::QueryEvent};
 use plan::{FullTableId, SelectInput};
 use sql_model::Id;
 use std::{convert::TryInto, sync::Arc};
@@ -158,7 +158,7 @@ impl SelectCommand {
                     .column_defs(&self.select_input.table_id, &self.select_input.selected_columns)
                     .into_iter()
                     .map(|column| {
-                        let pg_type: PostgreSqlType = (&column.sql_type()).into();
+                        let pg_type: PgType = (&column.sql_type()).into();
                         pg_type.as_column_metadata(column.name())
                     })
                     .collect(),

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -6,6 +6,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-sql_model = { path = "../sql_model" }
-
 ordered-float = "2.0.0"

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 use ordered_float::OrderedFloat;
-use sql_model::sql_types::SqlType;
 use std::fmt::{self, Display, Formatter};
 
-/// value shared by the row.
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Datum<'a> {
     Null,
@@ -25,16 +23,10 @@ pub enum Datum<'a> {
     Int16(i16),
     Int32(i32),
     Int64(i64),
-    // should u16, u32 be implemented here?
-    UInt64(u64),
     Float32(OrderedFloat<f32>),
     Float64(OrderedFloat<f64>),
     String(&'a str),
-    // this should only be used when loading string into a database
     OwnedString(String),
-    // Bytes(&'a [u8]),
-    SqlType(SqlType),
-    // fill in the rest of the types as they get implemented.
 }
 
 impl<'a> Datum<'a> {
@@ -46,12 +38,10 @@ impl<'a> Datum<'a> {
             Self::Int16(_) => 1 + std::mem::size_of::<i16>(),
             Self::Int32(_) => 1 + std::mem::size_of::<i32>(),
             Self::Int64(_) => 1 + std::mem::size_of::<i64>(),
-            Self::UInt64(_) => 1 + std::mem::size_of::<u64>(),
             Self::Float32(_) => 1 + std::mem::size_of::<f32>(),
             Self::Float64(_) => 1 + std::mem::size_of::<f64>(),
             Self::String(val) => 1 + std::mem::size_of::<usize>() + val.len(),
             Self::OwnedString(val) => 1 + std::mem::size_of::<usize>() + val.len(),
-            Self::SqlType(_) => 1 + std::mem::size_of::<SqlType>(),
         }
     }
 
@@ -75,12 +65,16 @@ impl<'a> Datum<'a> {
         Datum::Int32(val)
     }
 
+    pub fn from_u32(val: u32) -> Datum<'static> {
+        Datum::from_i32(val as i32)
+    }
+
     pub fn from_i64(val: i64) -> Datum<'static> {
         Datum::Int64(val)
     }
 
     pub fn from_u64(val: u64) -> Datum<'static> {
-        Datum::UInt64(val)
+        Datum::from_i64(val as i64)
     }
 
     pub fn from_f32(val: f32) -> Datum<'static> {
@@ -100,13 +94,16 @@ impl<'a> Datum<'a> {
         Datum::OwnedString(val)
     }
 
-    pub fn from_sql_type(val: SqlType) -> Datum<'static> {
-        Datum::SqlType(val)
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Self::Int32(val) => *val as u32,
+            _ => panic!("invalid use of Datum::as_u64"),
+        }
     }
 
     pub fn as_u64(&self) -> u64 {
         match self {
-            Self::UInt64(val) => *val,
+            Self::Int64(val) => *val as u64,
             _ => panic!("invalid use of Datum::as_u64"),
         }
     }
@@ -115,13 +112,6 @@ impl<'a> Datum<'a> {
         match self {
             Self::String(s) => s,
             _ => panic!("invalid use of Datum::as_str"),
-        }
-    }
-
-    pub fn as_sql_type(&self) -> SqlType {
-        match self {
-            Self::SqlType(sql_type) => *sql_type,
-            _ => panic!("invalid use of Datum::as_sql_type"),
         }
     }
 }
@@ -135,12 +125,10 @@ impl Display for Datum<'_> {
             Self::Int16(val) => write!(f, "{}", val),
             Self::Int32(val) => write!(f, "{}", val),
             Self::Int64(val) => write!(f, "{}", val),
-            Self::UInt64(val) => write!(f, "{}", val),
             Self::Float32(val) => write!(f, "{}", val.into_inner()),
             Self::Float64(val) => write!(f, "{}", val.into_inner()),
             Self::String(val) => write!(f, "{}", val),
             Self::OwnedString(val) => write!(f, "{}", val),
-            Self::SqlType(val) => write!(f, "{}", val),
         }
     }
 }

--- a/src/sql_model/src/sql_types.rs
+++ b/src/sql_model/src/sql_types.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use pg_model::pg_types::PostgreSqlType;
+use pg_model::pg_types::PgType;
 use sqlparser::ast::DataType;
 use std::{
     convert::TryFrom,
@@ -70,17 +70,17 @@ impl Display for SqlType {
     }
 }
 
-impl Into<PostgreSqlType> for &SqlType {
-    fn into(self) -> PostgreSqlType {
+impl Into<PgType> for &SqlType {
+    fn into(self) -> PgType {
         match self {
-            SqlType::Bool => PostgreSqlType::Bool,
-            SqlType::Char(_) => PostgreSqlType::Char,
-            SqlType::VarChar(_) => PostgreSqlType::VarChar,
-            SqlType::SmallInt => PostgreSqlType::SmallInt,
-            SqlType::Integer => PostgreSqlType::Integer,
-            SqlType::BigInt => PostgreSqlType::BigInt,
-            SqlType::Real => PostgreSqlType::Real,
-            SqlType::DoublePrecision => PostgreSqlType::DoublePrecision,
+            SqlType::Bool => PgType::Bool,
+            SqlType::Char(_) => PgType::Char,
+            SqlType::VarChar(_) => PgType::VarChar,
+            SqlType::SmallInt => PgType::SmallInt,
+            SqlType::Integer => PgType::Integer,
+            SqlType::BigInt => PgType::BigInt,
+            SqlType::Real => PgType::Real,
+            SqlType::DoublePrecision => PgType::DoublePrecision,
         }
     }
 }
@@ -95,50 +95,50 @@ mod tests {
 
         #[test]
         fn boolean() {
-            let pg_type: PostgreSqlType = (&SqlType::Bool).into();
-            assert_eq!(pg_type, PostgreSqlType::Bool);
+            let pg_type: PgType = (&SqlType::Bool).into();
+            assert_eq!(pg_type, PgType::Bool);
         }
 
         #[test]
         fn small_int() {
-            let pg_type: PostgreSqlType = (&SqlType::SmallInt).into();
-            assert_eq!(pg_type, PostgreSqlType::SmallInt);
+            let pg_type: PgType = (&SqlType::SmallInt).into();
+            assert_eq!(pg_type, PgType::SmallInt);
         }
 
         #[test]
         fn integer() {
-            let pg_type: PostgreSqlType = (&SqlType::Integer).into();
-            assert_eq!(pg_type, PostgreSqlType::Integer);
+            let pg_type: PgType = (&SqlType::Integer).into();
+            assert_eq!(pg_type, PgType::Integer);
         }
 
         #[test]
         fn big_int() {
-            let pg_type: PostgreSqlType = (&SqlType::BigInt).into();
-            assert_eq!(pg_type, PostgreSqlType::BigInt);
+            let pg_type: PgType = (&SqlType::BigInt).into();
+            assert_eq!(pg_type, PgType::BigInt);
         }
 
         #[test]
         fn char() {
-            let pg_type: PostgreSqlType = (&SqlType::Char(0)).into();
-            assert_eq!(pg_type, PostgreSqlType::Char);
+            let pg_type: PgType = (&SqlType::Char(0)).into();
+            assert_eq!(pg_type, PgType::Char);
         }
 
         #[test]
         fn var_char() {
-            let pg_type: PostgreSqlType = (&SqlType::VarChar(0)).into();
-            assert_eq!(pg_type, PostgreSqlType::VarChar);
+            let pg_type: PgType = (&SqlType::VarChar(0)).into();
+            assert_eq!(pg_type, PgType::VarChar);
         }
 
         #[test]
         fn real() {
-            let pg_type: PostgreSqlType = (&SqlType::Real).into();
-            assert_eq!(pg_type, PostgreSqlType::Real);
+            let pg_type: PgType = (&SqlType::Real).into();
+            assert_eq!(pg_type, PgType::Real);
         }
 
         #[test]
         fn double_precision() {
-            let pg_type: PostgreSqlType = (&SqlType::DoublePrecision).into();
-            assert_eq!(pg_type, PostgreSqlType::DoublePrecision);
+            let pg_type: PgType = (&SqlType::DoublePrecision).into();
+            assert_eq!(pg_type, PgType::DoublePrecision);
         }
     }
 }

--- a/src/sql_model/src/sql_types.rs
+++ b/src/sql_model/src/sql_types.rs
@@ -31,6 +31,35 @@ pub enum SqlType {
     DoublePrecision,
 }
 
+impl SqlType {
+    pub fn type_id(&self) -> u64 {
+        match self {
+            SqlType::Bool => 0,
+            SqlType::Char(_) => 1,
+            SqlType::VarChar(_) => 2,
+            SqlType::SmallInt => 3,
+            SqlType::Integer => 4,
+            SqlType::BigInt => 5,
+            SqlType::Real => 6,
+            SqlType::DoublePrecision => 7,
+        }
+    }
+
+    pub fn from_type_id(type_id: u64, chars_len: u64) -> SqlType {
+        match type_id {
+            0 => SqlType::Bool,
+            1 => SqlType::Char(chars_len),
+            2 => SqlType::VarChar(chars_len),
+            3 => SqlType::SmallInt,
+            4 => SqlType::Integer,
+            5 => SqlType::BigInt,
+            6 => SqlType::Real,
+            7 => SqlType::DoublePrecision,
+            _ => unreachable!(),
+        }
+    }
+}
+
 impl TryFrom<&DataType> for SqlType {
     type Error = NotSupportedType;
 


### PR DESCRIPTION
No issue to close

#### Description
instead of having `SqlType`s with length on min/max values limits store type id and length, int range value in SYSTEM.DEFINITION_SCHEMA.DATA_TYPE_DESCROPTOR table

#### Is it a feature that change user experience?
no

#### Client output
no changes to client output

