### PR TITLE
Update dependencies for cargo-deny issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,9 +665,9 @@ checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "lock_api"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard",
 ]
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5"
+checksum = "dacdec97876ef3ede8c50efc429220641a0b11ba0048b4b0c357bccbc47c5204"
 dependencies = [
  "num-traits",
 ]
@@ -895,9 +895,9 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api",


### PR DESCRIPTION
No issue to close.

#### Description

`cargo-deny` of CI reports issues on dependencies `ordered-float` and `lock_api` (which is only depended by `parking_lot`).

```
error[A001]: ordered_float:NotNan may contain NaN after panic in assignment operators
   ┌─ /github/workspace/Cargo.lock:89:1
   │
89 │ ordered-float 2.0.0 registry+https://github.com/rust-lang/crates.io-index
   │ ------------------------------------------------------------------------- security vulnerability detected
   │
   = ID: RUSTSEC-2020-0082
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2020-0082
```

```
warning[A004]: Some lock_api lock guard objects can cause data races
   ┌─ /github/workspace/Cargo.lock:69:1
   │
69 │ lock_api 0.4.1 registry+https://github.com/rust-lang/crates.io-index
   │ -------------------------------------------------------------------- unsound advisory detected
   │
   = ID: RUSTSEC-2020-0070
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2020-0070
```

#### Is it a feature that change user experience?

No.

#### Client output

No effect.
