### PR TITLE
Implement parameter type analysis for assign operation SQL of Prepared Statement

### DIFF
--- a/src/description/src/lib.rs
+++ b/src/description/src/lib.rs
@@ -16,9 +16,13 @@ use pg_wire::PgType;
 use sql_model::{sql_types::SqlType, Id};
 use sqlparser::ast::ObjectName;
 use std::{
+    collections::HashMap,
     convert::TryFrom,
     fmt::{self, Display, Formatter},
 };
+
+pub type ParamIndex = usize;
+pub type ParamTypes = HashMap<ParamIndex, SqlType>;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FullTableId((Id, Id));
@@ -139,7 +143,9 @@ impl AsRef<Id> for SchemaId {
 #[derive(PartialEq, Debug)]
 pub struct InsertStatement {
     pub table_id: FullTableId,
-    pub sql_types: Vec<SqlType>,
+    pub column_types: Vec<SqlType>,
+    pub param_count: usize,
+    pub param_types: ParamTypes,
 }
 
 #[derive(PartialEq, Debug)]

--- a/src/description/src/lib.rs
+++ b/src/description/src/lib.rs
@@ -192,6 +192,7 @@ pub enum Description {
 #[derive(PartialEq, Debug)]
 pub enum DescriptionError {
     SyntaxError(String),
+    ColumnDoesNotExist(String),
     TableDoesNotExist(String),
     TableAlreadyExists(String),
     SchemaDoesNotExist(String),
@@ -202,6 +203,10 @@ pub enum DescriptionError {
 impl DescriptionError {
     pub fn syntax_error<M: ToString>(message: &M) -> DescriptionError {
         DescriptionError::SyntaxError(message.to_string())
+    }
+
+    pub fn column_does_not_exist<T: ToString>(column: &T) -> DescriptionError {
+        DescriptionError::ColumnDoesNotExist(column.to_string())
     }
 
     pub fn table_does_not_exist<T: ToString>(table: &T) -> DescriptionError {

--- a/src/meta_def/src/lib.rs
+++ b/src/meta_def/src/lib.rs
@@ -37,6 +37,10 @@ impl TableDefinition {
     pub fn column_types(&self) -> Vec<SqlType> {
         self.columns.iter().map(|col_def| col_def.sql_type()).collect()
     }
+
+    pub fn columns(&self) -> &[ColumnDefinition] {
+        &self.columns
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/node/src/query_engine/tests/simple_prepared_statement.rs
+++ b/src/node/src/query_engine/tests/simple_prepared_statement.rs
@@ -126,7 +126,7 @@ fn prepare_with_indeterminate_type(database_with_table: (InMemory, ResultCollect
 }
 
 #[rstest::rstest]
-fn prepare_with_analyzed_types_in_assign_operation(database_with_table: (InMemory, ResultCollector)) {
+fn prepare_assign_operation_for_all_columns_analysis(database_with_table: (InMemory, ResultCollector)) {
     let (mut engine, collector) = database_with_table;
     engine
         .execute(Command::Query {
@@ -134,4 +134,82 @@ fn prepare_with_analyzed_types_in_assign_operation(database_with_table: (InMemor
         })
         .expect("query executed");
     collector.assert_receive_single(Ok(QueryEvent::StatementPrepared));
+
+    engine
+        .execute(Command::Query {
+            sql: "execute fooplan(123, 456, 789)".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
+
+    engine
+        .execute(Command::Query {
+            sql: "deallocate fooplan".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::StatementDeallocated));
+
+    engine
+        .execute(Command::Query {
+            sql: "select * from schema_name.table_name".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_many(vec![
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("col1", PgType::SmallInt),
+            ColumnMetadata::new("col2", PgType::SmallInt),
+            ColumnMetadata::new("col3", PgType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "456".to_owned(),
+            "789".to_owned(),
+            "123".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(1)),
+    ]);
+}
+
+#[rstest::rstest]
+fn prepare_assign_operation_for_specified_columns_analysis(database_with_table: (InMemory, ResultCollector)) {
+    let (mut engine, collector) = database_with_table;
+    engine
+        .execute(Command::Query {
+            sql: "prepare fooplan as insert into schema_name.table_name (COL3, COL2, col1) values ($1, $2, $3)"
+                .to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::StatementPrepared));
+
+    engine
+        .execute(Command::Query {
+            sql: "execute fooplan(123, 456, 789)".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::RecordsInserted(1)));
+
+    engine
+        .execute(Command::Query {
+            sql: "deallocate fooplan".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::StatementDeallocated));
+
+    engine
+        .execute(Command::Query {
+            sql: "select * from schema_name.table_name".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_many(vec![
+        Ok(QueryEvent::RowDescription(vec![
+            ColumnMetadata::new("col1", PgType::SmallInt),
+            ColumnMetadata::new("col2", PgType::SmallInt),
+            ColumnMetadata::new("col3", PgType::SmallInt),
+        ])),
+        Ok(QueryEvent::DataRow(vec![
+            "789".to_owned(),
+            "456".to_owned(),
+            "123".to_owned(),
+        ])),
+        Ok(QueryEvent::RecordsSelected(1)),
+    ]);
 }

--- a/src/node/src/query_engine/tests/simple_prepared_statement.rs
+++ b/src/node/src/query_engine/tests/simple_prepared_statement.rs
@@ -19,7 +19,6 @@ use pg_model::{
 };
 
 #[rstest::rstest]
-#[ignore]
 fn prepare_execute_and_deallocate(database_with_schema: (InMemory, ResultCollector)) {
     let (mut engine, collector) = database_with_schema;
     engine
@@ -73,17 +72,6 @@ fn prepare_execute_and_deallocate(database_with_schema: (InMemory, ResultCollect
 }
 
 #[rstest::rstest]
-fn prepare_with_wrong_type(database_with_table: (InMemory, ResultCollector)) {
-    let (mut engine, collector) = database_with_table;
-    engine
-        .execute(Command::Query {
-            sql: "prepare fooplan (i, j, k) as insert into schema_name.table_name values ($1, $2, $3)".to_owned(),
-        })
-        .expect("query executed");
-    collector.assert_receive_single(Err(QueryError::type_does_not_exist("i")));
-}
-
-#[rstest::rstest]
 fn execute_deallocated_prepared_statement(database_with_schema: (InMemory, ResultCollector)) {
     let (mut engine, collector) = database_with_schema;
     engine
@@ -113,4 +101,37 @@ fn execute_deallocated_prepared_statement(database_with_schema: (InMemory, Resul
         })
         .expect("query executed");
     collector.assert_receive_single(Err(QueryError::prepared_statement_does_not_exist("fooplan")));
+}
+
+#[rstest::rstest]
+fn prepare_with_wrong_type(database_with_table: (InMemory, ResultCollector)) {
+    let (mut engine, collector) = database_with_table;
+    engine
+        .execute(Command::Query {
+            sql: "prepare fooplan (i, j, k) as insert into schema_name.table_name values ($1, $2, $3)".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Err(QueryError::type_does_not_exist("i")));
+}
+
+#[rstest::rstest]
+fn prepare_with_indeterminate_type(database_with_table: (InMemory, ResultCollector)) {
+    let (mut engine, collector) = database_with_table;
+    engine
+        .execute(Command::Query {
+            sql: "prepare fooplan (smallint, smallint) as insert into schema_name.table_name values (1, $9)".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Err(QueryError::indeterminate_parameter_data_type(2)));
+}
+
+#[rstest::rstest]
+fn prepare_with_analyzed_types_in_assign_operation(database_with_table: (InMemory, ResultCollector)) {
+    let (mut engine, collector) = database_with_table;
+    engine
+        .execute(Command::Query {
+            sql: "prepare fooplan as insert into schema_name.table_name values ($2, $3, $1)".to_owned(),
+        })
+        .expect("query executed");
+    collector.assert_receive_single(Ok(QueryEvent::StatementPrepared));
 }


### PR DESCRIPTION
Closes #400

#### Description

Implements parameter type analysis for assign operation SQL, based on PR #407 , and handles some special `prepare` cases.

#### Is it a feature that change user experience?

Yes, this PR handles `psql` output of some special `prepare` cases as `Postgres` response.

The below SQL should be parsed successfully by analyzing the Table description.

```
xxx=> create schema schema_name;
xxx=> create table schema_name.table_name (col_1 smallint, col_2 smallint);

xxx=> prepare fooplan as insert into schema_name.table_name values ($2, $1);
PREPARE
```

`psql` should report a error message of `could not determine data type of parameter $3` for the below SQL.

```
xxx=> prepare fooplan (smallint, smallint) as insert into schema_name.table_name values (1, $9);
ERROR:  could not determine data type of parameter $3
```

Since the SQL contains the maximum parameter index `$9`, it is considered have nine parameters, but the `prepare` SQL only provide two.

#### Client output

For `psql`:

```
psql (12.1, server 0.0.0)
Type "help" for help.

xxx=> create schema schema_name;
CREATE SCHEMA
xxx=> create table schema_name.table_name (col_1 smallint, col_2 smallint);
CREATE TABLE
xxx=> prepare fooplan as insert into schema_name.table_name values ($2, $1);
PREPARE
xxx=> prepare fooplan (smallint, smallint) as insert into schema_name.table_name values (1, $9);
ERROR:  could not determine data type of parameter $3
```

For `epgsql`:

```
Eshell V10.4.3  (abort with ^G)
1> {ok, C} = epgsql:connect("localhost", "", "", #{codecs => []}).
{ok,<0.129.0>}
4> epgsql:squery(C, "prepare fooplan (smallint, smallint) as insert into schema_name.table_name values (1, $9)").
{error,{error,error,<<"42P18">>,indeterminate_datatype,
              <<"could not determine data type of parameter $3">>,[]}}
```
