### PR TITLE
Configures Github action for Erlang client compatibility on pull requ…

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -83,6 +83,26 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  erlang-client-compatibility:
+    needs:
+      - cargo-deny
+      - rustfmt
+      - clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: set-up-rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - name: set-up-erlang
+        uses: gleam-lang/setup-erlang@v1.1.0
+        with:
+            otp-version: 23.1
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run-tests
+        run: ./ci/erlang_client.sh
+
   ci-success:
     name: ci
     if: github.event_name == 'push' && success()

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 
 # Ignore Gradle build output directory
 build
+
+# Ignore Erlang Rebar3 build and test logs directories
+_build
+erlang_client_logs

--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ on a local machine and queries result has to be checked visually.
 1. Run `PERSISTENT=1 RUST_LOG=debug cargo run` from project folder in separate terminal window
 1. Run `./local/compatibility.sh`
 
+### Running Erlang Client Compatibility tests locally
+
+1. Install `Erlang` version `23.1` (which is tested on CI now). You could
+install specified version of Erlang via [asdf](https://github.com/asdf-vm/asdf).
+1. Install [rebar3](https://github.com/erlang/rebar3) to run Erlang Common Test.
+1. Run `./ci/erlang_client.sh`.
+1. Kill `database` process manually for running the tests again.
+
 ### Running Functional tests
 
 We use PyTest for functional tests. To run tests locally you need to set up

--- a/ci/erlang_client.sh
+++ b/ci/erlang_client.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script is used for Github Action. It starts database service in backgound
+# and runs Erlang tests.
+# The second invocation of `cargo build` is tricky. It is blocked unless the
+# first `cargo build` finishes. And `sleep 1` is used to wait for `cargo run`.
+cargo build && \
+  cargo run & \
+  cargo build && \
+  sleep 1 && \
+  rebar3 ct --dir tests/erlang_client/ --logdir erlang_client_logs/ -v

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,5 @@
+%% -*- mode: erlang -*-
+
+{deps, [
+    {epgsql, "4.5.0"}
+]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+{"1.2.0",
+[{<<"epgsql">>,{pkg,<<"epgsql">>,<<"4.5.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"epgsql">>, <<"CA863EE3A771E7696AE58EC924A29DF8435CDAFFA64DBA70C02DD2571AD2122D">>}]},
+{pkg_hash_ext,[
+ {<<"epgsql">>, <<"0A02D338CC1426C5873B412FED9D694F7B5143933C5F85F244655A5E77B23078">>}]}
+].

--- a/tests/erlang_client/simple/simple_basic_queries_SUITE.erl
+++ b/tests/erlang_client/simple/simple_basic_queries_SUITE.erl
@@ -1,0 +1,90 @@
+-module(simple_basic_queries_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2,
+         end_per_testcase/2]).
+-export([test_select_all_columns/1, test_select_specified_columns/1,
+         test_update_all/1, test_delete_all/1]).
+
+-define(CreateSchema, "create schema SCHEMA_NAME").
+-define(DropSchema, "drop schema SCHEMA_NAME").
+
+-define(CreateTable, "create table SCHEMA_NAME.TABLE_NAME
+        (COL_1 smallint, COL_2 smallint, COL_3 smallint)").
+-define(DropTable, "drop table SCHEMA_NAME.TABLE_NAME").
+
+-define(DeleteAllColumns, "delete from SCHEMA_NAME.TABLE_NAME").
+-define(InsertDefaultRows, "insert into SCHEMA_NAME.TABLE_NAME values
+        (1, 2, 3), (4, 5, 6), (7, 8, 9)").
+
+-define(SelectAllColumns, "select * from SCHEMA_NAME.TABLE_NAME").
+-define(SelectSpecifiedColumns, "select COL_2, COL_3 from
+        SCHEMA_NAME.TABLE_NAME").
+
+-define(UpdateAll, "update SCHEMA_NAME.TABLE_NAME set
+        COL_1 = 10, COL_2 = 11, COL_3 = 12").
+
+-define(DeleteAll, "delete from SCHEMA_NAME.TABLE_NAME").
+
+all() -> [test_select_all_columns, test_select_specified_columns,
+          test_update_all, test_delete_all].
+
+init_per_suite(Config) ->
+    {ok, DbConn} = create_db_connection(),
+    clear_all(DbConn),
+
+    DbCreateSchemaResult = epgsql:squery(DbConn, ?CreateSchema),
+    DbCreateTableResult = epgsql:squery(DbConn, ?CreateTable),
+
+    Config.
+
+end_per_suite(_Config) ->
+    {ok, DbConn} = create_db_connection(),
+    clear_all(DbConn),
+    ok.
+
+init_per_testcase(_AnyTestCase, Config) ->
+    {ok, DbConn} = create_db_connection(),
+
+    delete_all_rows(DbConn),
+    insert_default_rows(DbConn),
+
+    [{db_conn, DbConn} | Config].
+
+end_per_testcase(_AnyTestCase, Config) ->
+    DbConn = ?config(db_conn, Config),
+    delete_all_rows(DbConn),
+    ok.
+
+test_select_all_columns(Config) ->
+    DbConn = ?config(db_conn, Config),
+    {ok, _, _} = epgsql:squery(DbConn, ?SelectAllColumns).
+
+test_select_specified_columns(Config) ->
+    DbConn = ?config(db_conn, Config),
+    {ok, _, _} = epgsql:squery(DbConn, ?SelectSpecifiedColumns).
+
+test_update_all(Config) ->
+    DbConn = ?config(db_conn, Config),
+    {ok, 3} = epgsql:squery(DbConn, ?UpdateAll),
+    {ok, _, _} = epgsql:squery(DbConn, ?SelectAllColumns).
+
+test_delete_all(Config) ->
+    DbConn = ?config(db_conn, Config),
+    {ok, 3} = epgsql:squery(DbConn, ?DeleteAll),
+    {ok, _, _} = epgsql:squery(DbConn, ?SelectAllColumns).
+
+clear_all(DbConn) ->
+    epgsql:squery(DbConn, ?DropTable),
+    epgsql:squery(DbConn, ?DropSchema).
+
+create_db_connection() ->
+    epgsql:connect("localhost", "", "", #{codecs => []}).
+
+delete_all_rows(DbConn) ->
+    epgsql:squery(DbConn, ?DeleteAllColumns).
+
+insert_default_rows(DbConn) ->
+  {ok, 3} = epgsql:squery(DbConn, ?InsertDefaultRows).


### PR DESCRIPTION
Closes #431

#### Description

Per discussion in draft PR #443 , configures Github action to run simple Erlang tests on pull requests (not required for CI success/failure).

Will try to integrate `epqsql` (Erlang client) tests based on this process.

Developer could also run tests on local via script `ci/erlang_client.sh`.

Erlang could be installed via [asdf](https://github.com/asdf-vm/asdf).

1. Installs `asdf`: https://asdf-vm.com/#/core-manage-asdf?id=install

2. Runs the below shell commands to install Erlang.

```
asdf plugin-add erlang
asdf install erlang 23.1

asdf global erlang 23.1
asdf local erlang 23.1
asdf shell erlang 23.1
```

Rebar is an Erlang tool for managing the project (include `ct` - Common Test).
It could be installed via https://github.com/erlang/rebar3#getting-started.

The background `database` process needs to be killed manually on local.

#### Is it a feature that change user experience?

No.

#### Client output

```
$ ./ci/erlang_client.sh

    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on build directory
    Finished dev [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/database`
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling extra_tests/erlang_client
===> Running Common Test suites...

TEST INFO: 1 test(s), 4 case(s) in 1 suite(s)

Testing tests.erlang_client: Starting test, 4 test cases
%%% simple_basic_queries_SUITE: ....
Testing tests.erlang_client: TEST COMPLETE, 4 ok, 0 failed of 4 test cases

Updating /**/database/erlang_compatibility_logs/index.html ... done
Updating /**/database/erlang_compatibility_logs/all_runs.html ... done
```
