### PR TITLE
Configure GH action for Java compatibility tests on pull requests

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -23,47 +23,7 @@ jobs:
           repository: alex-dukhno/database/database
           tags: latest
 
-  compatibility-tests:
-    needs:
-      - publish-docker
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:12.4
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5433:5432
-    steps:
-      - name: docker-login
-        run: echo ${{secrets.GITHUB_TOKEN}} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: pull-docker-image
-        run: docker pull "docker.pkg.github.com/alex-dukhno/database/database:latest"
-      - name:
-        run: docker run -it -d -p 5432:5432 docker.pkg.github.com/alex-dukhno/database/database:latest
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: install java
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: run-tests
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: test -Dci=true
-
   coverage:
-    needs:
-      - compatibility-tests
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -83,6 +83,44 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  java-compatibility:
+    needs:
+      - cargo-deny
+      - rustfmt
+      - clippy
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12.4
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5433:5432
+    steps:
+      - name: set-up-rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - name: set-up-java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: start-database
+        run: cargo run & cargo build && sleep 1
+      - name: run-tests
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: test -Dci=true
+
   erlang-client-compatibility:
     needs:
       - cargo-deny

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  java-compatibility:
+  compatibility-test:
     needs:
       - cargo-deny
       - rustfmt


### PR DESCRIPTION
Closes #420 

#### Description

configures Github action to run Java compatibility tests on pull requests (not required for CI success/failure).
References [README](https://github.com/alex-dukhno/database#running-compatibility-tests-locally) for running Java compatibility tests on local.

#### Is it a feature that change user experience?

No.

#### Client output

No special client output.