### PR TITLE
Implement parameter type analysis for re-assign (Update) operation SQL of Prepared Statement

### DIFF
--- a/src/description/src/lib.rs
+++ b/src/description/src/lib.rs
@@ -149,7 +149,13 @@ impl AsRef<Id> for SchemaId {
 #[derive(PartialEq, Debug)]
 pub struct InsertStatement {
     pub table_id: FullTableId,
-    pub column_types: Vec<SqlType>,
+    pub param_count: usize,
+    pub param_types: ParamTypes,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct UpdateStatement {
+    pub table_id: FullTableId,
     pub param_count: usize,
     pub param_types: ParamTypes,
 }
@@ -206,6 +212,7 @@ pub enum Description {
     DropTables(DropTablesInfo),
     Insert(InsertStatement),
     Select(SelectStatement),
+    Update(UpdateStatement),
 }
 
 #[derive(PartialEq, Debug)]

--- a/src/query_analyzer/Cargo.toml
+++ b/src/query_analyzer/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 description = { path = "../description" }
+meta_def = { path = "../meta_def" }
 metadata = { path = "../metadata" }
 sql_model = { path = "../sql_model" }
 

--- a/src/query_analyzer/src/tests/mod.rs
+++ b/src/query_analyzer/src/tests/mod.rs
@@ -15,6 +15,7 @@
 mod ddl;
 mod insert;
 mod select;
+mod update;
 
 use super::*;
 use meta_def::ColumnDefinition;


### PR DESCRIPTION
Closes #401 

#### Description

Implements parameter type analysis for re-assign (Update) operation SQL.

#### Is it a feature that change user experience?

Yes, this PR handles parameter type analysis for both `prepare` SQL of `psql` and `Parse` messages of Extended Protocol.

The below SQL should be parsed successfully by analyzing the Table description.

```
xxx=> create schema schema_name;
xxx=> create table schema_name.table_name (col_1 smallint, col_2 smallint);

xxx=> prepare fooplan as update schema_name.table_name set COL_2 = $1 where col_1 = $2;
PREPARE
```

#### Client output

For `psql`:

```
psql (12.1, server 0.0.0)
Type "help" for help.

xxx=> create schema schema_name;
CREATE SCHEMA
xxx=> create table schema_name.table_name (col_1 smallint, col_2 smallint);
CREATE TABLE
xxx=> prepare fooplan as update schema_name.table_name set col_2 = $1 where col_1 = $2;
PREPARE
```